### PR TITLE
Allow HTTP provider discovery and defer remote refreshes

### DIFF
--- a/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
@@ -100,12 +100,29 @@ final class InferenceStore {
         }
 
         ironsmithSession = dependencies.accountClient.currentSession()
-        for provider in providers where provider.kind != .local {
-            await refreshDiscoveredModels(for: provider)
+        let selectedRemoteProvider = providers.first { provider in
+            provider.kind != .local
+                && selectedModelID?.hasPrefix("\(provider.identifier)::") == true
+        }
+        if let selectedRemoteProvider {
+            await refreshDiscoveredModels(for: selectedRemoteProvider)
         }
 
         reconcileSelectedModel()
         hasLoaded = true
+
+        let backgroundProviders = providers.filter {
+            $0.kind != .local && $0.identifier != selectedRemoteProvider?.identifier
+        }
+        guard !backgroundProviders.isEmpty else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            for provider in backgroundProviders {
+                await refreshDiscoveredModels(for: provider)
+            }
+            reconcileSelectedModel()
+        }
     }
 
     func prepareSettings(modelContext: ModelContext) async {

--- a/Ironsmith/Core/Inference/InferenceStore/Ollama.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/Ollama.swift
@@ -6,7 +6,7 @@ extension InferenceStore {
     }
 
     func canStartOllama(for provider: ProviderConfig) -> Bool {
-        provider.kind == .ollama && provider.hasLocalServerBaseURL
+        provider.kind == .ollama && provider.hasLoopbackServerBaseURL
     }
 
     func refreshOllamaInstallationStatus() {

--- a/Ironsmith/Core/Inference/InferenceStore/Providers.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/Providers.swift
@@ -58,12 +58,25 @@ extension InferenceStore {
             try repository.save()
             try refreshData()
 
-            await refreshDiscoveredModels(for: provider)
-            if selectedModelID == nil {
-                selectModel(
-                    remoteModels.first(where: { $0.providerIdentifier == provider.identifier })?
-                        .selectionIdentifier
-                )
+            if provider.kind == .ironsmith {
+                await refreshDiscoveredModels(for: provider)
+                if selectedModelID == nil {
+                    selectModel(
+                        remoteModels.first(where: { $0.providerIdentifier == provider.identifier })?
+                            .selectionIdentifier
+                    )
+                }
+            } else {
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    await refreshDiscoveredModels(for: provider)
+                    if selectedModelID == nil {
+                        selectModel(
+                            remoteModels.first(where: { $0.providerIdentifier == provider.identifier })?
+                                .selectionIdentifier
+                        )
+                    }
+                }
             }
             return true
         } catch {
@@ -114,8 +127,11 @@ extension InferenceStore {
         do {
             try repository.save()
             try refreshData(reconcileSelection: false)
-            await refreshDiscoveredModels(for: provider)
-            reconcileSelectedModel()
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                await refreshDiscoveredModels(for: provider)
+                reconcileSelectedModel()
+            }
             return true
         } catch {
             repository.rollback()
@@ -276,7 +292,7 @@ extension InferenceStore {
     private func validateProviderCanBeAdded(
         _ provider: ProviderConfig
     ) async throws {
-        guard provider.kind == .ollama, provider.hasLocalServerBaseURL else {
+        guard provider.kind == .ollama, provider.hasLoopbackServerBaseURL else {
             return
         }
 
@@ -314,8 +330,8 @@ extension InferenceStore {
 }
 
 extension ProviderConfig {
-    var hasLocalServerBaseURL: Bool {
-        ProviderBaseURLValidator.usesAllowedLocalHost(baseURLString)
+    var hasLoopbackServerBaseURL: Bool {
+        ProviderBaseURLValidator.usesLoopbackHost(baseURLString)
     }
 }
 

--- a/Ironsmith/Core/Inference/Providers/ProviderBaseURLValidator.swift
+++ b/Ironsmith/Core/Inference/Providers/ProviderBaseURLValidator.swift
@@ -13,16 +13,14 @@ nonisolated enum ProviderBaseURLValidator {
         }
 
         switch scheme {
-        case "https":
-            return url
-        case "http" where isAllowedLocalHTTPHost(rawHost):
+        case "http", "https":
             return url
         default:
             throw ProviderBaseURLValidationError.disallowedURL
         }
     }
 
-    static func isAllowedLocalHTTPHost(_ rawHost: String) -> Bool {
+    private static func isLoopbackHost(_ rawHost: String) -> Bool {
         let host = rawHost
             .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
             .lowercased()
@@ -34,7 +32,7 @@ nonisolated enum ProviderBaseURLValidator {
             || host.hasSuffix(".localhost")
     }
 
-    static func usesAllowedLocalHost(_ rawValue: String) -> Bool {
+    static func usesLoopbackHost(_ rawValue: String) -> Bool {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         let lowercased = trimmed.lowercased()
         if lowercased.hasPrefix("http://[::1]")
@@ -49,7 +47,7 @@ nonisolated enum ProviderBaseURLValidator {
             return false
         }
 
-        return isAllowedLocalHTTPHost(rawHost)
+        return isLoopbackHost(rawHost)
     }
 }
 

--- a/Ironsmith/Core/Inference/Providers/RemoteModelClient.swift
+++ b/Ironsmith/Core/Inference/Providers/RemoteModelClient.swift
@@ -5,6 +5,8 @@ struct RemoteModelClient {
 }
 
 extension RemoteModelClient {
+    static let discoveryTimeout: TimeInterval = 10
+
     static func live(accountClient: IronsmithAccountClient = .unconfigured) -> Self {
         Self { provider, apiKey in
             if provider.kind == .ironsmith {
@@ -45,6 +47,7 @@ extension RemoteModelClient {
 
         var request = URLRequest(url: baseURL.appendingPathComponent(modelsPath))
         request.httpMethod = "GET"
+        request.timeoutInterval = discoveryTimeout
 
         if let apiKey, !apiKey.isEmpty {
             switch descriptor.responseFormat {

--- a/Ironsmith/Features/Settings/Sheets/AddProvider/AddProviderSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/AddProvider/AddProviderSheetView.swift
@@ -156,7 +156,7 @@ struct AddProviderSheetView: View {
         if isOllama {
             let trimmedBaseURLString = baseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmedBaseURLString.isEmpty
-                || (ProviderBaseURLValidator.usesAllowedLocalHost(trimmedBaseURLString)
+                || (ProviderBaseURLValidator.usesLoopbackHost(trimmedBaseURLString)
                     && inferenceStore.ollamaInstallationStatus != .installed)
         }
 

--- a/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
@@ -267,6 +267,9 @@ extension InferenceTests {
         try context.save()
 
         await store.loadIfNeeded(modelContext: context)
+        await Self.eventually {
+            store.remoteModels.contains { $0.identifier == "gemma4:e2b" }
+        }
         #expect(store.remoteModels.contains { $0.identifier == "gemma4:e2b" })
         #expect(store.connectionIssue(for: provider) == nil)
 

--- a/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
@@ -90,23 +90,31 @@ extension InferenceTests {
         #expect(ollamaRequest.value(forHTTPHeaderField: "Authorization") == "Bearer ollama-key")
         #expect(customRequest.url?.absoluteString == "http://localhost:11434/v1/models")
         #expect(customRequest.value(forHTTPHeaderField: "Authorization") == nil)
+        #expect(customRequest.timeoutInterval == RemoteModelClient.discoveryTimeout)
     }
 
     @Test
-    func providerBaseURLValidationAllowsHTTPSAndLocalHTTPOnly() throws {
+    func providerBaseURLValidationAllowsAnyHTTPOrHTTPSHost() throws {
         let acceptedURLs = [
             "https://api.example.com",
+            "http://example.com",
+            "http://203.0.113.10:8000/v1",
+            "http://models.internal.example:8000/v1",
             "http://localhost",
             "http://127.0.0.1",
             "http://[::1]",
             "http://studio.localhost:11434/v1",
+            "http://10.0.0.2:8000/v1",
+            "http://172.16.0.2:8000/v1",
+            "http://172.31.255.254:8000/v1",
+            "http://192.168.1.103:8000/v1",
+            "http://169.254.10.20:8000/v1",
         ]
         for urlString in acceptedURLs {
             #expect(try ProviderBaseURLValidator.validatedURL(from: urlString).absoluteString == urlString)
         }
 
         let rejectedURLs = [
-            "http://example.com",
             "file:///tmp/model",
             "data:text/plain,hello",
             "ftp://example.com",
@@ -121,7 +129,7 @@ extension InferenceTests {
     }
 
     @Test
-    func providerRequestBuildersRejectUnsafeBaseURLs() throws {
+    func providerRequestBuildersAllowHTTPAndRejectUnsupportedSchemes() throws {
         let remoteProvider = ProviderConfig(
             identifier: "custom.remote-http",
             displayName: "Remote HTTP",
@@ -129,14 +137,37 @@ extension InferenceTests {
             authMode: .apiKey,
             origin: .custom
         )
-        #expect(throws: RemoteModelDiscoveryError.self) {
-            try RemoteModelClient.makeModelListRequest(for: remoteProvider, apiKey: nil)
-        }
-
-        #expect(throws: OllamaClientError.self) {
-            try OllamaClient.makeTagsRequest(baseURLString: "http://example.com", apiKey: nil)
-        }
+        #expect(try RemoteModelClient.makeModelListRequest(
+            for: remoteProvider,
+            apiKey: nil
+        ).url?.absoluteString == "http://example.com/v1/models")
+        #expect(try OllamaClient.makeTagsRequest(
+            baseURLString: "http://example.com",
+            apiKey: nil
+        ).url?.absoluteString == "http://example.com/api/tags")
         #expect(try OllamaClient.makeTagsRequest(baseURLString: "http://127.0.0.1:11434", apiKey: nil).url?.absoluteString == "http://127.0.0.1:11434/api/tags")
+        #expect(try RemoteModelClient.makeModelListRequest(
+            for: ProviderConfig(
+                identifier: "custom.lan",
+                displayName: "LAN Server",
+                baseURLString: "http://192.168.1.103:8000/v1",
+                authMode: .apiKey,
+                origin: .custom
+            ),
+            apiKey: nil
+        ).url?.absoluteString == "http://192.168.1.103:8000/v1/models")
+        #expect(throws: RemoteModelDiscoveryError.self) {
+            try RemoteModelClient.makeModelListRequest(
+                for: ProviderConfig(
+                    identifier: "custom.file",
+                    displayName: "File",
+                    baseURLString: "file:///tmp/model",
+                    authMode: .apiKey,
+                    origin: .custom
+                ),
+                apiKey: nil
+            )
+        }
     }
 
     @Test

--- a/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
@@ -23,8 +23,46 @@ extension InferenceTests {
 
         let persistedModels = try context.fetch(FetchDescriptor<ModelConfig>())
         #expect(didAdd)
+        await Self.eventually {
+            inferenceStore.remoteModels.map(\.identifier) == ["gpt-test"]
+        }
         #expect(inferenceStore.remoteModels.map(\.identifier) == ["gpt-test"])
         #expect(persistedModels.allSatisfy { $0.source != .remote })
+    }
+
+    @MainActor
+    @Test
+    func addingProviderDoesNotWaitForRemoteModelDiscovery() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let discoveryGate = RemoteDiscoveryGate()
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteDiscoveryHook: {
+                    await discoveryGate.wait()
+                }
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+
+        var didAdd: Bool?
+        Task { @MainActor in
+            didAdd = await inferenceStore.addProvider(
+                choice: .init(descriptor: ProviderCatalog.descriptor(for: .customOpenAICompatible)!),
+                apiKey: "",
+                displayName: "LAN Server",
+                baseURLString: "http://192.168.1.103:8000/v1"
+            )
+        }
+
+        await Self.eventually {
+            didAdd != nil
+        }
+
+        #expect(didAdd == true)
+        #expect(inferenceStore.providers.contains { $0.displayName == "LAN Server" })
+        await discoveryGate.open()
     }
 
     @MainActor
@@ -61,8 +99,39 @@ extension InferenceTests {
         await inferenceStore.loadIfNeeded(modelContext: context)
         await inferenceStore.loadIfNeeded(modelContext: context)
 
+        await Self.eventually {
+            inferenceStore.remoteModels.map(\.identifier) == ["gpt-test"]
+        }
         #expect(await counter.count == 1)
         #expect(inferenceStore.remoteModels.map(\.identifier) == ["gpt-test"])
+    }
+
+    @MainActor
+    @Test
+    func startupDoesNotWaitForUnselectedProviderDiscovery() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let provider = ProviderCatalog.makeProvider(for: .customOpenAICompatible)!
+        provider.identifier = "custom.unreachable"
+        provider.displayName = "Unreachable"
+        provider.baseURLString = "http://192.168.1.103:8000/v1"
+        context.insert(provider)
+        try context.save()
+
+        let discoveryGate = RemoteDiscoveryGate()
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteDiscoveryHook: {
+                    await discoveryGate.wait()
+                }
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+
+        #expect(inferenceStore.hasLoadedModels)
+        #expect(inferenceStore.selectedModel?.source == .appleFoundation)
+        await discoveryGate.open()
     }
 
     @MainActor
@@ -129,12 +198,15 @@ extension InferenceTests {
         #expect(customProviders.count == 2)
         #expect(Set(customProviders.map(\.identifier)).count == 2)
         #expect(customProviders.allSatisfy { $0.origin == .custom })
+        await Self.eventually {
+            inferenceStore.remoteModels.contains { $0.identifier == "llama3.1:8b" }
+        }
         #expect(inferenceStore.remoteModels.contains { $0.identifier == "llama3.1:8b" })
     }
 
     @MainActor
     @Test
-    func inferenceStoreRejectsUnsafeConfigurableProviderBaseURLs() async throws {
+    func inferenceStoreAcceptsHTTPAndRejectsUnsupportedProviderBaseURLSchemes() async throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
         let inferenceStore = InferenceStore(dependencies: Self.dependencies())
@@ -157,9 +229,11 @@ extension InferenceTests {
             baseURLString: "file:///tmp/model"
         )
 
-        #expect(!(didAddRemoteHTTP))
+        #expect(didAddRemoteHTTP)
         #expect(!(didAddFileURL))
-        #expect(inferenceStore.providers.allSatisfy { $0.kind != .customOpenAICompatible })
+        #expect(inferenceStore.providers.contains {
+            $0.displayName == "Remote HTTP" && $0.baseURLString == "http://example.com/v1"
+        })
 
         let didAddLocal = await inferenceStore.addProvider(
             choice: customChoice,
@@ -168,6 +242,12 @@ extension InferenceTests {
             baseURLString: "http://localhost:11434/v1"
         )
         let provider = try #require(inferenceStore.providers.first { $0.kind == .customOpenAICompatible })
+        let didAddLANServer = await inferenceStore.addProvider(
+            choice: customChoice,
+            apiKey: "",
+            displayName: "LAN Server",
+            baseURLString: "http://192.168.1.103:8000/v1"
+        )
         let didSaveRemoteHTTP = await inferenceStore.saveProviderEdits(
             provider: provider,
             apiKey: "",
@@ -176,9 +256,14 @@ extension InferenceTests {
         )
 
         #expect(didAddLocal)
-        #expect(!(didSaveRemoteHTTP))
-        #expect(provider.displayName == "Local")
-        #expect(provider.baseURLString == "http://localhost:11434/v1")
+        #expect(didAddLANServer)
+        #expect(inferenceStore.providers.contains {
+            $0.displayName == "LAN Server"
+                && $0.baseURLString == "http://192.168.1.103:8000/v1"
+        })
+        #expect(didSaveRemoteHTTP)
+        #expect(provider.displayName == "Remote HTTP")
+        #expect(provider.baseURLString == "http://example.com/v1")
     }
 
     @MainActor
@@ -214,6 +299,9 @@ extension InferenceTests {
         #expect(didSave)
         #expect(savedProvider.displayName == "Local LM Studio")
         #expect(savedProvider.baseURLString == "http://localhost:1234/v1")
+        await Self.eventually {
+            inferenceStore.remoteModels.contains { $0.identifier == "qwen2.5-coder" }
+        }
         #expect(inferenceStore.remoteModels.contains { $0.identifier == "qwen2.5-coder" })
     }
 
@@ -240,6 +328,9 @@ extension InferenceTests {
         let provider = try #require(inferenceStore.providers.first { $0.kind == .customOpenAICompatible })
 
         #expect(didAdd)
+        await Self.eventually {
+            inferenceStore.connectionIssue(for: provider) != nil
+        }
         #expect(inferenceStore.presentedErrorMessage == nil)
         #expect(inferenceStore.connectionIssue(for: provider)?.message == "Could not connect to the server.")
         #expect(!(inferenceStore.remoteModels.contains { $0.providerIdentifier == provider.identifier }))
@@ -276,6 +367,9 @@ extension InferenceTests {
         #expect(didSave)
         #expect(savedProvider.displayName == "Ollama")
         #expect(savedProvider.baseURLString == "http://localhost:11435")
+        await Self.eventually {
+            inferenceStore.remoteModels.contains { $0.identifier == "gemma4:e2b" }
+        }
         #expect(inferenceStore.remoteModels.contains { $0.identifier == "gemma4:e2b" })
         #expect(inferenceStore.apiKey(for: savedProvider) == "ollama-key")
     }
@@ -329,6 +423,9 @@ extension InferenceTests {
         let provider = try #require(inferenceStore.providers.first { $0.kind == .ollama })
 
         #expect(didAdd)
+        await Self.eventually {
+            inferenceStore.connectionIssue(for: provider) != nil
+        }
         #expect(inferenceStore.presentedErrorMessage == nil)
         #expect(inferenceStore.connectionIssue(for: provider)?.message == "Could not connect to Ollama.")
         #expect(try context.fetch(FetchDescriptor<ProviderConfig>()).contains { $0.kind == .ollama })

--- a/IronsmithTests/Core/Inference/InferenceTestSupport.swift
+++ b/IronsmithTests/Core/Inference/InferenceTestSupport.swift
@@ -289,6 +289,24 @@ actor RemoteDiscoveryCounter {
     }
 }
 
+actor RemoteDiscoveryGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation {
+            continuation = $0
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
 actor RemoteDiscoveryScript {
     private var results: [Result<[String], Error>]
     private var requestCount = 0


### PR DESCRIPTION
## Summary
- Relax provider base URL validation so HTTP and HTTPS OpenAI-compatible endpoints are accepted instead of only loopback hosts.
- Add a short discovery timeout for remote model-list requests.
- Make startup and provider add/edit flows refresh remote models asynchronously when possible, so the UI does not block on unrelated providers.
- Update Ollama handling to use loopback-only checks for local server start behavior.
- Expand inference tests to cover HTTP acceptance, timeout behavior, and non-blocking discovery.

## Testing
- Added and updated unit tests for provider URL validation, remote request construction, and Ollama/base URL behavior.
- Added async inference-store tests covering deferred discovery and startup selection reconciliation.