### PR TITLE
Add resumable tool generation and stronger repair handling

### DIFF
--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
@@ -370,7 +370,6 @@ struct ToolAppBundleClient {
             let sourceURL = try await iconClient.ensureIconAssets(
                 ToolIconRequest(
                     displayName: request.displayName,
-                    promptSummary: request.promptSummary,
                     iconPrompt: request.iconPrompt,
                     layout: request.layout
                 )

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleRequest.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleRequest.swift
@@ -8,7 +8,6 @@ struct ToolAppBundleRequest: Equatable, Sendable {
     let sandboxEnabled: Bool
     let sandboxPermissions: GeneratedAppSandboxPermissions
     let resourcePermissions: GeneratedAppResourcePermissions
-    let promptSummary: String?
     let iconPrompt: String?
 
     init(
@@ -19,7 +18,6 @@ struct ToolAppBundleRequest: Equatable, Sendable {
         sandboxEnabled: Bool,
         sandboxPermissions: GeneratedAppSandboxPermissions = .default,
         resourcePermissions: GeneratedAppResourcePermissions = .none,
-        promptSummary: String?,
         iconPrompt: String? = nil
     ) {
         self.displayName = displayName
@@ -29,7 +27,6 @@ struct ToolAppBundleRequest: Equatable, Sendable {
         self.sandboxEnabled = sandboxEnabled
         self.sandboxPermissions = sandboxPermissions
         self.resourcePermissions = resourcePermissions
-        self.promptSummary = promptSummary
         self.iconPrompt = iconPrompt
     }
 
@@ -57,7 +54,6 @@ struct ToolAppBundleRequest: Equatable, Sendable {
             sandboxEnabled: tool.sandboxEnabled,
             sandboxPermissions: sandboxPermissions,
             resourcePermissions: resourcePermissions,
-            promptSummary: tool.lastPromptSummary,
             iconPrompt: nil
         )
     }

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolIconClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolIconClient.swift
@@ -6,18 +6,15 @@ import ImagePlayground
 
 struct ToolIconRequest: Equatable, Sendable {
     let displayName: String
-    let promptSummary: String?
     let iconPrompt: String?
     let layout: ToolPackageLayout
 
     init(
         displayName: String,
-        promptSummary: String?,
         iconPrompt: String? = nil,
         layout: ToolPackageLayout
     ) {
         self.displayName = displayName
-        self.promptSummary = promptSummary
         self.iconPrompt = iconPrompt
         self.layout = layout
     }
@@ -27,6 +24,10 @@ struct ToolIconClient: Sendable {
     var ensureIconAssets: @Sendable (ToolIconRequest) async throws -> URL
 
     nonisolated private static let cachedPreviewPNGPixelSize = 256
+
+    nonisolated static let noOp = ToolIconClient { request in
+        request.layout.cachedAppIconICNSURL
+    }
 
     static func live(
         fileManager: FileManager = .default,

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -162,6 +162,8 @@ struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static let agentManifestFilename = "ironsmith-manifest.json"
     nonisolated static let packageMetadataDirectoryName = ".ironsmith"
     nonisolated static let versionsDirectoryName = "versions"
+    nonisolated static let pendingContentViewDraftFilename = "pending-ContentView.swift"
+    nonisolated static let pendingContentViewDraftPath = "\(packageMetadataDirectoryName)/\(pendingContentViewDraftFilename)"
     nonisolated static let pendingContentViewVersionFilename = "pending-ContentView.swift"
     nonisolated static let previousContentViewVersionFilename = "previous-ContentView.swift"
 
@@ -182,6 +184,10 @@ struct ToolPackageLayout: Equatable, Sendable {
 
     nonisolated var versionsDirectoryURL: URL {
         Self.versionsDirectoryURL(for: packageRootURL)
+    }
+
+    nonisolated var pendingContentViewDraftURL: URL {
+        Self.pendingContentViewDraftURL(for: packageRootURL)
     }
 
     nonisolated var pendingContentViewVersionURL: URL {
@@ -262,6 +268,11 @@ struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static func versionsDirectoryURL(for packageRootURL: URL) -> URL {
         packageMetadataDirectoryURL(for: packageRootURL)
             .appendingPathComponent(versionsDirectoryName, isDirectory: true)
+    }
+
+    nonisolated static func pendingContentViewDraftURL(for packageRootURL: URL) -> URL {
+        packageMetadataDirectoryURL(for: packageRootURL)
+            .appendingPathComponent(pendingContentViewDraftFilename)
     }
 
     nonisolated static func pendingContentViewVersionURL(for packageRootURL: URL) -> URL {

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/BuildSupport.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/BuildSupport.swift
@@ -90,6 +90,34 @@ extension ContentViewBuildRepairLoop {
         throw ToolGenerationError.compileFailed("ContentView.swift did not compile after generation and repair attempts.")
     }
 
+    func restoreInterruptedSource(
+        _ bestCandidate: SourceCandidate?,
+        failureRecovery: FailureRecovery
+    ) throws {
+        switch failureRecovery {
+        case .restoreBestCandidate:
+            if let bestCandidate {
+                try context.write(bestCandidate.source, to: contentViewPath, packageRootURL: layout.packageRootURL)
+                AgentDiagnosticsLog.append(
+                    """
+                    Restored best ContentView.swift candidate after interruption.
+                    packageRoot: \(layout.packageRootURL.path)
+                    phase: \(bestCandidate.phase)
+                    contentViewErrorCount: \(bestCandidate.contentViewErrorCount)
+                    """
+                )
+            }
+        case .restoreOriginalSource(let originalSource):
+            try context.write(originalSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
+            AgentDiagnosticsLog.append(
+                """
+                Restored original ContentView.swift after interrupted edit.
+                packageRoot: \(layout.packageRootURL.path)
+                """
+            )
+        }
+    }
+
     static func isRetryableCandidateFailure(_ error: any Error) -> Bool {
         guard let generationError = error as? ToolGenerationError else {
             return false

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
@@ -87,147 +87,152 @@ struct ContentViewBuildRepairLoop {
         var pendingRegenerationReason: String?
         var consecutiveRetryableCandidateFailures = 0
 
-        candidateLoop: for generationAttempt in 1...maximumGenerationAttempts {
-            try Task.checkCancellation()
-            let isInitialAttempt = generationAttempt == 1
-            if !isInitialAttempt {
-                AgentDiagnosticsLog.append(
-                    """
-                    Regenerating ContentView.swift.
-                    packageRoot: \(layout.packageRootURL.path)
-                    mode: \(activeGenerator.modeDescription)
-                    generationAttempt: \(generationAttempt)
-                    reason: \(pendingRegenerationReason ?? "repair requested a fresh candidate")
-                    """
-                )
-            }
-
-            let statusVerb = isInitialAttempt ? activeGenerator.initialStatusVerb : activeGenerator.retryStatusVerb
-            status("\(statusVerb) \(displayName)")
-            do {
-                try await activeGenerator.writeFreshCandidate(makeGenerationSession(instructions: activeGenerator.instructions))
+        do {
+            candidateLoop: for generationAttempt in 1...maximumGenerationAttempts {
                 try Task.checkCancellation()
-                try await Self.cleanContentViewSource(contentViewPath, layout: layout, context: context)
-                consecutiveRetryableCandidateFailures = 0
-            } catch where ToolGenerationError.isContextWindowExceeded(error) {
-                AgentDiagnosticsLog.append(
-                    """
-                    ContentView generation exceeded context window; retrying generation.
-                    packageRoot: \(layout.packageRootURL.path)
-                    mode: \(activeGenerator.modeDescription)
-                    generationAttempt: \(generationAttempt)
-                    error:
-                    \(AgentDiagnosticsLog.renderError(error, limit: 1_500))
-                    """
-                )
-                guard generationAttempt < maximumGenerationAttempts else {
-                    throw error
-                }
-                continue
-            } catch where activeGenerator.retriesInvalidCandidates && Self.isRetryableCandidateFailure(error) {
-                consecutiveRetryableCandidateFailures += 1
-                lastFailureMessage = error.localizedDescription
-                pendingRegenerationReason = error.localizedDescription
-                AgentDiagnosticsLog.append(
-                    """
-                    ContentView candidate rejected; requesting another candidate.
-                    packageRoot: \(layout.packageRootURL.path)
-                    mode: \(activeGenerator.modeDescription)
-                    generationAttempt: \(generationAttempt)
-                    error:
-                    \(AgentDiagnosticsLog.renderError(error, limit: 800))
-                    """
-                )
-                if let fallback = activeGenerator.invalidCandidateFallback,
-                   consecutiveRetryableCandidateFailures >= fallback.threshold,
-                   generationAttempt < maximumGenerationAttempts {
+                let isInitialAttempt = generationAttempt == 1
+                if !isInitialAttempt {
                     AgentDiagnosticsLog.append(
                         """
-                        Edit diff fallback selected.
+                        Regenerating ContentView.swift.
                         packageRoot: \(layout.packageRootURL.path)
+                        mode: \(activeGenerator.modeDescription)
                         generationAttempt: \(generationAttempt)
-                        invalidFailureCount: \(consecutiveRetryableCandidateFailures)
-                        fallbackReason: \(error.localizedDescription)
+                        reason: \(pendingRegenerationReason ?? "repair requested a fresh candidate")
                         """
                     )
-                    activeGenerator = fallback.makeGenerator()
-                    consecutiveRetryableCandidateFailures = 0
-                    pendingRegenerationReason = "switched to whole-file edit after repeated invalid edit diffs"
                 }
-                guard generationAttempt < maximumGenerationAttempts else {
+
+                let statusVerb = isInitialAttempt ? activeGenerator.initialStatusVerb : activeGenerator.retryStatusVerb
+                status("\(statusVerb) \(displayName)")
+                do {
+                    try await activeGenerator.writeFreshCandidate(makeGenerationSession(instructions: activeGenerator.instructions))
+                    try Task.checkCancellation()
+                    try await Self.cleanContentViewSource(contentViewPath, layout: layout, context: context)
+                    consecutiveRetryableCandidateFailures = 0
+                } catch where ToolGenerationError.isContextWindowExceeded(error) {
+                    AgentDiagnosticsLog.append(
+                        """
+                        ContentView generation exceeded context window; retrying generation.
+                        packageRoot: \(layout.packageRootURL.path)
+                        mode: \(activeGenerator.modeDescription)
+                        generationAttempt: \(generationAttempt)
+                        error:
+                        \(AgentDiagnosticsLog.renderError(error, limit: 1_500))
+                        """
+                    )
+                    guard generationAttempt < maximumGenerationAttempts else {
+                        throw error
+                    }
+                    continue
+                } catch where activeGenerator.retriesInvalidCandidates && Self.isRetryableCandidateFailure(error) {
+                    consecutiveRetryableCandidateFailures += 1
+                    lastFailureMessage = error.localizedDescription
+                    pendingRegenerationReason = error.localizedDescription
+                    AgentDiagnosticsLog.append(
+                        """
+                        ContentView candidate rejected; requesting another candidate.
+                        packageRoot: \(layout.packageRootURL.path)
+                        mode: \(activeGenerator.modeDescription)
+                        generationAttempt: \(generationAttempt)
+                        error:
+                        \(AgentDiagnosticsLog.renderError(error, limit: 800))
+                        """
+                    )
+                    if let fallback = activeGenerator.invalidCandidateFallback,
+                       consecutiveRetryableCandidateFailures >= fallback.threshold,
+                       generationAttempt < maximumGenerationAttempts {
+                        AgentDiagnosticsLog.append(
+                            """
+                            Edit diff fallback selected.
+                            packageRoot: \(layout.packageRootURL.path)
+                            generationAttempt: \(generationAttempt)
+                            invalidFailureCount: \(consecutiveRetryableCandidateFailures)
+                            fallbackReason: \(error.localizedDescription)
+                            """
+                        )
+                        activeGenerator = fallback.makeGenerator()
+                        consecutiveRetryableCandidateFailures = 0
+                        pendingRegenerationReason = "switched to whole-file edit after repeated invalid edit diffs"
+                    }
+                    guard generationAttempt < maximumGenerationAttempts else {
+                        break candidateLoop
+                    }
+                    continue
+                } catch {
+                    AgentDiagnosticsLog.append(
+                        """
+                        ContentView generation request failed.
+                        packageRoot: \(layout.packageRootURL.path)
+                        mode: \(activeGenerator.modeDescription)
+                        generationAttempt: \(generationAttempt)
+                        error:
+                        \(AgentDiagnosticsLog.renderError(error))
+                        """
+                    )
+                    throw error
+                }
+
+                let phase = isInitialAttempt ? "initial compile" : "regenerated compile \(generationAttempt - 1)"
+                status("Building \(displayName)")
+                guard var state = try await buildCurrentSource(phase: phase) else {
+                    if try compiledContentViewIsPlaceholder(phase: phase) {
+                        pendingRegenerationReason = "compiled ContentView.swift was only the placeholder scaffold"
+                        lastFailureMessage = "ContentView.swift compiled but only contains the placeholder Generated App scaffold."
+                        continue
+                    }
+                    return
+                }
+
+                guard let stableState = try await applyDeterministicRepairsUntilStable(
+                    startingFrom: state,
+                    phasePrefix: "\(phase) deterministic repair",
+                    status: status
+                ) else {
+                    return
+                }
+                state = stableState
+                lastFailedState = state
+
+                recordBestCandidate(from: state, phase: phase, bestCandidate: &bestCandidate)
+                if state.contentViewErrors.isEmpty {
+                    lastFailureMessage = SwiftPackageProcessClient.compilerExcerpt(from: state.result.combinedOutput)
                     break candidateLoop
                 }
-                continue
-            } catch {
-                AgentDiagnosticsLog.append(
-                    """
-                    ContentView generation request failed.
-                    packageRoot: \(layout.packageRootURL.path)
-                    mode: \(activeGenerator.modeDescription)
-                    generationAttempt: \(generationAttempt)
-                    error:
-                    \(AgentDiagnosticsLog.renderError(error))
-                    """
-                )
-                throw error
-            }
 
-            let phase = isInitialAttempt ? "initial compile" : "regenerated compile \(generationAttempt - 1)"
-            status("Building \(displayName)")
-            guard var state = try await buildCurrentSource(phase: phase) else {
-                if try compiledContentViewIsPlaceholder(phase: phase) {
-                    pendingRegenerationReason = "compiled ContentView.swift was only the placeholder scaffold"
-                    lastFailureMessage = "ContentView.swift compiled but only contains the placeholder Generated App scaffold."
+                let sourceAwareRegenerationThreshold = ToolGenerationRepairPolicy.regenerationThreshold(
+                    for: state.source,
+                    minimumThreshold: regenerationThreshold
+                )
+                if state.contentViewErrors.count > sourceAwareRegenerationThreshold {
+                    pendingRegenerationReason = "ContentView error count \(state.contentViewErrors.count) exceeded regeneration threshold \(sourceAwareRegenerationThreshold)"
                     continue
                 }
-                return
-            }
 
-            guard let stableState = try await applyDeterministicRepairsUntilStable(
-                startingFrom: state,
-                phasePrefix: "\(phase) deterministic repair",
-                status: status
-            ) else {
-                return
-            }
-            state = stableState
-            lastFailedState = state
+                guard context.repairStrategy.usesModelRepair else {
+                    pendingRegenerationReason = "deterministic-only repair stalled with \(state.contentViewErrors.count) ContentView errors"
+                    continue
+                }
 
-            recordBestCandidate(from: state, phase: phase, bestCandidate: &bestCandidate)
-            if state.contentViewErrors.isEmpty {
-                lastFailureMessage = SwiftPackageProcessClient.compilerExcerpt(from: state.result.combinedOutput)
-                break candidateLoop
+                switch try await runModelRepairForCurrentCandidate(
+                    startingFrom: state,
+                    status: status,
+                    bestCandidate: &bestCandidate
+                ) {
+                case .finished:
+                    return
+                case .regenerate(let reason):
+                    pendingRegenerationReason = reason
+                    continue
+                case .failed(let failedState):
+                    lastFailedState = failedState
+                    lastFailureMessage = "ContentView.swift still has \(failedState.contentViewErrors.count) compiler errors after repair attempts."
+                    break candidateLoop
+                }
             }
-
-            let sourceAwareRegenerationThreshold = ToolGenerationRepairPolicy.regenerationThreshold(
-                for: state.source,
-                minimumThreshold: regenerationThreshold
-            )
-            if state.contentViewErrors.count > sourceAwareRegenerationThreshold {
-                pendingRegenerationReason = "ContentView error count \(state.contentViewErrors.count) exceeded regeneration threshold \(sourceAwareRegenerationThreshold)"
-                continue
-            }
-
-            guard context.repairStrategy.usesModelRepair else {
-                pendingRegenerationReason = "deterministic-only repair stalled with \(state.contentViewErrors.count) ContentView errors"
-                continue
-            }
-
-            switch try await runModelRepairForCurrentCandidate(
-                startingFrom: state,
-                status: status,
-                bestCandidate: &bestCandidate
-            ) {
-            case .finished:
-                return
-            case .regenerate(let reason):
-                pendingRegenerationReason = reason
-                continue
-            case .failed(let failedState):
-                lastFailedState = failedState
-                lastFailureMessage = "ContentView.swift still has \(failedState.contentViewErrors.count) compiler errors after repair attempts."
-                break candidateLoop
-            }
+        } catch where IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
+            try restoreInterruptedSource(bestCandidate, failureRecovery: failureRecovery)
+            throw error
         }
 
         try restoreBestCandidateAndFail(

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
@@ -193,6 +193,9 @@ struct ContentViewBuildRepairLoop {
                 }
                 state = stableState
                 lastFailedState = state
+                try await lifecycle.updateRepairErrorCount(
+                    state.contentViewErrors.isEmpty ? nil : state.contentViewErrors.count
+                )
 
                 recordBestCandidate(from: state, phase: phase, bestCandidate: &bestCandidate)
                 if state.contentViewErrors.isEmpty {

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
@@ -8,6 +8,7 @@ struct ContentViewBuildRepairLoop {
     let contentViewPath: String
     let regenerationThreshold: Int
     let maximumGenerationAttempts: Int
+    let lifecycle: ToolGenerationLifecycle
 
     struct SourceCandidate {
         let source: String

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ModelRepair.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ModelRepair.swift
@@ -21,6 +21,7 @@ extension ContentViewBuildRepairLoop {
             guard !state.contentViewErrors.isEmpty else {
                 return .failed(state)
             }
+            try await lifecycle.updateRepairErrorCount(state.contentViewErrors.count)
             status(repairStatus(errorCount: state.contentViewErrors.count))
             let originalSource = state.source
             let contentViewErrors = state.contentViewErrors

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/RepairPrompt.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/RepairPrompt.swift
@@ -116,6 +116,7 @@ extension ContentViewBuildRepairLoop {
             try Task.checkCancellation()
             diff = response
         } catch {
+            try? context.fileClient.removeItemIfExists(layout.pendingContentViewDraftURL)
             AgentDiagnosticsLog.append(
                 """
                 Model repair request failed.

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/RepairPrompt.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/RepairPrompt.swift
@@ -101,13 +101,20 @@ extension ContentViewBuildRepairLoop {
         let diff: String
         do {
             try Task.checkCancellation()
-            let response = try await context.respond(
+            try await lifecycle.updatePhase(.generating, .generatingRepairDiff, nil)
+            let draftPath = ToolPackageLayout.pendingContentViewDraftPath
+            let response = try await context.streamText(
                 in: repairConversation.session,
-                to: prompt,
-                generating: String.self
-            )
+                to: prompt
+            ) { partialDiff in
+                try context.write(
+                    partialDiff,
+                    to: draftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+            }
             try Task.checkCancellation()
-            diff = response.content
+            diff = response
         } catch {
             AgentDiagnosticsLog.append(
                 """

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -4,6 +4,16 @@ import Foundation
 struct SingleFileToolGenerationRuntime {
     let context: ToolGenerationRuntimeContext
 
+    private struct CreateToolSetup {
+        let displayName: String
+        let executableName: String
+        let bundleIdentifier: String
+        let layout: ToolPackageLayout
+        let contentViewPath: String
+        let manifest: ToolManifest
+        let iconPrompt: String?
+    }
+
     func generateTool(
         for prompt: String,
         existingTool: Tool? = nil,
@@ -18,21 +28,23 @@ struct SingleFileToolGenerationRuntime {
             throw ToolGenerationError.emptyPrompt
         }
 
-        if let existingTool, !existingTool.isGenerationReady {
-            return try await resumeTool(
-                prompt: trimmedPrompt,
-                existingTool: existingTool,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                lifecycle: lifecycle,
-                status: status
-            )
-        }
-
         if let existingTool {
+            let effectivePrompt = existingTool.isGenerationReady
+                ? trimmedPrompt
+                : Self.savedPrompt(for: existingTool, fallback: trimmedPrompt)
+            if !existingTool.isGenerationReady, (existingTool.generationMode ?? .create) == .create {
+                return try await createTool(
+                    prompt: effectivePrompt,
+                    existingTool: existingTool,
+                    sandboxEnabled: sandboxEnabled,
+                    sandboxPermissions: sandboxPermissions,
+                    resourcePermissions: resourcePermissions,
+                    lifecycle: lifecycle,
+                    status: status
+                )
+            }
             return try await editTool(
-                prompt: trimmedPrompt,
+                prompt: effectivePrompt,
                 existingTool: existingTool,
                 sandboxEnabled: sandboxEnabled,
                 sandboxPermissions: sandboxPermissions,
@@ -56,26 +68,37 @@ struct SingleFileToolGenerationRuntime {
         ToolGenerationRuntimeContext.cleanedSource(response)
     }
 
-    private func createTool(
+    private static func savedPrompt(for tool: Tool, fallback: String) -> String {
+        let savedPrompt = tool.pendingPrompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let savedPrompt, !savedPrompt.isEmpty {
+            return savedPrompt
+        }
+        return fallback
+    }
+
+    private func loadCreateSetup(for tool: Tool) throws -> CreateToolSetup {
+        let manifest = try context.loadManifest(at: tool.agentManifestURL)
+        let layout = ToolPackageLayout(
+            packageRootURL: tool.packageRootURL,
+            executableName: manifest.executableName
+        )
+        return CreateToolSetup(
+            displayName: manifest.displayName,
+            executableName: manifest.executableName,
+            bundleIdentifier: tool.bundleIdentifier,
+            layout: layout,
+            contentViewPath: manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName),
+            manifest: manifest,
+            iconPrompt: nil
+        )
+    }
+
+    private func prepareNewCreateSetup(
+        metadata: ToolMetadataSuggestion,
         prompt: String,
         sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        status("Planning app")
-        try await lifecycle.updatePhase(.generating, .planning, nil)
-        try Task.checkCancellation()
-        let metadata = await context.metadataClient.suggestMetadata(
-            userPrompt: prompt,
-            languageModel: context.metadataLanguageModel,
-            generationOptions: context.generationOptions
-        )
-        try Task.checkCancellation()
-        let promptRefinement = await contentGenerationPrompt(for: prompt, sandboxEnabled: sandboxEnabled)
-        let contentGenerationPrompt = promptRefinement.prompt
-        try Task.checkCancellation()
+        lifecycle: ToolGenerationLifecycle
+    ) async throws -> CreateToolSetup {
         let displayName = metadata.displayName
         let executableName = ToolNameSanitizer.executableName(from: displayName)
         let bundleIdentifier = ToolBundleIdentifier.make(executableName: executableName)
@@ -93,101 +116,166 @@ struct SingleFileToolGenerationRuntime {
             ]
         )
 
+        try context.fileClient.createDirectory(layout.sourceDirectoryURL)
+        try context.write(layout.packageManifestContent(), to: "Package.swift", packageRootURL: layout.packageRootURL)
+        try context.write(layout.fixedAppEntrySource(), to: layout.appEntrySourcePath, packageRootURL: layout.packageRootURL)
+        try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
+        try await lifecycle.prepareCreatedTool(
+            ToolGenerationPreparedTool(
+                name: displayName,
+                executableName: executableName,
+                bundleIdentifier: bundleIdentifier,
+                sandboxEnabled: sandboxEnabled,
+                packageRootURL: packageRootURL,
+                manifest: manifest
+            ),
+            prompt
+        )
+
+        return CreateToolSetup(
+            displayName: displayName,
+            executableName: executableName,
+            bundleIdentifier: bundleIdentifier,
+            layout: layout,
+            contentViewPath: contentViewPath,
+            manifest: manifest,
+            iconPrompt: metadata.iconPrompt
+        )
+    }
+
+    private func createTool(
+        prompt: String,
+        existingTool: Tool? = nil,
+        sandboxEnabled: Bool,
+        sandboxPermissions: GeneratedAppSandboxPermissions,
+        resourcePermissions: GeneratedAppResourcePermissions,
+        lifecycle: ToolGenerationLifecycle,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        let startingPhase = existingTool?.generationPhase ?? .initializing
+        let setup: CreateToolSetup
+        if let existingTool, let resumedSetup = try? loadCreateSetup(for: existingTool) {
+            setup = resumedSetup
+        } else {
+            status("Naming app")
+            try await lifecycle.updatePhase(.generating, .planning, nil)
+            try Task.checkCancellation()
+            let metadata = await context.metadataClient.suggestMetadata(
+                userPrompt: prompt,
+                languageModel: context.metadataLanguageModel,
+                generationOptions: context.generationOptions
+            )
+            try Task.checkCancellation()
+            setup = try await prepareNewCreateSetup(
+                metadata: metadata,
+                prompt: prompt,
+                sandboxEnabled: sandboxEnabled,
+                lifecycle: lifecycle
+            )
+        }
+
         AgentDiagnosticsLog.append(
             """
             Tool generation started.
             mode: create
-            displayName: \(displayName)
-            executableName: \(executableName)
-            packageRoot: \(packageRootURL.path)
+            displayName: \(setup.displayName)
+            executableName: \(setup.executableName)
+            packageRoot: \(setup.layout.packageRootURL.path)
+            phase: \(startingPhase.rawValue)
             prompt: \(AgentDiagnosticsLog.compact(prompt, limit: 240))
             """
         )
 
         do {
             try Task.checkCancellation()
-            try context.fileClient.createDirectory(layout.sourceDirectoryURL)
-
-            status("Preparing \(displayName)")
-            try context.write(layout.packageManifestContent(), to: "Package.swift", packageRootURL: layout.packageRootURL)
-            try context.write(layout.fixedAppEntrySource(), to: layout.appEntrySourcePath, packageRootURL: layout.packageRootURL)
-            try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
-            try await lifecycle.prepareCreatedTool(
-                ToolGenerationPreparedTool(
-                    name: displayName,
-                    executableName: executableName,
-                    bundleIdentifier: bundleIdentifier,
-                    sandboxEnabled: sandboxEnabled,
-                    packageRootURL: packageRootURL,
-                    manifest: manifest
-                ),
-                prompt,
-                promptRefinement.refinedPrompt
-            )
-
-            let generator = ContentViewCandidateGenerator(modeDescription: "create") { session in
-                try await regenerateCreatedContentView(
-                    userPrompt: contentGenerationPrompt,
-                    sandboxEnabled: sandboxEnabled,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    lifecycle: lifecycle,
-                    session: session
+            if startingPhase == .initializing || startingPhase == .planning || startingPhase == .generatingIcon {
+                try await generateIconAssets(
+                    displayName: setup.displayName,
+                    iconPrompt: setup.iconPrompt,
+                    layout: setup.layout,
+                    lifecycle: lifecycle
                 )
             }
+
+            let contentPrompt: String
+            if startingPhase == .generatingSource
+                || startingPhase == .generatingRepairDiff
+                || startingPhase == .repairing
+                || startingPhase == .packaging
+                || startingPhase == .completed {
+                contentPrompt = prompt
+            } else {
+                contentPrompt = try await contentGenerationPrompt(
+                    for: prompt,
+                    sandboxEnabled: sandboxEnabled,
+                    lifecycle: lifecycle
+                )
+            }
+
+            if startingPhase == .packaging || startingPhase == .completed {
+                return try await packageTool(
+                    displayName: setup.displayName,
+                    executableName: setup.executableName,
+                    bundleIdentifier: setup.bundleIdentifier,
+                    packageRootURL: setup.layout.packageRootURL,
+                    manifest: setup.manifest,
+                    sandboxEnabled: sandboxEnabled,
+                    sandboxPermissions: sandboxPermissions,
+                    resourcePermissions: resourcePermissions,
+                    iconPrompt: setup.iconPrompt,
+                    lifecycle: lifecycle,
+                    status: status
+                )
+            }
+
+            let generator = createGenerator(
+                userPrompt: contentPrompt,
+                sandboxEnabled: sandboxEnabled,
+                layout: setup.layout,
+                contentViewPath: setup.contentViewPath,
+                lifecycle: lifecycle,
+                resumePartialSource: startingPhase == .generatingSource,
+                useCurrentSourceOnFirstAttempt: startingPhase == .repairing || startingPhase == .generatingRepairDiff
+            )
             try await compileGeneratedTool(
-                displayName: displayName,
-                layout: layout,
-                contentViewPath: contentViewPath,
+                displayName: setup.displayName,
+                layout: setup.layout,
+                contentViewPath: setup.contentViewPath,
                 generator: generator,
                 lifecycle: lifecycle,
                 status: status
             )
 
-            try Task.checkCancellation()
-            let binDirectory = try await context.processClient.showBinPath(packageRootURL)
-            let binaryURL = binDirectory.appendingPathComponent(executableName)
-            await context.processClient.stripQuarantine(binaryURL)
-
-            try Task.checkCancellation()
-            status("Packaging \(displayName)")
-            try await lifecycle.updatePhase(.generating, .packaging, nil)
-            _ = try await context.appBundleClient.buildInternalApp(
-                ToolAppBundleRequest(
-                    displayName: displayName,
-                    executableName: executableName,
-                    bundleIdentifier: bundleIdentifier,
-                    packageRootURL: packageRootURL,
-                    sandboxEnabled: sandboxEnabled,
-                    sandboxPermissions: sandboxPermissions,
-                    resourcePermissions: resourcePermissions,
-                    promptSummary: prompt,
-                    iconPrompt: metadata.iconPrompt
-                )
-            )
-
-            return ToolGenerationResult(
-                toolName: displayName,
-                executableName: executableName,
-                bundleIdentifier: bundleIdentifier,
+            return try await packageTool(
+                displayName: setup.displayName,
+                executableName: setup.executableName,
+                bundleIdentifier: setup.bundleIdentifier,
+                packageRootURL: setup.layout.packageRootURL,
+                manifest: setup.manifest,
                 sandboxEnabled: sandboxEnabled,
-                packageRootURL: packageRootURL,
-                manifest: manifest
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                iconPrompt: setup.iconPrompt,
+                lifecycle: lifecycle,
+                status: status
             )
         } catch is CancellationError {
             if !lifecycle.preservesCreatedPackageOnCancellation {
-                try? context.fileClient.removeItemIfExists(packageRootURL)
+                try? context.fileClient.removeItemIfExists(setup.layout.packageRootURL)
             }
             throw CancellationError()
         }
     }
 
-    private func contentGenerationPrompt(for prompt: String, sandboxEnabled: Bool) async -> (
-        prompt: String,
-        refinedPrompt: String?
-    ) {
+    private func contentGenerationPrompt(
+        for prompt: String,
+        sandboxEnabled: Bool,
+        lifecycle: ToolGenerationLifecycle
+    ) async throws -> String {
+        try await lifecycle.updatePhase(.generating, .refiningPrompt, nil)
+        try Task.checkCancellation()
         guard context.promptRefinementEnabled else {
-            return (prompt, nil)
+            return prompt
         }
 
         let refinedPrompt = await context.promptRefinementClient.refinePrompt(
@@ -196,7 +284,12 @@ struct SingleFileToolGenerationRuntime {
             generationOptions: context.generationOptions,
             sandboxEnabled: sandboxEnabled
         )
-        return (refinedPrompt ?? prompt, refinedPrompt)
+        try Task.checkCancellation()
+        guard let refinedPrompt else {
+            return prompt
+        }
+        try await lifecycle.updatePendingPrompt(refinedPrompt)
+        return refinedPrompt
     }
 
     private func editTool(
@@ -214,6 +307,25 @@ struct SingleFileToolGenerationRuntime {
             executableName: manifest.executableName
         )
         let contentViewPath = manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
+        let startingPhase = existingTool.isGenerationReady
+            ? ToolGenerationPhase.planning
+            : (existingTool.generationPhase ?? .generatingEditDiff)
+        if !existingTool.isGenerationReady,
+           startingPhase == .packaging || startingPhase == .completed {
+            return try await packageTool(
+                displayName: manifest.displayName,
+                executableName: manifest.executableName,
+                bundleIdentifier: existingTool.bundleIdentifier,
+                packageRootURL: existingTool.packageRootURL,
+                manifest: manifest,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                iconPrompt: nil,
+                lifecycle: lifecycle,
+                status: status
+            )
+        }
         let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
         let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
 
@@ -224,6 +336,7 @@ struct SingleFileToolGenerationRuntime {
             displayName: \(manifest.displayName)
             executableName: \(manifest.executableName)
             packageRoot: \(existingTool.packageRootURL.path)
+            phase: \(startingPhase.rawValue)
             prompt: \(AgentDiagnosticsLog.compact(prompt, limit: 240))
             editableFile: \(contentViewPath)
             """
@@ -231,58 +344,16 @@ struct SingleFileToolGenerationRuntime {
 
         do {
             try Task.checkCancellation()
-            try await lifecycle.updatePhase(.generating, .generatingEditDiff, nil)
             try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
-            let generator: ContentViewCandidateGenerator
-            if context.repairStrategy.usesModelRepair {
-                generator = ContentViewCandidateGenerator(
-                    modeDescription: "edit",
-                    initialStatusVerb: "Editing",
-                    retryStatusVerb: "Editing",
-                    instructions: ToolGenerationPrompts.diffEditInstructions,
-                    retriesInvalidCandidates: true,
-                    invalidCandidateFallback: ContentViewCandidateGenerator.InvalidCandidateFallback(
-                        threshold: ToolGenerationRepairPolicy.invalidInitialEditDiffsBeforeFullFileEdit,
-                        modeDescription: "edit whole-file fallback",
-                        initialStatusVerb: "Editing",
-                        retryStatusVerb: "Editing"
-                    ) { session in
-                        try await regenerateEditedContentView(
-                            userPrompt: prompt,
-                            layout: layout,
-                            contentViewPath: contentViewPath,
-                            existingSource: existingSource,
-                            lifecycle: lifecycle,
-                            session: session
-                        )
-                    }
-                ) { session in
-                    try await regenerateEditedContentViewDiff(
-                        userPrompt: prompt,
-                        layout: layout,
-                        contentViewPath: contentViewPath,
-                        existingSource: existingSource,
-                        maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
-                        lifecycle: lifecycle,
-                        session: session
-                    )
-                }
-            } else {
-                generator = ContentViewCandidateGenerator(
-                    modeDescription: "edit",
-                    initialStatusVerb: "Editing",
-                    retryStatusVerb: "Editing"
-                ) { session in
-                    try await regenerateEditedContentView(
-                        userPrompt: prompt,
-                        layout: layout,
-                        contentViewPath: contentViewPath,
-                        existingSource: existingSource,
-                        lifecycle: lifecycle,
-                        session: session
-                    )
-                }
-            }
+            let generator = editGenerator(
+                userPrompt: prompt,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                existingSource: existingSource,
+                lifecycle: lifecycle,
+                resumePartialDiff: startingPhase == .generatingEditDiff,
+                resumePartialSource: startingPhase == .generatingSource
+            )
             try await compileGeneratedTool(
                 displayName: manifest.displayName,
                 layout: layout,
@@ -303,10 +374,10 @@ struct SingleFileToolGenerationRuntime {
                     packageRootURL: existingTool.packageRootURL,
                     sandboxEnabled: sandboxEnabled,
                     sandboxPermissions: sandboxPermissions,
-                    resourcePermissions: resourcePermissions,
-                    promptSummary: prompt
+                    resourcePermissions: resourcePermissions
                 )
             )
+            try? context.fileClient.removeItemIfExists(layout.pendingContentViewDraftURL)
             try context.versionBackupClient.promoteStagedVersion(backup)
         } catch {
             try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
@@ -336,630 +407,6 @@ struct SingleFileToolGenerationRuntime {
         )
     }
 
-    private func resumeTool(
-        prompt: String,
-        existingTool: Tool,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        let manifest = try context.loadManifest(at: existingTool.agentManifestURL)
-        let layout = ToolPackageLayout(
-            packageRootURL: existingTool.packageRootURL,
-            executableName: manifest.executableName
-        )
-        let contentViewPath = manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
-        let mode = existingTool.generationMode ?? .create
-        let phase = existingTool.generationPhase ?? .planning
-        let userPrompt = existingTool.pendingPrompt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-            ? existingTool.pendingPrompt ?? prompt
-            : prompt
-        let refinedPrompt = existingTool.pendingRefinedPrompt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-            ? existingTool.pendingRefinedPrompt ?? userPrompt
-            : userPrompt
-
-        AgentDiagnosticsLog.append(
-            """
-            Tool generation resumed.
-            mode: \(mode.rawValue)
-            phase: \(phase.rawValue)
-            displayName: \(manifest.displayName)
-            executableName: \(manifest.executableName)
-            packageRoot: \(existingTool.packageRootURL.path)
-            """
-        )
-
-        switch phase {
-        case .initializing, .planning:
-            return try await resumeFromPlanning(
-                mode: mode,
-                userPrompt: userPrompt,
-                refinedPrompt: refinedPrompt,
-                existingTool: existingTool,
-                manifest: manifest,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                lifecycle: lifecycle,
-                status: status
-            )
-
-        case .generatingSource:
-            return try await resumeSourceGeneration(
-                mode: mode,
-                userPrompt: userPrompt,
-                refinedPrompt: refinedPrompt,
-                existingTool: existingTool,
-                manifest: manifest,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                lifecycle: lifecycle,
-                status: status
-            )
-
-        case .generatingEditDiff:
-            return try await resumeEditDiffGeneration(
-                userPrompt: userPrompt,
-                existingTool: existingTool,
-                manifest: manifest,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                lifecycle: lifecycle,
-                status: status
-            )
-
-        case .generatingRepairDiff, .repairing:
-            try await compileGeneratedTool(
-                displayName: manifest.displayName,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                generator: resumedRepairGenerator(
-                    mode: mode,
-                    userPrompt: userPrompt,
-                    refinedPrompt: refinedPrompt,
-                    sandboxEnabled: sandboxEnabled,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    existingSource: try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL),
-                    lifecycle: lifecycle
-                ),
-                failureRecovery: mode == .edit
-                    ? .restoreOriginalSource(try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL))
-                    : .restoreBestCandidate,
-                lifecycle: lifecycle,
-                status: status
-            )
-            return try await packageResumedTool(
-                existingTool,
-                manifest: manifest,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                prompt: userPrompt,
-                lifecycle: lifecycle,
-                status: status
-            )
-
-        case .packaging, .completed:
-            return try await packageResumedTool(
-                existingTool,
-                manifest: manifest,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                prompt: userPrompt,
-                lifecycle: lifecycle,
-                status: status
-            )
-        }
-    }
-
-    private func resumeFromPlanning(
-        mode: ToolGenerationMode,
-        userPrompt: String,
-        refinedPrompt: String,
-        existingTool: Tool,
-        manifest: ToolManifest,
-        layout: ToolPackageLayout,
-        contentViewPath: String,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        switch mode {
-        case .create:
-            let generator = ContentViewCandidateGenerator(modeDescription: "resume create") { session in
-                try await regenerateCreatedContentView(
-                    userPrompt: refinedPrompt,
-                    sandboxEnabled: sandboxEnabled,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    lifecycle: lifecycle,
-                    session: session
-                )
-            }
-            try await compileGeneratedTool(
-                displayName: manifest.displayName,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                generator: generator,
-                lifecycle: lifecycle,
-                status: status
-            )
-        case .edit:
-            let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
-            let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
-            do {
-                let generator = editGenerator(
-                    userPrompt: userPrompt,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    existingSource: existingSource,
-                    lifecycle: lifecycle
-                )
-                try await compileGeneratedTool(
-                    displayName: manifest.displayName,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    generator: generator,
-                    failureRecovery: .restoreOriginalSource(existingSource),
-                    lifecycle: lifecycle,
-                    status: status
-                )
-                try context.versionBackupClient.promoteStagedVersion(backup)
-            } catch {
-                try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
-                try? context.versionBackupClient.discardStagedVersion(backup)
-                throw error
-            }
-        }
-
-        return try await packageResumedTool(
-            existingTool,
-            manifest: manifest,
-            sandboxEnabled: sandboxEnabled,
-            sandboxPermissions: sandboxPermissions,
-            resourcePermissions: resourcePermissions,
-            prompt: userPrompt,
-            lifecycle: lifecycle,
-            status: status
-        )
-    }
-
-    private func resumeSourceGeneration(
-        mode: ToolGenerationMode,
-        userPrompt: String,
-        refinedPrompt: String,
-        existingTool: Tool,
-        manifest: ToolManifest,
-        layout: ToolPackageLayout,
-        contentViewPath: String,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        let partialSource = try context.readIfPresent(
-            ToolPackageLayout.pendingContentViewDraftPath,
-            packageRootURL: layout.packageRootURL
-        )
-        var didAttemptContinuation = false
-        let basePrompt = mode == .create
-            ? ToolGenerationPrompts.singleFileCreatePrompt(
-                userPrompt: refinedPrompt,
-                executableName: layout.executableName,
-                sandboxEnabled: sandboxEnabled
-            )
-            : ToolGenerationPrompts.singleFileEditPrompt(
-                userPrompt: userPrompt,
-                executableName: layout.executableName,
-                existingSource: try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
-            )
-
-        let writeContinuationOrFreshCandidate: (LanguageModelSession) async throws -> Void = { session in
-            if !didAttemptContinuation, !partialSource.isEmpty {
-                didAttemptContinuation = true
-                try await continueSourceDraft(
-                    partialSource: partialSource,
-                    originalPrompt: basePrompt,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    lifecycle: lifecycle,
-                    session: session
-                )
-                return
-            }
-
-            switch mode {
-            case .create:
-                try await regenerateCreatedContentView(
-                    userPrompt: refinedPrompt,
-                    sandboxEnabled: sandboxEnabled,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    lifecycle: lifecycle,
-                    session: session
-                )
-            case .edit:
-                let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
-                try await regenerateEditedContentView(
-                    userPrompt: userPrompt,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    existingSource: existingSource,
-                    lifecycle: lifecycle,
-                    session: session
-                )
-            }
-        }
-
-        if mode == .edit {
-            let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
-            let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
-            do {
-                try await compileGeneratedTool(
-                    displayName: manifest.displayName,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    generator: ContentViewCandidateGenerator(
-                        modeDescription: "resume source",
-                        initialStatusVerb: "Continuing",
-                        retryStatusVerb: "Editing",
-                        writeFreshCandidate: writeContinuationOrFreshCandidate
-                    ),
-                    failureRecovery: .restoreOriginalSource(existingSource),
-                    lifecycle: lifecycle,
-                    status: status
-                )
-                try context.versionBackupClient.promoteStagedVersion(backup)
-            } catch {
-                try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
-                try? context.versionBackupClient.discardStagedVersion(backup)
-                throw error
-            }
-        } else {
-            try await compileGeneratedTool(
-                displayName: manifest.displayName,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                generator: ContentViewCandidateGenerator(
-                    modeDescription: "resume source",
-                    initialStatusVerb: "Continuing",
-                    retryStatusVerb: "Regenerating",
-                    writeFreshCandidate: writeContinuationOrFreshCandidate
-                ),
-                lifecycle: lifecycle,
-                status: status
-            )
-        }
-
-        return try await packageResumedTool(
-            existingTool,
-            manifest: manifest,
-            sandboxEnabled: sandboxEnabled,
-            sandboxPermissions: sandboxPermissions,
-            resourcePermissions: resourcePermissions,
-            prompt: userPrompt,
-            lifecycle: lifecycle,
-            status: status
-        )
-    }
-
-    private func resumeEditDiffGeneration(
-        userPrompt: String,
-        existingTool: Tool,
-        manifest: ToolManifest,
-        layout: ToolPackageLayout,
-        contentViewPath: String,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
-        let partialDiff = try context.readIfPresent(
-            ToolPackageLayout.pendingContentViewDraftPath,
-            packageRootURL: layout.packageRootURL
-        )
-        let originalPrompt = ToolGenerationPrompts.singleFileEditDiffPrompt(
-            userPrompt: userPrompt,
-            executableName: layout.executableName,
-            existingSource: existingSource,
-            maximumDiffHunks: context.repairStrategy.maxInitialEditHunks
-        )
-        var didAttemptContinuation = false
-        let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
-        do {
-            let generator = ContentViewCandidateGenerator(
-                modeDescription: "resume edit diff",
-                initialStatusVerb: "Continuing",
-                retryStatusVerb: "Editing",
-                instructions: ToolGenerationPrompts.diffEditInstructions,
-                retriesInvalidCandidates: true,
-                invalidCandidateFallback: ContentViewCandidateGenerator.InvalidCandidateFallback(
-                    threshold: ToolGenerationRepairPolicy.invalidInitialEditDiffsBeforeFullFileEdit,
-                    modeDescription: "edit whole-file fallback",
-                    initialStatusVerb: "Editing",
-                    retryStatusVerb: "Editing"
-                ) { session in
-                    try await regenerateEditedContentView(
-                        userPrompt: userPrompt,
-                        layout: layout,
-                        contentViewPath: contentViewPath,
-                        existingSource: existingSource,
-                        lifecycle: lifecycle,
-                        session: session
-                    )
-                }
-            ) { session in
-                if !didAttemptContinuation, !partialDiff.isEmpty {
-                    didAttemptContinuation = true
-                    try await continueDiffDraft(
-                        partialDiff: partialDiff,
-                        originalPrompt: originalPrompt,
-                        originalSource: existingSource,
-                        maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
-                        layout: layout,
-                        contentViewPath: contentViewPath,
-                        phase: .generatingEditDiff,
-                        lifecycle: lifecycle,
-                        session: session
-                    )
-                    return
-                }
-
-                try await regenerateEditedContentViewDiff(
-                    userPrompt: userPrompt,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    existingSource: existingSource,
-                    maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
-                    lifecycle: lifecycle,
-                    session: session
-                )
-            }
-            try await compileGeneratedTool(
-                displayName: manifest.displayName,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                generator: generator,
-                failureRecovery: .restoreOriginalSource(existingSource),
-                lifecycle: lifecycle,
-                status: status
-            )
-            try context.versionBackupClient.promoteStagedVersion(backup)
-        } catch {
-            try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
-            try? context.versionBackupClient.discardStagedVersion(backup)
-            throw error
-        }
-
-        return try await packageResumedTool(
-            existingTool,
-            manifest: manifest,
-            sandboxEnabled: sandboxEnabled,
-            sandboxPermissions: sandboxPermissions,
-            resourcePermissions: resourcePermissions,
-            prompt: userPrompt,
-            lifecycle: lifecycle,
-            status: status
-        )
-    }
-
-    private func resumedRepairGenerator(
-        mode: ToolGenerationMode,
-        userPrompt: String,
-        refinedPrompt: String,
-        sandboxEnabled: Bool,
-        layout: ToolPackageLayout,
-        contentViewPath: String,
-        existingSource: String,
-        lifecycle: ToolGenerationLifecycle
-    ) -> ContentViewCandidateGenerator {
-        switch mode {
-        case .create:
-            ContentViewCandidateGenerator(modeDescription: "resume repair") { session in
-                try await regenerateCreatedContentView(
-                    userPrompt: refinedPrompt,
-                    sandboxEnabled: sandboxEnabled,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    lifecycle: lifecycle,
-                    session: session
-                )
-            }
-        case .edit:
-            editGenerator(
-                userPrompt: userPrompt,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                existingSource: existingSource,
-                lifecycle: lifecycle
-            )
-        }
-    }
-
-    private func editGenerator(
-        userPrompt: String,
-        layout: ToolPackageLayout,
-        contentViewPath: String,
-        existingSource: String,
-        lifecycle: ToolGenerationLifecycle
-    ) -> ContentViewCandidateGenerator {
-        if context.repairStrategy.usesModelRepair {
-            return ContentViewCandidateGenerator(
-                modeDescription: "edit",
-                initialStatusVerb: "Editing",
-                retryStatusVerb: "Editing",
-                instructions: ToolGenerationPrompts.diffEditInstructions,
-                retriesInvalidCandidates: true,
-                invalidCandidateFallback: ContentViewCandidateGenerator.InvalidCandidateFallback(
-                    threshold: ToolGenerationRepairPolicy.invalidInitialEditDiffsBeforeFullFileEdit,
-                    modeDescription: "edit whole-file fallback",
-                    initialStatusVerb: "Editing",
-                    retryStatusVerb: "Editing"
-                ) { session in
-                    try await regenerateEditedContentView(
-                        userPrompt: userPrompt,
-                        layout: layout,
-                        contentViewPath: contentViewPath,
-                        existingSource: existingSource,
-                        lifecycle: lifecycle,
-                        session: session
-                    )
-                }
-            ) { session in
-                try await regenerateEditedContentViewDiff(
-                    userPrompt: userPrompt,
-                    layout: layout,
-                    contentViewPath: contentViewPath,
-                    existingSource: existingSource,
-                    maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
-                    lifecycle: lifecycle,
-                    session: session
-                )
-            }
-        }
-
-        return ContentViewCandidateGenerator(
-            modeDescription: "edit",
-            initialStatusVerb: "Editing",
-            retryStatusVerb: "Editing"
-        ) { session in
-            try await regenerateEditedContentView(
-                userPrompt: userPrompt,
-                layout: layout,
-                contentViewPath: contentViewPath,
-                existingSource: existingSource,
-                lifecycle: lifecycle,
-                session: session
-            )
-        }
-    }
-
-    private func continueSourceDraft(
-        partialSource: String,
-        originalPrompt: String,
-        layout: ToolPackageLayout,
-        contentViewPath: String,
-        lifecycle: ToolGenerationLifecycle,
-        session: LanguageModelSession
-    ) async throws {
-        let prompt = ToolGenerationPrompts.sourceContinuationPrompt(
-            originalPrompt: originalPrompt,
-            partialSource: partialSource
-        )
-        try await lifecycle.updatePhase(.generating, .generatingSource, nil)
-        let continuation = try await context.streamText(in: session, to: prompt) { partialContinuation in
-            try context.write(
-                partialSource + partialContinuation,
-                to: ToolPackageLayout.pendingContentViewDraftPath,
-                packageRootURL: layout.packageRootURL
-            )
-        }
-        try context.write(
-            partialSource + continuation,
-            to: contentViewPath,
-            packageRootURL: layout.packageRootURL
-        )
-    }
-
-    private func continueDiffDraft(
-        partialDiff: String,
-        originalPrompt: String,
-        originalSource: String,
-        maximumDiffHunks: Int?,
-        layout: ToolPackageLayout,
-        contentViewPath: String,
-        phase: ToolGenerationPhase,
-        lifecycle: ToolGenerationLifecycle,
-        session: LanguageModelSession
-    ) async throws {
-        let prompt = ToolGenerationPrompts.diffContinuationPrompt(
-            originalPrompt: originalPrompt,
-            partialDiff: partialDiff
-        )
-        try await lifecycle.updatePhase(.generating, phase, nil)
-        let continuation = try await context.streamText(in: session, to: prompt) { partialContinuation in
-            try context.write(
-                partialDiff + partialContinuation,
-                to: ToolPackageLayout.pendingContentViewDraftPath,
-                packageRootURL: layout.packageRootURL
-            )
-        }
-        let sanitizedDiff = ContentViewRepairSupport.sanitizedRepairDiffSummary(partialDiff + continuation)
-        let editedSource = try ContentViewRepairSupport.applyValidatedDiff(
-            sanitizedDiff,
-            to: originalSource,
-            maximumHunks: maximumDiffHunks
-        )
-        try context.write(
-            editedSource,
-            to: contentViewPath,
-            packageRootURL: layout.packageRootURL
-        )
-    }
-
-    private func packageResumedTool(
-        _ tool: Tool,
-        manifest: ToolManifest,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
-        prompt: String,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        let layout = ToolPackageLayout(
-            packageRootURL: tool.packageRootURL,
-            executableName: manifest.executableName
-        )
-        try Task.checkCancellation()
-        let binDirectory = try await context.processClient.showBinPath(tool.packageRootURL)
-        let binaryURL = binDirectory.appendingPathComponent(manifest.executableName)
-        await context.processClient.stripQuarantine(binaryURL)
-
-        try Task.checkCancellation()
-        status("Packaging \(manifest.displayName)")
-        try await lifecycle.updatePhase(.generating, .packaging, nil)
-        _ = try await context.appBundleClient.buildInternalApp(
-            ToolAppBundleRequest(
-                displayName: manifest.displayName,
-                executableName: manifest.executableName,
-                bundleIdentifier: tool.bundleIdentifier,
-                packageRootURL: tool.packageRootURL,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                promptSummary: prompt
-            )
-        )
-
-        try? context.fileClient.removeItemIfExists(layout.pendingContentViewDraftURL)
-        return ToolGenerationResult(
-            toolName: manifest.displayName,
-            executableName: manifest.executableName,
-            bundleIdentifier: tool.bundleIdentifier,
-            sandboxEnabled: sandboxEnabled,
-            packageRootURL: tool.packageRootURL,
-            manifest: manifest
-        )
-    }
-
     private func compileGeneratedTool(
         displayName: String,
         layout: ToolPackageLayout,
@@ -984,6 +431,440 @@ struct SingleFileToolGenerationRuntime {
             failureRecovery: failureRecovery,
             status: status
         )
+    }
+
+    private func generateIconAssets(
+        displayName: String,
+        iconPrompt: String?,
+        layout: ToolPackageLayout,
+        lifecycle: ToolGenerationLifecycle
+    ) async throws {
+        try await lifecycle.updatePhase(.generating, .generatingIcon, nil)
+        do {
+            try Task.checkCancellation()
+            _ = try await context.iconClient.ensureIconAssets(
+                ToolIconRequest(
+                    displayName: displayName,
+                    iconPrompt: iconPrompt,
+                    layout: layout
+                )
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            AgentDiagnosticsLog.append(
+                """
+                Early icon generation failed; packaging can retry.
+                displayName: \(displayName)
+                packageRoot: \(layout.packageRootURL.path)
+                error:
+                \(AgentDiagnosticsLog.renderError(error, limit: 500))
+                """
+            )
+        }
+    }
+
+    private func createGenerator(
+        userPrompt: String,
+        sandboxEnabled: Bool,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        lifecycle: ToolGenerationLifecycle,
+        resumePartialSource: Bool,
+        useCurrentSourceOnFirstAttempt: Bool
+    ) -> ContentViewCandidateGenerator {
+        var didUseCurrentSource = false
+        var didAttemptContinuation = false
+        let originalPrompt = ToolGenerationPrompts.singleFileCreatePrompt(
+            userPrompt: userPrompt,
+            executableName: layout.executableName,
+            sandboxEnabled: sandboxEnabled
+        )
+
+        return ContentViewCandidateGenerator(
+            modeDescription: resumePartialSource ? "continue create" : "create",
+            initialStatusVerb: resumePartialSource ? "Continuing" : "Generating",
+            retryStatusVerb: "Regenerating"
+        ) { session in
+            if useCurrentSourceOnFirstAttempt && !didUseCurrentSource {
+                didUseCurrentSource = true
+                let currentSource = try context.readIfPresent(
+                    contentViewPath,
+                    packageRootURL: layout.packageRootURL
+                )
+                if !currentSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return
+                }
+            }
+
+            if resumePartialSource && !didAttemptContinuation {
+                didAttemptContinuation = true
+                let partialSource = try context.readIfPresent(
+                    ToolPackageLayout.pendingContentViewDraftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+                if !partialSource.isEmpty {
+                    do {
+                        try await continueSourceDraft(
+                            partialSource: partialSource,
+                            originalPrompt: originalPrompt,
+                            layout: layout,
+                            contentViewPath: contentViewPath,
+                            lifecycle: lifecycle,
+                            session: session
+                        )
+                        return
+                    } catch is CancellationError {
+                        throw CancellationError()
+                    } catch {
+                        AgentDiagnosticsLog.append(
+                            """
+                            Source continuation failed; requesting a fresh source file.
+                            packageRoot: \(layout.packageRootURL.path)
+                            error:
+                            \(AgentDiagnosticsLog.renderError(error, limit: 800))
+                            """
+                        )
+                    }
+                }
+            }
+
+            try await regenerateCreatedContentView(
+                userPrompt: userPrompt,
+                sandboxEnabled: sandboxEnabled,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                lifecycle: lifecycle,
+                session: session
+            )
+        }
+    }
+
+    private func editGenerator(
+        userPrompt: String,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        existingSource: String,
+        lifecycle: ToolGenerationLifecycle,
+        resumePartialDiff: Bool,
+        resumePartialSource: Bool
+    ) -> ContentViewCandidateGenerator {
+        if resumePartialSource || !context.repairStrategy.usesModelRepair {
+            return wholeFileEditGenerator(
+                userPrompt: userPrompt,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                existingSource: existingSource,
+                lifecycle: lifecycle,
+                resumePartialSource: resumePartialSource
+            )
+        }
+
+        var didAttemptContinuation = false
+        let originalPrompt = ToolGenerationPrompts.singleFileEditDiffPrompt(
+            userPrompt: userPrompt,
+            executableName: layout.executableName,
+            existingSource: existingSource,
+            maximumDiffHunks: context.repairStrategy.maxInitialEditHunks
+        )
+
+        return ContentViewCandidateGenerator(
+            modeDescription: resumePartialDiff ? "continue edit diff" : "edit",
+            initialStatusVerb: resumePartialDiff ? "Continuing" : "Editing",
+            retryStatusVerb: "Editing",
+            instructions: ToolGenerationPrompts.diffEditInstructions,
+            retriesInvalidCandidates: true,
+            invalidCandidateFallback: ContentViewCandidateGenerator.InvalidCandidateFallback(
+                threshold: ToolGenerationRepairPolicy.invalidInitialEditDiffsBeforeFullFileEdit,
+                modeDescription: "edit whole-file fallback",
+                initialStatusVerb: "Editing",
+                retryStatusVerb: "Editing"
+            ) { session in
+                try await regenerateEditedContentView(
+                    userPrompt: userPrompt,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    existingSource: existingSource,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+            }
+        ) { session in
+            if resumePartialDiff && !didAttemptContinuation {
+                didAttemptContinuation = true
+                let partialDiff = try context.readIfPresent(
+                    ToolPackageLayout.pendingContentViewDraftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+                if !partialDiff.isEmpty {
+                    try await continueDiffDraft(
+                        partialDiff: partialDiff,
+                        originalPrompt: originalPrompt,
+                        originalSource: existingSource,
+                        maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
+                        layout: layout,
+                        contentViewPath: contentViewPath,
+                        lifecycle: lifecycle,
+                        session: session
+                    )
+                    return
+                }
+            }
+
+            try await regenerateEditedContentViewDiff(
+                userPrompt: userPrompt,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                existingSource: existingSource,
+                maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
+                lifecycle: lifecycle,
+                session: session
+            )
+        }
+    }
+
+    private func wholeFileEditGenerator(
+        userPrompt: String,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        existingSource: String,
+        lifecycle: ToolGenerationLifecycle,
+        resumePartialSource: Bool
+    ) -> ContentViewCandidateGenerator {
+        var didAttemptContinuation = false
+        let originalPrompt = ToolGenerationPrompts.singleFileEditPrompt(
+            userPrompt: userPrompt,
+            executableName: layout.executableName,
+            existingSource: existingSource
+        )
+
+        return ContentViewCandidateGenerator(
+            modeDescription: resumePartialSource ? "continue edit source" : "edit",
+            initialStatusVerb: resumePartialSource ? "Continuing" : "Editing",
+            retryStatusVerb: "Editing"
+        ) { session in
+            if resumePartialSource && !didAttemptContinuation {
+                didAttemptContinuation = true
+                let partialSource = try context.readIfPresent(
+                    ToolPackageLayout.pendingContentViewDraftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+                if !partialSource.isEmpty {
+                    try await continueSourceDraft(
+                        partialSource: partialSource,
+                        originalPrompt: originalPrompt,
+                        layout: layout,
+                        contentViewPath: contentViewPath,
+                        lifecycle: lifecycle,
+                        session: session
+                    )
+                    return
+                }
+            }
+
+            try await regenerateEditedContentView(
+                userPrompt: userPrompt,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                existingSource: existingSource,
+                lifecycle: lifecycle,
+                session: session
+            )
+        }
+    }
+
+    private func continueSourceDraft(
+        partialSource: String,
+        originalPrompt: String,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        lifecycle: ToolGenerationLifecycle,
+        session: LanguageModelSession
+    ) async throws {
+        let prompt = ToolGenerationPrompts.sourceContinuationPrompt(
+            originalPrompt: originalPrompt,
+            partialSource: partialSource
+        )
+        do {
+            try await lifecycle.updatePhase(.generating, .generatingSource, nil)
+            let continuation = try await context.streamText(in: session, to: prompt) { partialContinuation in
+                try context.write(
+                    partialSource + partialContinuation,
+                    to: ToolPackageLayout.pendingContentViewDraftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+            }
+            try context.write(
+                partialSource + continuation,
+                to: contentViewPath,
+                packageRootURL: layout.packageRootURL
+            )
+        } catch {
+            try trimPendingSourceDraftToCleanBoundary(layout: layout)
+            throw error
+        }
+    }
+
+    private func continueDiffDraft(
+        partialDiff: String,
+        originalPrompt: String,
+        originalSource: String,
+        maximumDiffHunks: Int?,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        lifecycle: ToolGenerationLifecycle,
+        session: LanguageModelSession
+    ) async throws {
+        let prompt = ToolGenerationPrompts.diffContinuationPrompt(
+            originalPrompt: originalPrompt,
+            partialDiff: partialDiff
+        )
+        do {
+            try await lifecycle.updatePhase(.generating, .generatingEditDiff, nil)
+            let continuation = try await context.streamText(in: session, to: prompt) { partialContinuation in
+                try context.write(
+                    partialDiff + partialContinuation,
+                    to: ToolPackageLayout.pendingContentViewDraftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+            }
+            let sanitizedDiff = ContentViewRepairSupport.sanitizedRepairDiffSummary(partialDiff + continuation)
+            let editedSource = try ContentViewRepairSupport.applyValidatedDiff(
+                sanitizedDiff,
+                to: originalSource,
+                maximumHunks: maximumDiffHunks
+            )
+            try context.write(
+                editedSource,
+                to: contentViewPath,
+                packageRootURL: layout.packageRootURL
+            )
+        } catch {
+            try trimPendingDiffDraftToLastValidPrefix(
+                layout: layout,
+                originalSource: originalSource,
+                maximumDiffHunks: maximumDiffHunks
+            )
+            throw error
+        }
+    }
+
+    private func packageTool(
+        displayName: String,
+        executableName: String,
+        bundleIdentifier: String,
+        packageRootURL: URL,
+        manifest: ToolManifest,
+        sandboxEnabled: Bool,
+        sandboxPermissions: GeneratedAppSandboxPermissions,
+        resourcePermissions: GeneratedAppResourcePermissions,
+        iconPrompt: String?,
+        lifecycle: ToolGenerationLifecycle,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        let layout = ToolPackageLayout(packageRootURL: packageRootURL, executableName: executableName)
+        try Task.checkCancellation()
+        let binDirectory = try await context.processClient.showBinPath(packageRootURL)
+        let binaryURL = binDirectory.appendingPathComponent(executableName)
+        await context.processClient.stripQuarantine(binaryURL)
+
+        try Task.checkCancellation()
+        status("Packaging \(displayName)")
+        try await lifecycle.updatePhase(.generating, .packaging, nil)
+        _ = try await context.appBundleClient.buildInternalApp(
+            ToolAppBundleRequest(
+                displayName: displayName,
+                executableName: executableName,
+                bundleIdentifier: bundleIdentifier,
+                packageRootURL: packageRootURL,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                iconPrompt: iconPrompt
+            )
+        )
+
+        try? context.fileClient.removeItemIfExists(layout.pendingContentViewDraftURL)
+        return ToolGenerationResult(
+            toolName: displayName,
+            executableName: executableName,
+            bundleIdentifier: bundleIdentifier,
+            sandboxEnabled: sandboxEnabled,
+            packageRootURL: packageRootURL,
+            manifest: manifest
+        )
+    }
+
+    private func trimPendingSourceDraftToCleanBoundary(layout: ToolPackageLayout) throws {
+        let draft = try context.readIfPresent(
+            ToolPackageLayout.pendingContentViewDraftPath,
+            packageRootURL: layout.packageRootURL
+        )
+        guard !draft.isEmpty else { return }
+        let trimmed = Self.sourcePrefixAtCleanBoundary(draft)
+        try context.write(
+            trimmed,
+            to: ToolPackageLayout.pendingContentViewDraftPath,
+            packageRootURL: layout.packageRootURL
+        )
+    }
+
+    private static func sourcePrefixAtCleanBoundary(_ source: String) -> String {
+        let trimmedRight = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedRight.isEmpty else { return "" }
+        let lastLine = trimmedRight.components(separatedBy: .newlines).last ?? trimmedRight
+        if isCleanTrailingSourceLine(lastLine) {
+            return trimmedRight
+        }
+        guard let lastNewline = trimmedRight.lastIndex(of: "\n") else {
+            return ""
+        }
+        return String(trimmedRight[..<lastNewline]).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func isCleanTrailingSourceLine(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        let quoteCount = trimmed.filter { $0 == "\"" }.count
+        if !quoteCount.isMultiple(of: 2) { return false }
+        if trimmed.hasPrefix("import "), trimmed.split(separator: " ").count >= 2 { return true }
+        if trimmed.hasSuffix("{") || trimmed.hasSuffix("}") || trimmed.hasSuffix(")") || trimmed.hasSuffix("]") {
+            return true
+        }
+        if trimmed.hasSuffix(",") || trimmed.hasSuffix(";") { return true }
+        return false
+    }
+
+    private func trimPendingDiffDraftToLastValidPrefix(
+        layout: ToolPackageLayout,
+        originalSource: String,
+        maximumDiffHunks: Int?
+    ) throws {
+        let draft = try context.readIfPresent(
+            ToolPackageLayout.pendingContentViewDraftPath,
+            packageRootURL: layout.packageRootURL
+        )
+        guard !draft.isEmpty else { return }
+        let lines = draft.components(separatedBy: .newlines)
+        for endIndex in stride(from: lines.count, through: 0, by: -1) {
+            let candidate = lines.prefix(endIndex).joined(separator: "\n")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard candidate.contains("@@") else { continue }
+            let sanitizedDiff = ContentViewRepairSupport.sanitizedRepairDiffSummary(candidate)
+            if (try? ContentViewRepairSupport.applyValidatedDiff(
+                sanitizedDiff,
+                to: originalSource,
+                maximumHunks: maximumDiffHunks
+            )) != nil {
+                try context.write(
+                    candidate,
+                    to: ToolPackageLayout.pendingContentViewDraftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+                return
+            }
+        }
+        try context.write("", to: ToolPackageLayout.pendingContentViewDraftPath, packageRootURL: layout.packageRootURL)
     }
 
     private func regenerateCreatedContentView(
@@ -1026,6 +907,7 @@ struct SingleFileToolGenerationRuntime {
                 \(AgentDiagnosticsLog.renderError(error))
                 """
             )
+            try? trimPendingSourceDraftToCleanBoundary(layout: layout)
             throw error
         }
     }
@@ -1070,6 +952,7 @@ struct SingleFileToolGenerationRuntime {
                 \(AgentDiagnosticsLog.renderError(error))
                 """
             )
+            try? trimPendingSourceDraftToCleanBoundary(layout: layout)
             throw error
         }
     }
@@ -1111,6 +994,11 @@ struct SingleFileToolGenerationRuntime {
                 error:
                 \(AgentDiagnosticsLog.renderError(error))
                 """
+            )
+            try? trimPendingDiffDraftToLastValidPrefix(
+                layout: layout,
+                originalSource: existingSource,
+                maximumDiffHunks: maximumDiffHunks
             )
             throw error
         }

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -10,11 +10,24 @@ struct SingleFileToolGenerationRuntime {
         sandboxEnabled: Bool = true,
         sandboxPermissions: GeneratedAppSandboxPermissions = .default,
         resourcePermissions: GeneratedAppResourcePermissions = .none,
+        lifecycle: ToolGenerationLifecycle = .noop,
         status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult {
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPrompt.isEmpty else {
             throw ToolGenerationError.emptyPrompt
+        }
+
+        if let existingTool, !existingTool.isGenerationReady {
+            return try await resumeTool(
+                prompt: trimmedPrompt,
+                existingTool: existingTool,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                lifecycle: lifecycle,
+                status: status
+            )
         }
 
         if let existingTool {
@@ -24,6 +37,7 @@ struct SingleFileToolGenerationRuntime {
                 sandboxEnabled: sandboxEnabled,
                 sandboxPermissions: sandboxPermissions,
                 resourcePermissions: resourcePermissions,
+                lifecycle: lifecycle,
                 status: status
             )
         }
@@ -33,6 +47,7 @@ struct SingleFileToolGenerationRuntime {
             sandboxEnabled: sandboxEnabled,
             sandboxPermissions: sandboxPermissions,
             resourcePermissions: resourcePermissions,
+            lifecycle: lifecycle,
             status: status
         )
     }
@@ -46,9 +61,11 @@ struct SingleFileToolGenerationRuntime {
         sandboxEnabled: Bool,
         sandboxPermissions: GeneratedAppSandboxPermissions,
         resourcePermissions: GeneratedAppResourcePermissions,
+        lifecycle: ToolGenerationLifecycle,
         status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult {
         status("Planning app")
+        try await lifecycle.updatePhase(.generating, .planning, nil)
         try Task.checkCancellation()
         let metadata = await context.metadataClient.suggestMetadata(
             userPrompt: prompt,
@@ -56,7 +73,8 @@ struct SingleFileToolGenerationRuntime {
             generationOptions: context.generationOptions
         )
         try Task.checkCancellation()
-        let contentGenerationPrompt = await contentGenerationPrompt(for: prompt, sandboxEnabled: sandboxEnabled)
+        let promptRefinement = await contentGenerationPrompt(for: prompt, sandboxEnabled: sandboxEnabled)
+        let contentGenerationPrompt = promptRefinement.prompt
         try Task.checkCancellation()
         let displayName = metadata.displayName
         let executableName = ToolNameSanitizer.executableName(from: displayName)
@@ -94,6 +112,18 @@ struct SingleFileToolGenerationRuntime {
             try context.write(layout.packageManifestContent(), to: "Package.swift", packageRootURL: layout.packageRootURL)
             try context.write(layout.fixedAppEntrySource(), to: layout.appEntrySourcePath, packageRootURL: layout.packageRootURL)
             try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
+            try await lifecycle.prepareCreatedTool(
+                ToolGenerationPreparedTool(
+                    name: displayName,
+                    executableName: executableName,
+                    bundleIdentifier: bundleIdentifier,
+                    sandboxEnabled: sandboxEnabled,
+                    packageRootURL: packageRootURL,
+                    manifest: manifest
+                ),
+                prompt,
+                promptRefinement.refinedPrompt
+            )
 
             let generator = ContentViewCandidateGenerator(modeDescription: "create") { session in
                 try await regenerateCreatedContentView(
@@ -101,6 +131,7 @@ struct SingleFileToolGenerationRuntime {
                     sandboxEnabled: sandboxEnabled,
                     layout: layout,
                     contentViewPath: contentViewPath,
+                    lifecycle: lifecycle,
                     session: session
                 )
             }
@@ -109,6 +140,7 @@ struct SingleFileToolGenerationRuntime {
                 layout: layout,
                 contentViewPath: contentViewPath,
                 generator: generator,
+                lifecycle: lifecycle,
                 status: status
             )
 
@@ -119,6 +151,7 @@ struct SingleFileToolGenerationRuntime {
 
             try Task.checkCancellation()
             status("Packaging \(displayName)")
+            try await lifecycle.updatePhase(.generating, .packaging, nil)
             _ = try await context.appBundleClient.buildInternalApp(
                 ToolAppBundleRequest(
                     displayName: displayName,
@@ -142,14 +175,19 @@ struct SingleFileToolGenerationRuntime {
                 manifest: manifest
             )
         } catch is CancellationError {
-            try? context.fileClient.removeItemIfExists(packageRootURL)
+            if !lifecycle.preservesCreatedPackageOnCancellation {
+                try? context.fileClient.removeItemIfExists(packageRootURL)
+            }
             throw CancellationError()
         }
     }
 
-    private func contentGenerationPrompt(for prompt: String, sandboxEnabled: Bool) async -> String {
+    private func contentGenerationPrompt(for prompt: String, sandboxEnabled: Bool) async -> (
+        prompt: String,
+        refinedPrompt: String?
+    ) {
         guard context.promptRefinementEnabled else {
-            return prompt
+            return (prompt, nil)
         }
 
         let refinedPrompt = await context.promptRefinementClient.refinePrompt(
@@ -158,7 +196,7 @@ struct SingleFileToolGenerationRuntime {
             generationOptions: context.generationOptions,
             sandboxEnabled: sandboxEnabled
         )
-        return refinedPrompt ?? prompt
+        return (refinedPrompt ?? prompt, refinedPrompt)
     }
 
     private func editTool(
@@ -167,6 +205,7 @@ struct SingleFileToolGenerationRuntime {
         sandboxEnabled: Bool,
         sandboxPermissions: GeneratedAppSandboxPermissions,
         resourcePermissions: GeneratedAppResourcePermissions,
+        lifecycle: ToolGenerationLifecycle,
         status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult {
         let manifest = try context.loadManifest(at: existingTool.agentManifestURL)
@@ -192,6 +231,7 @@ struct SingleFileToolGenerationRuntime {
 
         do {
             try Task.checkCancellation()
+            try await lifecycle.updatePhase(.generating, .generatingEditDiff, nil)
             try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
             let generator: ContentViewCandidateGenerator
             if context.repairStrategy.usesModelRepair {
@@ -212,6 +252,7 @@ struct SingleFileToolGenerationRuntime {
                             layout: layout,
                             contentViewPath: contentViewPath,
                             existingSource: existingSource,
+                            lifecycle: lifecycle,
                             session: session
                         )
                     }
@@ -222,6 +263,7 @@ struct SingleFileToolGenerationRuntime {
                         contentViewPath: contentViewPath,
                         existingSource: existingSource,
                         maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
+                        lifecycle: lifecycle,
                         session: session
                     )
                 }
@@ -236,6 +278,7 @@ struct SingleFileToolGenerationRuntime {
                         layout: layout,
                         contentViewPath: contentViewPath,
                         existingSource: existingSource,
+                        lifecycle: lifecycle,
                         session: session
                     )
                 }
@@ -246,10 +289,12 @@ struct SingleFileToolGenerationRuntime {
                 contentViewPath: contentViewPath,
                 generator: generator,
                 failureRecovery: .restoreOriginalSource(existingSource),
+                lifecycle: lifecycle,
                 status: status
             )
             try Task.checkCancellation()
             status("Packaging \(manifest.displayName)")
+            try await lifecycle.updatePhase(.generating, .packaging, nil)
             _ = try await context.appBundleClient.buildInternalApp(
                 ToolAppBundleRequest(
                     displayName: manifest.displayName,
@@ -291,21 +336,648 @@ struct SingleFileToolGenerationRuntime {
         )
     }
 
+    private func resumeTool(
+        prompt: String,
+        existingTool: Tool,
+        sandboxEnabled: Bool,
+        sandboxPermissions: GeneratedAppSandboxPermissions,
+        resourcePermissions: GeneratedAppResourcePermissions,
+        lifecycle: ToolGenerationLifecycle,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        let manifest = try context.loadManifest(at: existingTool.agentManifestURL)
+        let layout = ToolPackageLayout(
+            packageRootURL: existingTool.packageRootURL,
+            executableName: manifest.executableName
+        )
+        let contentViewPath = manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
+        let mode = existingTool.generationMode ?? .create
+        let phase = existingTool.generationPhase ?? .planning
+        let userPrompt = existingTool.pendingPrompt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? existingTool.pendingPrompt ?? prompt
+            : prompt
+        let refinedPrompt = existingTool.pendingRefinedPrompt?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            ? existingTool.pendingRefinedPrompt ?? userPrompt
+            : userPrompt
+
+        AgentDiagnosticsLog.append(
+            """
+            Tool generation resumed.
+            mode: \(mode.rawValue)
+            phase: \(phase.rawValue)
+            displayName: \(manifest.displayName)
+            executableName: \(manifest.executableName)
+            packageRoot: \(existingTool.packageRootURL.path)
+            """
+        )
+
+        switch phase {
+        case .initializing, .planning:
+            return try await resumeFromPlanning(
+                mode: mode,
+                userPrompt: userPrompt,
+                refinedPrompt: refinedPrompt,
+                existingTool: existingTool,
+                manifest: manifest,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                lifecycle: lifecycle,
+                status: status
+            )
+
+        case .generatingSource:
+            return try await resumeSourceGeneration(
+                mode: mode,
+                userPrompt: userPrompt,
+                refinedPrompt: refinedPrompt,
+                existingTool: existingTool,
+                manifest: manifest,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                lifecycle: lifecycle,
+                status: status
+            )
+
+        case .generatingEditDiff:
+            return try await resumeEditDiffGeneration(
+                userPrompt: userPrompt,
+                existingTool: existingTool,
+                manifest: manifest,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                lifecycle: lifecycle,
+                status: status
+            )
+
+        case .generatingRepairDiff, .repairing:
+            try await compileGeneratedTool(
+                displayName: manifest.displayName,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                generator: resumedRepairGenerator(
+                    mode: mode,
+                    userPrompt: userPrompt,
+                    refinedPrompt: refinedPrompt,
+                    sandboxEnabled: sandboxEnabled,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    existingSource: try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL),
+                    lifecycle: lifecycle
+                ),
+                failureRecovery: mode == .edit
+                    ? .restoreOriginalSource(try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL))
+                    : .restoreBestCandidate,
+                lifecycle: lifecycle,
+                status: status
+            )
+            return try await packageResumedTool(
+                existingTool,
+                manifest: manifest,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                prompt: userPrompt,
+                lifecycle: lifecycle,
+                status: status
+            )
+
+        case .packaging, .completed:
+            return try await packageResumedTool(
+                existingTool,
+                manifest: manifest,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                prompt: userPrompt,
+                lifecycle: lifecycle,
+                status: status
+            )
+        }
+    }
+
+    private func resumeFromPlanning(
+        mode: ToolGenerationMode,
+        userPrompt: String,
+        refinedPrompt: String,
+        existingTool: Tool,
+        manifest: ToolManifest,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        sandboxEnabled: Bool,
+        sandboxPermissions: GeneratedAppSandboxPermissions,
+        resourcePermissions: GeneratedAppResourcePermissions,
+        lifecycle: ToolGenerationLifecycle,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        switch mode {
+        case .create:
+            let generator = ContentViewCandidateGenerator(modeDescription: "resume create") { session in
+                try await regenerateCreatedContentView(
+                    userPrompt: refinedPrompt,
+                    sandboxEnabled: sandboxEnabled,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+            }
+            try await compileGeneratedTool(
+                displayName: manifest.displayName,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                generator: generator,
+                lifecycle: lifecycle,
+                status: status
+            )
+        case .edit:
+            let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
+            let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
+            do {
+                let generator = editGenerator(
+                    userPrompt: userPrompt,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    existingSource: existingSource,
+                    lifecycle: lifecycle
+                )
+                try await compileGeneratedTool(
+                    displayName: manifest.displayName,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    generator: generator,
+                    failureRecovery: .restoreOriginalSource(existingSource),
+                    lifecycle: lifecycle,
+                    status: status
+                )
+                try context.versionBackupClient.promoteStagedVersion(backup)
+            } catch {
+                try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
+                try? context.versionBackupClient.discardStagedVersion(backup)
+                throw error
+            }
+        }
+
+        return try await packageResumedTool(
+            existingTool,
+            manifest: manifest,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions,
+            prompt: userPrompt,
+            lifecycle: lifecycle,
+            status: status
+        )
+    }
+
+    private func resumeSourceGeneration(
+        mode: ToolGenerationMode,
+        userPrompt: String,
+        refinedPrompt: String,
+        existingTool: Tool,
+        manifest: ToolManifest,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        sandboxEnabled: Bool,
+        sandboxPermissions: GeneratedAppSandboxPermissions,
+        resourcePermissions: GeneratedAppResourcePermissions,
+        lifecycle: ToolGenerationLifecycle,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        let partialSource = try context.readIfPresent(
+            ToolPackageLayout.pendingContentViewDraftPath,
+            packageRootURL: layout.packageRootURL
+        )
+        var didAttemptContinuation = false
+        let basePrompt = mode == .create
+            ? ToolGenerationPrompts.singleFileCreatePrompt(
+                userPrompt: refinedPrompt,
+                executableName: layout.executableName,
+                sandboxEnabled: sandboxEnabled
+            )
+            : ToolGenerationPrompts.singleFileEditPrompt(
+                userPrompt: userPrompt,
+                executableName: layout.executableName,
+                existingSource: try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
+            )
+
+        let writeContinuationOrFreshCandidate: (LanguageModelSession) async throws -> Void = { session in
+            if !didAttemptContinuation, !partialSource.isEmpty {
+                didAttemptContinuation = true
+                try await continueSourceDraft(
+                    partialSource: partialSource,
+                    originalPrompt: basePrompt,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+                return
+            }
+
+            switch mode {
+            case .create:
+                try await regenerateCreatedContentView(
+                    userPrompt: refinedPrompt,
+                    sandboxEnabled: sandboxEnabled,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+            case .edit:
+                let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
+                try await regenerateEditedContentView(
+                    userPrompt: userPrompt,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    existingSource: existingSource,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+            }
+        }
+
+        if mode == .edit {
+            let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
+            let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
+            do {
+                try await compileGeneratedTool(
+                    displayName: manifest.displayName,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    generator: ContentViewCandidateGenerator(
+                        modeDescription: "resume source",
+                        initialStatusVerb: "Continuing",
+                        retryStatusVerb: "Editing",
+                        writeFreshCandidate: writeContinuationOrFreshCandidate
+                    ),
+                    failureRecovery: .restoreOriginalSource(existingSource),
+                    lifecycle: lifecycle,
+                    status: status
+                )
+                try context.versionBackupClient.promoteStagedVersion(backup)
+            } catch {
+                try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
+                try? context.versionBackupClient.discardStagedVersion(backup)
+                throw error
+            }
+        } else {
+            try await compileGeneratedTool(
+                displayName: manifest.displayName,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                generator: ContentViewCandidateGenerator(
+                    modeDescription: "resume source",
+                    initialStatusVerb: "Continuing",
+                    retryStatusVerb: "Regenerating",
+                    writeFreshCandidate: writeContinuationOrFreshCandidate
+                ),
+                lifecycle: lifecycle,
+                status: status
+            )
+        }
+
+        return try await packageResumedTool(
+            existingTool,
+            manifest: manifest,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions,
+            prompt: userPrompt,
+            lifecycle: lifecycle,
+            status: status
+        )
+    }
+
+    private func resumeEditDiffGeneration(
+        userPrompt: String,
+        existingTool: Tool,
+        manifest: ToolManifest,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        sandboxEnabled: Bool,
+        sandboxPermissions: GeneratedAppSandboxPermissions,
+        resourcePermissions: GeneratedAppResourcePermissions,
+        lifecycle: ToolGenerationLifecycle,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
+        let partialDiff = try context.readIfPresent(
+            ToolPackageLayout.pendingContentViewDraftPath,
+            packageRootURL: layout.packageRootURL
+        )
+        let originalPrompt = ToolGenerationPrompts.singleFileEditDiffPrompt(
+            userPrompt: userPrompt,
+            executableName: layout.executableName,
+            existingSource: existingSource,
+            maximumDiffHunks: context.repairStrategy.maxInitialEditHunks
+        )
+        var didAttemptContinuation = false
+        let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
+        do {
+            let generator = ContentViewCandidateGenerator(
+                modeDescription: "resume edit diff",
+                initialStatusVerb: "Continuing",
+                retryStatusVerb: "Editing",
+                instructions: ToolGenerationPrompts.diffEditInstructions,
+                retriesInvalidCandidates: true,
+                invalidCandidateFallback: ContentViewCandidateGenerator.InvalidCandidateFallback(
+                    threshold: ToolGenerationRepairPolicy.invalidInitialEditDiffsBeforeFullFileEdit,
+                    modeDescription: "edit whole-file fallback",
+                    initialStatusVerb: "Editing",
+                    retryStatusVerb: "Editing"
+                ) { session in
+                    try await regenerateEditedContentView(
+                        userPrompt: userPrompt,
+                        layout: layout,
+                        contentViewPath: contentViewPath,
+                        existingSource: existingSource,
+                        lifecycle: lifecycle,
+                        session: session
+                    )
+                }
+            ) { session in
+                if !didAttemptContinuation, !partialDiff.isEmpty {
+                    didAttemptContinuation = true
+                    try await continueDiffDraft(
+                        partialDiff: partialDiff,
+                        originalPrompt: originalPrompt,
+                        originalSource: existingSource,
+                        maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
+                        layout: layout,
+                        contentViewPath: contentViewPath,
+                        phase: .generatingEditDiff,
+                        lifecycle: lifecycle,
+                        session: session
+                    )
+                    return
+                }
+
+                try await regenerateEditedContentViewDiff(
+                    userPrompt: userPrompt,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    existingSource: existingSource,
+                    maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+            }
+            try await compileGeneratedTool(
+                displayName: manifest.displayName,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                generator: generator,
+                failureRecovery: .restoreOriginalSource(existingSource),
+                lifecycle: lifecycle,
+                status: status
+            )
+            try context.versionBackupClient.promoteStagedVersion(backup)
+        } catch {
+            try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
+            try? context.versionBackupClient.discardStagedVersion(backup)
+            throw error
+        }
+
+        return try await packageResumedTool(
+            existingTool,
+            manifest: manifest,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions,
+            prompt: userPrompt,
+            lifecycle: lifecycle,
+            status: status
+        )
+    }
+
+    private func resumedRepairGenerator(
+        mode: ToolGenerationMode,
+        userPrompt: String,
+        refinedPrompt: String,
+        sandboxEnabled: Bool,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        existingSource: String,
+        lifecycle: ToolGenerationLifecycle
+    ) -> ContentViewCandidateGenerator {
+        switch mode {
+        case .create:
+            ContentViewCandidateGenerator(modeDescription: "resume repair") { session in
+                try await regenerateCreatedContentView(
+                    userPrompt: refinedPrompt,
+                    sandboxEnabled: sandboxEnabled,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+            }
+        case .edit:
+            editGenerator(
+                userPrompt: userPrompt,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                existingSource: existingSource,
+                lifecycle: lifecycle
+            )
+        }
+    }
+
+    private func editGenerator(
+        userPrompt: String,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        existingSource: String,
+        lifecycle: ToolGenerationLifecycle
+    ) -> ContentViewCandidateGenerator {
+        if context.repairStrategy.usesModelRepair {
+            return ContentViewCandidateGenerator(
+                modeDescription: "edit",
+                initialStatusVerb: "Editing",
+                retryStatusVerb: "Editing",
+                instructions: ToolGenerationPrompts.diffEditInstructions,
+                retriesInvalidCandidates: true,
+                invalidCandidateFallback: ContentViewCandidateGenerator.InvalidCandidateFallback(
+                    threshold: ToolGenerationRepairPolicy.invalidInitialEditDiffsBeforeFullFileEdit,
+                    modeDescription: "edit whole-file fallback",
+                    initialStatusVerb: "Editing",
+                    retryStatusVerb: "Editing"
+                ) { session in
+                    try await regenerateEditedContentView(
+                        userPrompt: userPrompt,
+                        layout: layout,
+                        contentViewPath: contentViewPath,
+                        existingSource: existingSource,
+                        lifecycle: lifecycle,
+                        session: session
+                    )
+                }
+            ) { session in
+                try await regenerateEditedContentViewDiff(
+                    userPrompt: userPrompt,
+                    layout: layout,
+                    contentViewPath: contentViewPath,
+                    existingSource: existingSource,
+                    maximumDiffHunks: context.repairStrategy.maxInitialEditHunks,
+                    lifecycle: lifecycle,
+                    session: session
+                )
+            }
+        }
+
+        return ContentViewCandidateGenerator(
+            modeDescription: "edit",
+            initialStatusVerb: "Editing",
+            retryStatusVerb: "Editing"
+        ) { session in
+            try await regenerateEditedContentView(
+                userPrompt: userPrompt,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                existingSource: existingSource,
+                lifecycle: lifecycle,
+                session: session
+            )
+        }
+    }
+
+    private func continueSourceDraft(
+        partialSource: String,
+        originalPrompt: String,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        lifecycle: ToolGenerationLifecycle,
+        session: LanguageModelSession
+    ) async throws {
+        let prompt = ToolGenerationPrompts.sourceContinuationPrompt(
+            originalPrompt: originalPrompt,
+            partialSource: partialSource
+        )
+        try await lifecycle.updatePhase(.generating, .generatingSource, nil)
+        let continuation = try await context.streamText(in: session, to: prompt) { partialContinuation in
+            try context.write(
+                partialSource + partialContinuation,
+                to: ToolPackageLayout.pendingContentViewDraftPath,
+                packageRootURL: layout.packageRootURL
+            )
+        }
+        try context.write(
+            partialSource + continuation,
+            to: contentViewPath,
+            packageRootURL: layout.packageRootURL
+        )
+    }
+
+    private func continueDiffDraft(
+        partialDiff: String,
+        originalPrompt: String,
+        originalSource: String,
+        maximumDiffHunks: Int?,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        phase: ToolGenerationPhase,
+        lifecycle: ToolGenerationLifecycle,
+        session: LanguageModelSession
+    ) async throws {
+        let prompt = ToolGenerationPrompts.diffContinuationPrompt(
+            originalPrompt: originalPrompt,
+            partialDiff: partialDiff
+        )
+        try await lifecycle.updatePhase(.generating, phase, nil)
+        let continuation = try await context.streamText(in: session, to: prompt) { partialContinuation in
+            try context.write(
+                partialDiff + partialContinuation,
+                to: ToolPackageLayout.pendingContentViewDraftPath,
+                packageRootURL: layout.packageRootURL
+            )
+        }
+        let sanitizedDiff = ContentViewRepairSupport.sanitizedRepairDiffSummary(partialDiff + continuation)
+        let editedSource = try ContentViewRepairSupport.applyValidatedDiff(
+            sanitizedDiff,
+            to: originalSource,
+            maximumHunks: maximumDiffHunks
+        )
+        try context.write(
+            editedSource,
+            to: contentViewPath,
+            packageRootURL: layout.packageRootURL
+        )
+    }
+
+    private func packageResumedTool(
+        _ tool: Tool,
+        manifest: ToolManifest,
+        sandboxEnabled: Bool,
+        sandboxPermissions: GeneratedAppSandboxPermissions,
+        resourcePermissions: GeneratedAppResourcePermissions,
+        prompt: String,
+        lifecycle: ToolGenerationLifecycle,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        let layout = ToolPackageLayout(
+            packageRootURL: tool.packageRootURL,
+            executableName: manifest.executableName
+        )
+        try Task.checkCancellation()
+        let binDirectory = try await context.processClient.showBinPath(tool.packageRootURL)
+        let binaryURL = binDirectory.appendingPathComponent(manifest.executableName)
+        await context.processClient.stripQuarantine(binaryURL)
+
+        try Task.checkCancellation()
+        status("Packaging \(manifest.displayName)")
+        try await lifecycle.updatePhase(.generating, .packaging, nil)
+        _ = try await context.appBundleClient.buildInternalApp(
+            ToolAppBundleRequest(
+                displayName: manifest.displayName,
+                executableName: manifest.executableName,
+                bundleIdentifier: tool.bundleIdentifier,
+                packageRootURL: tool.packageRootURL,
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions,
+                promptSummary: prompt
+            )
+        )
+
+        try? context.fileClient.removeItemIfExists(layout.pendingContentViewDraftURL)
+        return ToolGenerationResult(
+            toolName: manifest.displayName,
+            executableName: manifest.executableName,
+            bundleIdentifier: tool.bundleIdentifier,
+            sandboxEnabled: sandboxEnabled,
+            packageRootURL: tool.packageRootURL,
+            manifest: manifest
+        )
+    }
+
     private func compileGeneratedTool(
         displayName: String,
         layout: ToolPackageLayout,
         contentViewPath: String,
         generator: ContentViewCandidateGenerator,
         failureRecovery: ContentViewBuildRepairLoop.FailureRecovery = .restoreBestCandidate,
+        lifecycle: ToolGenerationLifecycle,
         status: @escaping @MainActor (String) -> Void
     ) async throws {
+        try await lifecycle.updatePhase(.generating, .repairing, nil)
         let repairLoop = ContentViewBuildRepairLoop(
             context: context,
             layout: layout,
             displayName: displayName,
             contentViewPath: contentViewPath,
             regenerationThreshold: ToolGenerationRepairPolicy.regenerationThreshold,
-            maximumGenerationAttempts: ToolGenerationRepairPolicy.maximumGenerationAttempts
+            maximumGenerationAttempts: ToolGenerationRepairPolicy.maximumGenerationAttempts,
+            lifecycle: lifecycle
         )
         try await repairLoop.run(
             generator: generator,
@@ -319,6 +991,7 @@ struct SingleFileToolGenerationRuntime {
         sandboxEnabled: Bool,
         layout: ToolPackageLayout,
         contentViewPath: String,
+        lifecycle: ToolGenerationLifecycle,
         session: LanguageModelSession
     ) async throws {
         let prompt = ToolGenerationPrompts.singleFileCreatePrompt(
@@ -326,11 +999,23 @@ struct SingleFileToolGenerationRuntime {
             executableName: layout.executableName,
             sandboxEnabled: sandboxEnabled
         )
-        let response: LanguageModelSession.Response<String>
+        let draftPath = ToolPackageLayout.pendingContentViewDraftPath
         do {
             try Task.checkCancellation()
-            response = try await context.respond(in: session, to: prompt)
+            try await lifecycle.updatePhase(.generating, .generatingSource, nil)
+            let response = try await context.streamText(in: session, to: prompt) { partialSource in
+                try context.write(
+                    partialSource,
+                    to: draftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+            }
             try Task.checkCancellation()
+            try context.write(
+                response,
+                to: contentViewPath,
+                packageRootURL: layout.packageRootURL
+            )
         } catch {
             AgentDiagnosticsLog.append(
                 """
@@ -343,11 +1028,6 @@ struct SingleFileToolGenerationRuntime {
             )
             throw error
         }
-        try context.write(
-            response.content,
-            to: contentViewPath,
-            packageRootURL: layout.packageRootURL
-        )
     }
 
     private func regenerateEditedContentView(
@@ -355,6 +1035,7 @@ struct SingleFileToolGenerationRuntime {
         layout: ToolPackageLayout,
         contentViewPath: String,
         existingSource: String,
+        lifecycle: ToolGenerationLifecycle,
         session: LanguageModelSession
     ) async throws {
         let prompt = ToolGenerationPrompts.singleFileEditPrompt(
@@ -362,11 +1043,23 @@ struct SingleFileToolGenerationRuntime {
             executableName: layout.executableName,
             existingSource: existingSource
         )
-        let response: LanguageModelSession.Response<String>
+        let draftPath = ToolPackageLayout.pendingContentViewDraftPath
         do {
             try Task.checkCancellation()
-            response = try await context.respond(in: session, to: prompt)
+            try await lifecycle.updatePhase(.generating, .generatingSource, nil)
+            let response = try await context.streamText(in: session, to: prompt) { partialSource in
+                try context.write(
+                    partialSource,
+                    to: draftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+            }
             try Task.checkCancellation()
+            try context.write(
+                response,
+                to: contentViewPath,
+                packageRootURL: layout.packageRootURL
+            )
         } catch {
             AgentDiagnosticsLog.append(
                 """
@@ -379,11 +1072,6 @@ struct SingleFileToolGenerationRuntime {
             )
             throw error
         }
-        try context.write(
-            response.content,
-            to: contentViewPath,
-            packageRootURL: layout.packageRootURL
-        )
     }
 
     private func regenerateEditedContentViewDiff(
@@ -392,6 +1080,7 @@ struct SingleFileToolGenerationRuntime {
         contentViewPath: String,
         existingSource: String,
         maximumDiffHunks: Int?,
+        lifecycle: ToolGenerationLifecycle,
         session: LanguageModelSession
     ) async throws {
         let prompt = ToolGenerationPrompts.singleFileEditDiffPrompt(
@@ -400,10 +1089,18 @@ struct SingleFileToolGenerationRuntime {
             existingSource: existingSource,
             maximumDiffHunks: maximumDiffHunks
         )
-        let response: LanguageModelSession.Response<String>
+        let draftPath = ToolPackageLayout.pendingContentViewDraftPath
+        let response: String
         do {
             try Task.checkCancellation()
-            response = try await context.respond(in: session, to: prompt)
+            try await lifecycle.updatePhase(.generating, .generatingEditDiff, nil)
+            response = try await context.streamText(in: session, to: prompt) { partialDiff in
+                try context.write(
+                    partialDiff,
+                    to: draftPath,
+                    packageRootURL: layout.packageRootURL
+                )
+            }
             try Task.checkCancellation()
         } catch {
             AgentDiagnosticsLog.append(
@@ -418,13 +1115,13 @@ struct SingleFileToolGenerationRuntime {
             throw error
         }
 
-        let sanitizedDiff = ContentViewRepairSupport.sanitizedRepairDiffSummary(response.content)
+        let sanitizedDiff = ContentViewRepairSupport.sanitizedRepairDiffSummary(response)
         try Task.checkCancellation()
         AgentDiagnosticsLog.append(
             """
             Model edit diff proposed.
             packageRoot: \(layout.packageRootURL.path)
-            rawCharacters: \(response.content.count)
+            rawCharacters: \(response.count)
             sanitizedDiff:
             \(AgentDiagnosticsLog.compactMultiline(sanitizedDiff, limit: AgentDiagnosticsLog.repairDiffLimit))
             """

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -143,6 +143,39 @@ struct SingleFileToolGenerationRuntime {
         )
     }
 
+    private func preparePlaceholderCreateTool(
+        prompt: String,
+        sandboxEnabled: Bool,
+        lifecycle: ToolGenerationLifecycle
+    ) async throws {
+        let displayName = "New App"
+        let executableName = ToolNameSanitizer.executableName(from: displayName)
+        let packageRootURL = try context.makeUniquePackageRoot(displayName: displayName)
+        let layout = ToolPackageLayout(packageRootURL: packageRootURL, executableName: executableName)
+        let contentViewPath = layout.sourcePath(for: layout.defaultContentViewFileName)
+        let manifest = ToolManifest(
+            displayName: displayName,
+            executableName: executableName,
+            files: [
+                ToolManifestFile(
+                    path: contentViewPath,
+                    description: "Primary SwiftUI screen and supporting app logic."
+                )
+            ]
+        )
+        try await lifecycle.prepareCreatedTool(
+            ToolGenerationPreparedTool(
+                name: displayName,
+                executableName: executableName,
+                bundleIdentifier: ToolBundleIdentifier.make(executableName: executableName),
+                sandboxEnabled: sandboxEnabled,
+                packageRootURL: packageRootURL,
+                manifest: manifest
+            ),
+            prompt
+        )
+    }
+
     private func createTool(
         prompt: String,
         existingTool: Tool? = nil,
@@ -158,6 +191,13 @@ struct SingleFileToolGenerationRuntime {
             setup = resumedSetup
         } else {
             status("Naming app")
+            if existingTool == nil {
+                try await preparePlaceholderCreateTool(
+                    prompt: prompt,
+                    sandboxEnabled: sandboxEnabled,
+                    lifecycle: lifecycle
+                )
+            }
             try await lifecycle.updatePhase(.generating, .planning, nil)
             try Task.checkCancellation()
             let metadata = await context.metadataClient.suggestMetadata(

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -16,6 +16,7 @@ struct ToolGenerationLifecycle {
         _ prompt: String
     ) async throws -> Void
     nonisolated(unsafe) let updatePendingPrompt: (_ prompt: String) async throws -> Void
+    nonisolated(unsafe) let updateRepairErrorCount: (_ count: Int?) async throws -> Void
     nonisolated(unsafe) let updatePhase: (
         _ state: ToolGenerationState,
         _ phase: ToolGenerationPhase?,
@@ -29,6 +30,7 @@ struct ToolGenerationLifecycle {
             _ prompt: String
         ) async throws -> Void = { _, _ in },
         updatePendingPrompt: @escaping (_ prompt: String) async throws -> Void = { _ in },
+        updateRepairErrorCount: @escaping (_ count: Int?) async throws -> Void = { _ in },
         updatePhase: @escaping (
             _ state: ToolGenerationState,
             _ phase: ToolGenerationPhase?,
@@ -38,6 +40,7 @@ struct ToolGenerationLifecycle {
         self.preservesCreatedPackageOnCancellation = preservesCreatedPackageOnCancellation
         self.prepareCreatedTool = prepareCreatedTool
         self.updatePendingPrompt = updatePendingPrompt
+        self.updateRepairErrorCount = updateRepairErrorCount
         self.updatePhase = updatePhase
     }
 

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -1,15 +1,83 @@
 import Foundation
 
+struct ToolGenerationPreparedTool {
+    let name: String
+    let executableName: String
+    let bundleIdentifier: String
+    let sandboxEnabled: Bool
+    let packageRootURL: URL
+    let manifest: ToolManifest
+}
+
+struct ToolGenerationLifecycle {
+    let preservesCreatedPackageOnCancellation: Bool
+    nonisolated(unsafe) let prepareCreatedTool: (
+        _ preparedTool: ToolGenerationPreparedTool,
+        _ prompt: String,
+        _ refinedPrompt: String?
+    ) async throws -> Void
+    nonisolated(unsafe) let updatePhase: (
+        _ state: ToolGenerationState,
+        _ phase: ToolGenerationPhase?,
+        _ errorSummary: String?
+    ) async throws -> Void
+
+    nonisolated init(
+        preservesCreatedPackageOnCancellation: Bool = false,
+        prepareCreatedTool: @escaping (
+            _ preparedTool: ToolGenerationPreparedTool,
+            _ prompt: String,
+            _ refinedPrompt: String?
+        ) async throws -> Void = { _, _, _ in },
+        updatePhase: @escaping (
+            _ state: ToolGenerationState,
+            _ phase: ToolGenerationPhase?,
+            _ errorSummary: String?
+        ) async throws -> Void = { _, _, _ in }
+    ) {
+        self.preservesCreatedPackageOnCancellation = preservesCreatedPackageOnCancellation
+        self.prepareCreatedTool = prepareCreatedTool
+        self.updatePhase = updatePhase
+    }
+
+    nonisolated static var noop: ToolGenerationLifecycle {
+        ToolGenerationLifecycle()
+    }
+}
+
 struct ToolGenerationClient {
-    var generateTool: (
+    private var generateToolWithLifecycle: (
         _ prompt: String,
         _ existingTool: Tool?,
         _ sandboxEnabled: Bool,
         _ sandboxPermissions: GeneratedAppSandboxPermissions,
         _ resourcePermissions: GeneratedAppResourcePermissions,
         _ languageModelContext: AgentLanguageModelContext,
+        _ lifecycle: ToolGenerationLifecycle,
         _ status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult
+
+    func generateTool(
+        _ prompt: String,
+        _ existingTool: Tool?,
+        _ sandboxEnabled: Bool,
+        _ sandboxPermissions: GeneratedAppSandboxPermissions,
+        _ resourcePermissions: GeneratedAppResourcePermissions,
+        _ languageModelContext: AgentLanguageModelContext,
+        lifecycle: ToolGenerationLifecycle = .noop,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        try await generateToolWithLifecycle(
+            prompt,
+            existingTool,
+            sandboxEnabled,
+            sandboxPermissions,
+            resourcePermissions,
+            languageModelContext,
+            lifecycle,
+            status
+        )
+    }
 
     init(
         _ generateTool: @escaping (
@@ -22,7 +90,40 @@ struct ToolGenerationClient {
             _ status: @escaping @MainActor (String) -> Void
         ) async throws -> ToolGenerationResult
     ) {
-        self.generateTool = generateTool
+        self.generateToolWithLifecycle = {
+            prompt,
+            existingTool,
+            sandboxEnabled,
+            sandboxPermissions,
+            resourcePermissions,
+            languageModelContext,
+            _,
+            status in
+            try await generateTool(
+                prompt,
+                existingTool,
+                sandboxEnabled,
+                sandboxPermissions,
+                resourcePermissions,
+                languageModelContext,
+                status
+            )
+        }
+    }
+
+    init(
+        withLifecycle generateTool: @escaping (
+            _ prompt: String,
+            _ existingTool: Tool?,
+            _ sandboxEnabled: Bool,
+            _ sandboxPermissions: GeneratedAppSandboxPermissions,
+            _ resourcePermissions: GeneratedAppResourcePermissions,
+            _ languageModelContext: AgentLanguageModelContext,
+            _ lifecycle: ToolGenerationLifecycle,
+            _ status: @escaping @MainActor (String) -> Void
+        ) async throws -> ToolGenerationResult
+    ) {
+        self.generateToolWithLifecycle = generateTool
     }
 
     static func live(
@@ -34,7 +135,7 @@ struct ToolGenerationClient {
         promptRefinementClient: ToolPromptRefinementClient = .live(),
         versionBackupClient: ToolVersionBackupClient = .live
     ) -> Self {
-        Self { prompt, existingTool, sandboxEnabled, sandboxPermissions, resourcePermissions, languageModelContext, status in
+        Self(withLifecycle: { prompt, existingTool, sandboxEnabled, sandboxPermissions, resourcePermissions, languageModelContext, lifecycle, status in
             let context = ToolGenerationRuntimeContext(
                 languageModel: languageModelContext.languageModel,
                 metadataLanguageModel: languageModelContext.metadataLanguageModel,
@@ -57,9 +158,10 @@ struct ToolGenerationClient {
                 sandboxEnabled: sandboxEnabled,
                 sandboxPermissions: sandboxPermissions,
                 resourcePermissions: resourcePermissions,
+                lifecycle: lifecycle,
                 status: status
             )
-        }
+        })
     }
 }
 

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -13,9 +13,9 @@ struct ToolGenerationLifecycle {
     let preservesCreatedPackageOnCancellation: Bool
     nonisolated(unsafe) let prepareCreatedTool: (
         _ preparedTool: ToolGenerationPreparedTool,
-        _ prompt: String,
-        _ refinedPrompt: String?
+        _ prompt: String
     ) async throws -> Void
+    nonisolated(unsafe) let updatePendingPrompt: (_ prompt: String) async throws -> Void
     nonisolated(unsafe) let updatePhase: (
         _ state: ToolGenerationState,
         _ phase: ToolGenerationPhase?,
@@ -26,9 +26,9 @@ struct ToolGenerationLifecycle {
         preservesCreatedPackageOnCancellation: Bool = false,
         prepareCreatedTool: @escaping (
             _ preparedTool: ToolGenerationPreparedTool,
-            _ prompt: String,
-            _ refinedPrompt: String?
-        ) async throws -> Void = { _, _, _ in },
+            _ prompt: String
+        ) async throws -> Void = { _, _ in },
+        updatePendingPrompt: @escaping (_ prompt: String) async throws -> Void = { _ in },
         updatePhase: @escaping (
             _ state: ToolGenerationState,
             _ phase: ToolGenerationPhase?,
@@ -37,6 +37,7 @@ struct ToolGenerationLifecycle {
     ) {
         self.preservesCreatedPackageOnCancellation = preservesCreatedPackageOnCancellation
         self.prepareCreatedTool = prepareCreatedTool
+        self.updatePendingPrompt = updatePendingPrompt
         self.updatePhase = updatePhase
     }
 
@@ -131,6 +132,7 @@ struct ToolGenerationClient {
         fileClient: AgentFileClient = .live,
         processClient: SwiftPackageProcessClient = .live,
         appBundleClient: ToolAppBundleClient = .live(),
+        iconClient: ToolIconClient = .live(),
         metadataClient: ToolMetadataClient = .live(),
         promptRefinementClient: ToolPromptRefinementClient = .live(),
         versionBackupClient: ToolVersionBackupClient = .live
@@ -145,6 +147,7 @@ struct ToolGenerationClient {
                 fileClient: fileClient,
                 processClient: processClient,
                 appBundleClient: appBundleClient,
+                iconClient: iconClient,
                 metadataClient: metadataClient,
                 promptRefinementClient: promptRefinementClient,
                 promptRefinementEnabled: languageModelContext.promptRefinementEnabled,

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
@@ -127,6 +127,46 @@ enum ToolGenerationPrompts {
         """
     }
 
+    static func sourceContinuationPrompt(
+        originalPrompt: String,
+        partialSource: String
+    ) -> String {
+        """
+        Continue the exact Swift source response that was interrupted.
+        Return only the next characters of ContentView.swift.
+        Do not repeat any text from the partial source.
+        Do not include markdown fences, explanations, or labels.
+
+        Original request context:
+        \(originalPrompt)
+
+        Partial ContentView.swift already generated:
+        ```swift
+        \(partialSource)
+        ```
+        """
+    }
+
+    static func diffContinuationPrompt(
+        originalPrompt: String,
+        partialDiff: String
+    ) -> String {
+        """
+        Continue the exact unified diff response that was interrupted.
+        Return only the next characters of the diff.
+        Do not repeat any text from the partial diff.
+        Do not include markdown fences, explanations, or labels.
+
+        Original request context:
+        \(originalPrompt)
+
+        Partial unified diff already generated:
+        ```diff
+        \(partialDiff)
+        ```
+        """
+    }
+
     static func conversationalRepairPrompt(
         diagnostics: [SwiftCompilerDiagnostic],
         source: String?,

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
@@ -58,6 +58,7 @@ enum ToolGenerationPrompts {
     Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
     \(validUnifiedDiffShapeExample)
     Keep the edit focused on the user's requested change.
+    Prefer several small, focused hunks over one large hunk when multiple areas need changes.
     """
 
     static func singleFileCreatePrompt(
@@ -118,6 +119,7 @@ enum ToolGenerationPrompts {
         \(diffHunkLimitInstruction(maximumDiffHunks))
         The diff must patch ContentView.swift only.
         Include enough unchanged context in each hunk to make it uniquely applicable.
+        Prefer small focused hunks instead of one broad rewrite.
         Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
         Do not rewrite the entire file unless the whole file is malformed.
         Current authoritative ContentView.swift:

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
@@ -10,6 +10,7 @@ struct ToolGenerationRuntimeContext {
     let fileClient: AgentFileClient
     let processClient: SwiftPackageProcessClient
     let appBundleClient: ToolAppBundleClient
+    let iconClient: ToolIconClient
     let metadataClient: ToolMetadataClient
     let promptRefinementClient: ToolPromptRefinementClient
     let promptRefinementEnabled: Bool
@@ -25,6 +26,7 @@ struct ToolGenerationRuntimeContext {
         fileClient: AgentFileClient,
         processClient: SwiftPackageProcessClient,
         appBundleClient: ToolAppBundleClient,
+        iconClient: ToolIconClient = .noOp,
         metadataClient: ToolMetadataClient = .fallback(),
         promptRefinementClient: ToolPromptRefinementClient = .disabled(),
         promptRefinementEnabled: Bool = true,
@@ -39,6 +41,7 @@ struct ToolGenerationRuntimeContext {
         self.fileClient = fileClient
         self.processClient = processClient
         self.appBundleClient = appBundleClient
+        self.iconClient = iconClient
         self.metadataClient = metadataClient
         self.promptRefinementClient = promptRefinementClient
         self.promptRefinementEnabled = promptRefinementEnabled
@@ -54,6 +57,7 @@ struct ToolGenerationRuntimeContext {
         fileClient: AgentFileClient,
         processClient: SwiftPackageProcessClient,
         appBundleClient: ToolAppBundleClient,
+        iconClient: ToolIconClient = .noOp,
         metadataClient: ToolMetadataClient = .fallback(),
         promptRefinementClient: ToolPromptRefinementClient = .disabled(),
         promptRefinementEnabled: Bool = true,
@@ -69,6 +73,7 @@ struct ToolGenerationRuntimeContext {
             fileClient: fileClient,
             processClient: processClient,
             appBundleClient: appBundleClient,
+            iconClient: iconClient,
             metadataClient: metadataClient,
             promptRefinementClient: promptRefinementClient,
             promptRefinementEnabled: promptRefinementEnabled,

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
@@ -97,6 +97,32 @@ struct ToolGenerationRuntimeContext {
         }
     }
 
+    func streamText<PromptContent>(
+        in session: LanguageModelSession,
+        to prompt: PromptContent,
+        onSnapshot: @escaping @MainActor (String) throws -> Void
+    ) async throws -> String where PromptContent: PromptRepresentable {
+        var latest = ""
+        do {
+            let stream = session.streamResponse(
+                to: Prompt(prompt),
+                generating: String.self,
+                options: generationOptions
+            )
+            for try await snapshot in stream {
+                latest = snapshot.content
+                try await MainActor.run {
+                    try onSnapshot(latest)
+                }
+            }
+            await afterLanguageModelInvocation()
+            return latest
+        } catch {
+            await afterLanguageModelInvocation()
+            throw error
+        }
+    }
+
     func makeUniquePackageRoot(displayName: String) throws -> URL {
         try fileClient.createDirectory(toolsDirectoryURL)
 

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -6,6 +6,29 @@
 import Foundation
 import SwiftData
 
+enum ToolGenerationState: String, Codable, CaseIterable, Equatable, Sendable {
+    case ready
+    case generating
+    case stopped
+    case failed
+}
+
+enum ToolGenerationPhase: String, Codable, CaseIterable, Equatable, Sendable {
+    case initializing
+    case planning
+    case generatingSource
+    case generatingEditDiff
+    case generatingRepairDiff
+    case repairing
+    case packaging
+    case completed
+}
+
+enum ToolGenerationMode: String, Codable, CaseIterable, Equatable, Sendable {
+    case create
+    case edit
+}
+
 @Model
 final class Tool {
     @Attribute(.unique) var id: UUID
@@ -15,6 +38,12 @@ final class Tool {
     var sandboxEnabled: Bool
     var packageRootPath: String
     var lastPromptSummary: String?
+    var generationStateRawValue: String = ToolGenerationState.ready.rawValue
+    var generationPhaseRawValue: String? = ToolGenerationPhase.completed.rawValue
+    var generationModeRawValue: String?
+    var pendingPrompt: String?
+    var pendingRefinedPrompt: String?
+    var generationErrorSummary: String?
     var createdAt: Date
     var updatedAt: Date
 
@@ -26,6 +55,12 @@ final class Tool {
         sandboxEnabled: Bool = true,
         packageRootPath: String,
         lastPromptSummary: String? = nil,
+        generationState: ToolGenerationState = .ready,
+        generationPhase: ToolGenerationPhase? = .completed,
+        generationMode: ToolGenerationMode? = nil,
+        pendingPrompt: String? = nil,
+        pendingRefinedPrompt: String? = nil,
+        generationErrorSummary: String? = nil,
         createdAt: Date = .now,
         updatedAt: Date = .now
     ) {
@@ -37,12 +72,45 @@ final class Tool {
         self.sandboxEnabled = sandboxEnabled
         self.packageRootPath = packageRootPath
         self.lastPromptSummary = lastPromptSummary
+        self.generationStateRawValue = generationState.rawValue
+        self.generationPhaseRawValue = generationPhase?.rawValue
+        self.generationModeRawValue = generationMode?.rawValue
+        self.pendingPrompt = pendingPrompt
+        self.pendingRefinedPrompt = pendingRefinedPrompt
+        self.generationErrorSummary = generationErrorSummary
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
 }
 
 extension Tool {
+    var generationState: ToolGenerationState {
+        get { ToolGenerationState(rawValue: generationStateRawValue) ?? .ready }
+        set { generationStateRawValue = newValue.rawValue }
+    }
+
+    var generationPhase: ToolGenerationPhase? {
+        get {
+            generationPhaseRawValue.flatMap(ToolGenerationPhase.init(rawValue:))
+        }
+        set {
+            generationPhaseRawValue = newValue?.rawValue
+        }
+    }
+
+    var generationMode: ToolGenerationMode? {
+        get {
+            generationModeRawValue.flatMap(ToolGenerationMode.init(rawValue:))
+        }
+        set {
+            generationModeRawValue = newValue?.rawValue
+        }
+    }
+
+    var isGenerationReady: Bool {
+        generationState == .ready
+    }
+
     var packageRootURL: URL {
         URL(fileURLWithPath: packageRootPath, isDirectory: true)
     }

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -44,6 +44,7 @@ final class Tool {
     var generationModeRawValue: String?
     var pendingPrompt: String?
     var generationErrorSummary: String?
+    var generationRepairErrorCount: Int? = nil
     var createdAt: Date
     var updatedAt: Date
 
@@ -59,6 +60,7 @@ final class Tool {
         generationMode: ToolGenerationMode? = nil,
         pendingPrompt: String? = nil,
         generationErrorSummary: String? = nil,
+        generationRepairErrorCount: Int? = nil,
         createdAt: Date = .now,
         updatedAt: Date = .now
     ) {
@@ -74,6 +76,7 @@ final class Tool {
         self.generationModeRawValue = generationMode?.rawValue
         self.pendingPrompt = pendingPrompt
         self.generationErrorSummary = generationErrorSummary
+        self.generationRepairErrorCount = generationRepairErrorCount
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -16,6 +16,8 @@ enum ToolGenerationState: String, Codable, CaseIterable, Equatable, Sendable {
 enum ToolGenerationPhase: String, Codable, CaseIterable, Equatable, Sendable {
     case initializing
     case planning
+    case generatingIcon
+    case refiningPrompt
     case generatingSource
     case generatingEditDiff
     case generatingRepairDiff
@@ -37,12 +39,10 @@ final class Tool {
     var bundleIdentifier: String
     var sandboxEnabled: Bool
     var packageRootPath: String
-    var lastPromptSummary: String?
     var generationStateRawValue: String = ToolGenerationState.ready.rawValue
     var generationPhaseRawValue: String? = ToolGenerationPhase.completed.rawValue
     var generationModeRawValue: String?
     var pendingPrompt: String?
-    var pendingRefinedPrompt: String?
     var generationErrorSummary: String?
     var createdAt: Date
     var updatedAt: Date
@@ -54,12 +54,10 @@ final class Tool {
         bundleIdentifier: String? = nil,
         sandboxEnabled: Bool = true,
         packageRootPath: String,
-        lastPromptSummary: String? = nil,
         generationState: ToolGenerationState = .ready,
         generationPhase: ToolGenerationPhase? = .completed,
         generationMode: ToolGenerationMode? = nil,
         pendingPrompt: String? = nil,
-        pendingRefinedPrompt: String? = nil,
         generationErrorSummary: String? = nil,
         createdAt: Date = .now,
         updatedAt: Date = .now
@@ -71,12 +69,10 @@ final class Tool {
         self.bundleIdentifier = bundleIdentifier ?? ToolBundleIdentifier.make(executableName: resolvedExecutableName)
         self.sandboxEnabled = sandboxEnabled
         self.packageRootPath = packageRootPath
-        self.lastPromptSummary = lastPromptSummary
         self.generationStateRawValue = generationState.rawValue
         self.generationPhaseRawValue = generationPhase?.rawValue
         self.generationModeRawValue = generationMode?.rawValue
         self.pendingPrompt = pendingPrompt
-        self.pendingRefinedPrompt = pendingRefinedPrompt
         self.generationErrorSummary = generationErrorSummary
         self.createdAt = createdAt
         self.updatedAt = updatedAt

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -99,6 +99,9 @@ struct ToolLibraryPopoverView: View {
                                 onDiscard: {
                                     toolLibraryStore.discardGeneration(tool, in: modelContext)
                                 },
+                                onStop: {
+                                    toolLibraryStore.cancelGeneration()
+                                },
                                 onDelete: {
                                     toolPendingDeletion = tool
                                 }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -89,6 +89,16 @@ struct ToolLibraryPopoverView: View {
                                         await toolLibraryStore.viewSource(tool)
                                     }
                                 },
+                                onContinue: {
+                                    toolLibraryStore.continueGeneration(
+                                        tool,
+                                        modelContext: modelContext,
+                                        inferenceStore: inferenceStore
+                                    )
+                                },
+                                onDiscard: {
+                                    toolLibraryStore.discardGeneration(tool, in: modelContext)
+                                },
                                 onDelete: {
                                     toolPendingDeletion = tool
                                 }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -116,21 +116,6 @@ struct ToolLibraryPopoverView: View {
                 await toolLibraryStore.refreshRestoreAvailability(for: tools)
             }
 
-            if let generationStatus = toolLibraryStore.generationStatus {
-                HStack(spacing: 8) {
-                    ProgressView()
-                        .controlSize(.small)
-                        .accessibilityLabel("Generating app")
-
-                    Text(generationStatus)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-
-                    Spacer()
-                }
-            }
-
             PromptComposerView(
                 prompt: $toolLibraryStore.prompt,
                 sandboxEnabled: $toolLibraryStore.sandboxEnabled,

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -63,12 +63,11 @@ struct ToolRowView: View {
                 )
             }
 
+            if canContinue {
+                generationActionButtons
+            }
+
             Menu {
-                if canContinue {
-                    Button("Continue Generation", action: onContinue)
-                    Button("Discard Generation", role: .destructive, action: onDiscard)
-                    Divider()
-                }
                 Button("Go Back to Previous Version", action: onRevert)
                     .disabled(!tool.isGenerationReady || !canRevert)
                 Button("Export App", action: onExport)
@@ -112,6 +111,16 @@ struct ToolRowView: View {
                     .frame(width: 42, height: 42)
                     .background(.black.opacity(0.28), in: RoundedRectangle(cornerRadius: 9))
                     .accessibilityLabel("Running \(tool.name)")
+            } else if isHoveringRow && canContinue {
+                Button(action: onContinue) {
+                    Image(systemName: "play.fill")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(RunToolButtonStyle())
+                .help("Continue \(tool.name)")
+                .accessibilityLabel("Continue \(tool.name)")
+                .accessibilityIdentifier("continue-tool-\(tool.id.uuidString)")
             } else if isHoveringRow && tool.isGenerationReady {
                 Button(action: onRun) {
                     Image(systemName: "play.fill")
@@ -126,20 +135,91 @@ struct ToolRowView: View {
         }
     }
 
+    private var generationActionButtons: some View {
+        HStack(spacing: 4) {
+            Button(action: onContinue) {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.borderless)
+            .help("Continue generation")
+            .accessibilityLabel("Continue generation for \(tool.name)")
+
+            Button(role: .destructive, action: onDiscard) {
+                Image(systemName: "trash")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.borderless)
+            .help("Discard generation")
+            .accessibilityLabel("Discard generation for \(tool.name)")
+        }
+        .fixedSize()
+    }
+
     private var generationStatusText: String? {
         switch tool.generationState {
         case .ready:
             return nil
         case .generating:
-            return "Generating"
+            return phaseStatusText
         case .stopped:
-            return "Stopped"
+            return "Stopped · \(phaseName)"
         case .failed:
             if let generationErrorSummary = tool.generationErrorSummary,
                !generationErrorSummary.isEmpty {
-                return "Failed: \(generationErrorSummary)"
+                return "Failed · \(phaseName): \(generationErrorSummary)"
             }
-            return "Failed"
+            return "Failed · \(phaseName)"
+        }
+    }
+
+    private var phaseStatusText: String {
+        switch tool.generationPhase {
+        case .initializing:
+            return "Initializing"
+        case .planning:
+            return "Naming app"
+        case .generatingIcon:
+            return "Generating icon"
+        case .refiningPrompt:
+            return "Enhancing prompt"
+        case .generatingSource:
+            return "Generating source"
+        case .generatingEditDiff:
+            return "Editing source"
+        case .generatingRepairDiff:
+            return "Repairing source"
+        case .repairing:
+            return "Building"
+        case .packaging:
+            return "Packaging"
+        case .completed, nil:
+            return "Finishing"
+        }
+    }
+
+    private var phaseName: String {
+        switch tool.generationPhase {
+        case .initializing:
+            return "initializing"
+        case .planning:
+            return "naming"
+        case .generatingIcon:
+            return "icon"
+        case .refiningPrompt:
+            return "prompt"
+        case .generatingSource:
+            return "source"
+        case .generatingEditDiff:
+            return "edit"
+        case .generatingRepairDiff, .repairing:
+            return "repair"
+        case .packaging:
+            return "packaging"
+        case .completed, nil:
+            return "generation"
         }
     }
 

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -20,6 +20,7 @@ struct ToolRowView: View {
     let onViewSource: () -> Void
     let onContinue: () -> Void
     let onDiscard: () -> Void
+    let onStop: () -> Void
     let onDelete: () -> Void
     @State private var isHoveringRow = false
 
@@ -63,10 +64,6 @@ struct ToolRowView: View {
                 )
             }
 
-            if canContinue {
-                generationActionButtons
-            }
-
             Menu {
                 Button("Go Back to Previous Version", action: onRevert)
                     .disabled(!tool.isGenerationReady || !canRevert)
@@ -76,7 +73,11 @@ struct ToolRowView: View {
                     .disabled(!tool.isGenerationReady)
                 Button("Show in Finder", action: onShowInFinder)
                 Divider()
-                Button("Delete App", role: .destructive, action: onDelete)
+                if shouldDiscardFromMenu {
+                    Button("Discard Edit", role: .destructive, action: onDiscard)
+                } else {
+                    Button("Delete App", role: .destructive, action: onDelete)
+                }
             } label: {
                 Image(systemName: "ellipsis.circle")
                     .font(.system(size: 18, weight: .semibold))
@@ -99,18 +100,20 @@ struct ToolRowView: View {
             ToolIconImageView(tool: tool)
                 .frame(width: 42, height: 42)
 
-            if tool.generationState == .generating {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(width: 42, height: 42)
-                    .background(.black.opacity(0.28), in: RoundedRectangle(cornerRadius: 9))
-                    .accessibilityLabel("Generating \(tool.name)")
+            if tool.generationState == .generating && isHoveringRow {
+                Button(action: onStop) {
+                    Image(systemName: "stop.fill")
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.white)
+                }
+                .buttonStyle(RunToolButtonStyle())
+                .help("Stop \(tool.name)")
+                .accessibilityLabel("Stop \(tool.name)")
+                .accessibilityIdentifier("stop-tool-\(tool.id.uuidString)")
+            } else if tool.generationState == .generating {
+                iconProgressOverlay("Generating \(tool.name)")
             } else if isRunning {
-                ProgressView()
-                    .controlSize(.small)
-                    .frame(width: 42, height: 42)
-                    .background(.black.opacity(0.28), in: RoundedRectangle(cornerRadius: 9))
-                    .accessibilityLabel("Running \(tool.name)")
+                iconProgressOverlay("Running \(tool.name)")
             } else if isHoveringRow && canContinue {
                 Button(action: onContinue) {
                     Image(systemName: "play.fill")
@@ -135,27 +138,8 @@ struct ToolRowView: View {
         }
     }
 
-    private var generationActionButtons: some View {
-        HStack(spacing: 4) {
-            Button(action: onContinue) {
-                Image(systemName: "play.fill")
-                    .font(.system(size: 11, weight: .semibold))
-                    .frame(width: 22, height: 22)
-            }
-            .buttonStyle(.borderless)
-            .help("Continue generation")
-            .accessibilityLabel("Continue generation for \(tool.name)")
-
-            Button(role: .destructive, action: onDiscard) {
-                Image(systemName: "trash")
-                    .font(.system(size: 11, weight: .semibold))
-                    .frame(width: 22, height: 22)
-            }
-            .buttonStyle(.borderless)
-            .help("Discard generation")
-            .accessibilityLabel("Discard generation for \(tool.name)")
-        }
-        .fixedSize()
+    private func iconProgressOverlay(_ accessibilityLabel: String) -> some View {
+        IconProgressBadge(accessibilityLabel: accessibilityLabel)
     }
 
     private var generationStatusText: String? {
@@ -165,13 +149,9 @@ struct ToolRowView: View {
         case .generating:
             return phaseStatusText
         case .stopped:
-            return "Stopped · \(phaseName)"
+            return "Stopped"
         case .failed:
-            if let generationErrorSummary = tool.generationErrorSummary,
-               !generationErrorSummary.isEmpty {
-                return "Failed · \(phaseName): \(generationErrorSummary)"
-            }
-            return "Failed · \(phaseName)"
+            return "Failed"
         }
     }
 
@@ -190,9 +170,9 @@ struct ToolRowView: View {
         case .generatingEditDiff:
             return "Editing source"
         case .generatingRepairDiff:
-            return "Repairing source"
+            return repairStatusText ?? "Repairing"
         case .repairing:
-            return "Building"
+            return repairStatusText ?? "Building"
         case .packaging:
             return "Packaging"
         case .completed, nil:
@@ -200,41 +180,24 @@ struct ToolRowView: View {
         }
     }
 
-    private var phaseName: String {
-        switch tool.generationPhase {
-        case .initializing:
-            return "initializing"
-        case .planning:
-            return "naming"
-        case .generatingIcon:
-            return "icon"
-        case .refiningPrompt:
-            return "prompt"
-        case .generatingSource:
-            return "source"
-        case .generatingEditDiff:
-            return "edit"
-        case .generatingRepairDiff, .repairing:
-            return "repair"
-        case .packaging:
-            return "packaging"
-        case .completed, nil:
-            return "generation"
-        }
+    private var repairStatusText: String? {
+        guard let count = tool.generationRepairErrorCount, count > 0 else { return nil }
+        let errorLabel = count == 1 ? "error" : "errors"
+        return "Repairing \(count) \(errorLabel)"
     }
 
     private var canContinue: Bool {
         tool.generationState == .stopped || tool.generationState == .failed
     }
 
+    private var shouldDiscardFromMenu: Bool {
+        canContinue && tool.generationMode == .edit
+    }
+
     private var statusStyle: some ShapeStyle {
         switch tool.generationState {
-        case .ready:
+        case .ready, .generating, .stopped:
             return AnyShapeStyle(.secondary)
-        case .generating:
-            return AnyShapeStyle(.secondary)
-        case .stopped:
-            return AnyShapeStyle(.orange)
         case .failed:
             return AnyShapeStyle(.red)
         }
@@ -282,6 +245,7 @@ struct ToolRowView: View {
         onViewSource: {},
         onContinue: {},
         onDiscard: {},
+        onStop: {},
         onDelete: {}
     )
     .padding()
@@ -385,6 +349,40 @@ private struct RunToolButtonStyle: ButtonStyle {
             .background(.black.opacity(0.42), in: RoundedRectangle(cornerRadius: 9))
             .scaleEffect(configuration.isPressed ? 0.88 : 1)
             .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+    }
+}
+
+private struct IconProgressBadge: View {
+    let accessibilityLabel: String
+    @State private var isSpinning = false
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(.white.opacity(0.92))
+                .frame(width: 24, height: 24)
+                .shadow(color: .black.opacity(0.38), radius: 3, y: 1)
+
+            Circle()
+                .trim(from: 0.18, to: 0.84)
+                .stroke(
+                    .black.opacity(0.78),
+                    style: StrokeStyle(lineWidth: 2.4, lineCap: .round)
+                )
+                .frame(width: 14, height: 14)
+                .rotationEffect(.degrees(isSpinning ? 360 : 0))
+        }
+        .frame(width: 42, height: 42)
+        .accessibilityLabel(accessibilityLabel)
+        .onAppear {
+            isSpinning = false
+            withAnimation(.linear(duration: 0.85).repeatForever(autoreverses: false)) {
+                isSpinning = true
+            }
+        }
+        .onDisappear {
+            isSpinning = false
+        }
     }
 }
 

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -18,6 +18,8 @@ struct ToolRowView: View {
     let onExport: () -> Void
     let onShowInFinder: () -> Void
     let onViewSource: () -> Void
+    let onContinue: () -> Void
+    let onDiscard: () -> Void
     let onDelete: () -> Void
     @State private var isHoveringRow = false
 
@@ -26,10 +28,19 @@ struct ToolRowView: View {
             HStack(spacing: 10) {
                 icon
 
-                Text(tool.name)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(tool.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    if let generationStatusText {
+                        Text(generationStatusText)
+                            .font(.caption)
+                            .foregroundStyle(statusStyle)
+                            .lineLimit(1)
+                    }
+                }
 
                 Spacer()
 
@@ -47,16 +58,23 @@ struct ToolRowView: View {
             .overlay {
                 ToolRowClickHandlingView(
                     ignoredLeadingWidth: 64,
-                    onSelect: onSelect,
-                    onRun: onRun
+                    onSelect: tool.isGenerationReady ? onSelect : {},
+                    onRun: tool.isGenerationReady ? onRun : {}
                 )
             }
 
             Menu {
+                if canContinue {
+                    Button("Continue Generation", action: onContinue)
+                    Button("Discard Generation", role: .destructive, action: onDiscard)
+                    Divider()
+                }
                 Button("Go Back to Previous Version", action: onRevert)
-                    .disabled(!canRevert)
+                    .disabled(!tool.isGenerationReady || !canRevert)
                 Button("Export App", action: onExport)
+                    .disabled(!tool.isGenerationReady)
                 Button("View Source", action: onViewSource)
+                    .disabled(!tool.isGenerationReady)
                 Button("Show in Finder", action: onShowInFinder)
                 Divider()
                 Button("Delete App", role: .destructive, action: onDelete)
@@ -82,13 +100,19 @@ struct ToolRowView: View {
             ToolIconImageView(tool: tool)
                 .frame(width: 42, height: 42)
 
-            if isRunning {
+            if tool.generationState == .generating {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 42, height: 42)
+                    .background(.black.opacity(0.28), in: RoundedRectangle(cornerRadius: 9))
+                    .accessibilityLabel("Generating \(tool.name)")
+            } else if isRunning {
                 ProgressView()
                     .controlSize(.small)
                     .frame(width: 42, height: 42)
                     .background(.black.opacity(0.28), in: RoundedRectangle(cornerRadius: 9))
                     .accessibilityLabel("Running \(tool.name)")
-            } else if isHoveringRow {
+            } else if isHoveringRow && tool.isGenerationReady {
                 Button(action: onRun) {
                     Image(systemName: "play.fill")
                         .font(.system(size: 15, weight: .bold))
@@ -102,9 +126,47 @@ struct ToolRowView: View {
         }
     }
 
+    private var generationStatusText: String? {
+        switch tool.generationState {
+        case .ready:
+            return nil
+        case .generating:
+            return "Generating"
+        case .stopped:
+            return "Stopped"
+        case .failed:
+            if let generationErrorSummary = tool.generationErrorSummary,
+               !generationErrorSummary.isEmpty {
+                return "Failed: \(generationErrorSummary)"
+            }
+            return "Failed"
+        }
+    }
+
+    private var canContinue: Bool {
+        tool.generationState == .stopped || tool.generationState == .failed
+    }
+
+    private var statusStyle: some ShapeStyle {
+        switch tool.generationState {
+        case .ready:
+            return AnyShapeStyle(.secondary)
+        case .generating:
+            return AnyShapeStyle(.secondary)
+        case .stopped:
+            return AnyShapeStyle(.orange)
+        case .failed:
+            return AnyShapeStyle(.red)
+        }
+    }
+
     private var backgroundStyle: some ShapeStyle {
         if isSelected {
             return AnyShapeStyle(.tint.opacity(0.28))
+        }
+
+        if !tool.isGenerationReady {
+            return AnyShapeStyle(.quaternary.opacity(0.52))
         }
 
         if isRunning {
@@ -138,6 +200,8 @@ struct ToolRowView: View {
         onExport: {},
         onShowInFinder: {},
         onViewSource: {},
+        onContinue: {},
+        onDiscard: {},
         onDelete: {}
     )
     .padding()

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -106,6 +106,7 @@ final class ToolLibraryStore {
 
     func delete(_ tool: Tool, in modelContext: ModelContext) {
         guard !(isGenerating && tool.generationState == .generating) else { return }
+        let packageRootURL = tool.packageRootURL
         handleDeletedTool(tool)
         modelContext.delete(tool)
 
@@ -114,6 +115,13 @@ final class ToolLibraryStore {
         } catch {
             modelContext.rollback()
             presentError(error.localizedDescription)
+            return
+        }
+
+        do {
+            try removePackageIfExists(packageRootURL)
+        } catch {
+            presentError("Deleted app from the library, but could not remove its files: \(error.localizedDescription)")
         }
     }
 

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -295,7 +295,6 @@ final class ToolLibraryStore {
                 repository.insert(tool)
                 try repository.save()
             }
-            try Task.checkCancellation()
             prompt = Self.defaultPrompt
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
         } catch {
@@ -499,7 +498,6 @@ final class ToolLibraryStore {
             ) { _ in }
             applyCompletedGenerationResult(result, to: tool, prompt: resumePrompt)
             try modelContext.save()
-            try Task.checkCancellation()
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
         } catch {
             if IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -11,6 +11,14 @@ enum ToolLibraryPresentedErrorAction: Equatable {
     case buyIronsmithCredits
 }
 
+private final class BindingBox<Value> {
+    var value: Value
+
+    init(_ value: Value) {
+        self.value = value
+    }
+}
+
 @MainActor
 @Observable
 final class ToolLibraryStore {
@@ -60,6 +68,7 @@ final class ToolLibraryStore {
     }
 
     func selectForEditing(_ tool: Tool) {
+        guard tool.isGenerationReady else { return }
         selectedToolID = tool.id
         selectedToolName = tool.name
         sandboxEnabled = tool.sandboxEnabled
@@ -83,6 +92,10 @@ final class ToolLibraryStore {
             clearSelection()
             return
         }
+        guard selectedTool.isGenerationReady else {
+            clearSelection()
+            return
+        }
 
         selectedToolName = selectedTool.name
         sandboxEnabled = selectedTool.sandboxEnabled
@@ -93,6 +106,7 @@ final class ToolLibraryStore {
     }
 
     func delete(_ tool: Tool, in modelContext: ModelContext) {
+        guard !isGenerating else { return }
         handleDeletedTool(tool)
         modelContext.delete(tool)
 
@@ -105,7 +119,7 @@ final class ToolLibraryStore {
     }
 
     func canRestorePreviousVersion(_ tool: Tool) -> Bool {
-        restorableToolIDs.contains(tool.id)
+        tool.isGenerationReady && restorableToolIDs.contains(tool.id)
     }
 
     func refreshRestoreAvailability(for tools: [Tool]) async {
@@ -148,8 +162,42 @@ final class ToolLibraryStore {
         generationTask?.cancel()
     }
 
+    func continueGeneration(
+        _ tool: Tool,
+        modelContext: ModelContext,
+        inferenceStore: InferenceStore
+    ) {
+        guard canContinueGeneration(tool), generationTask == nil else { return }
+        generationTask = Task { @MainActor in
+            await resumeGeneration(tool, modelContext: modelContext, inferenceStore: inferenceStore)
+            generationTask = nil
+        }
+    }
+
+    func discardGeneration(_ tool: Tool, in modelContext: ModelContext) {
+        guard !isGenerating, canContinueGeneration(tool) else { return }
+        let packageRootURL = tool.packageRootURL
+        removePendingDraft(for: tool)
+
+        do {
+            switch tool.generationMode ?? .create {
+            case .create:
+                handleDeletedTool(tool)
+                modelContext.delete(tool)
+                try modelContext.save()
+                try removePackageIfExists(packageRootURL)
+            case .edit:
+                clearPendingGeneration(on: tool)
+                try modelContext.save()
+            }
+        } catch {
+            modelContext.rollback()
+            presentError(error.localizedDescription)
+        }
+    }
+
     func restorePreviousVersion(_ tool: Tool, in modelContext: ModelContext) async {
-        guard !isGenerating else { return }
+        guard !isGenerating, tool.isGenerationReady else { return }
         isGenerating = true
         clearPresentedErrorState()
         generationStatus = "Restoring \(tool.name)"
@@ -166,6 +214,7 @@ final class ToolLibraryStore {
             generationStatus = "Building \(tool.name)"
             try await dependencies.buildClient.buildTool(tool)
             tool.lastPromptSummary = "Reverted to previous version"
+            clearPendingGeneration(on: tool)
             tool.updatedAt = .now
             try modelContext.save()
             generationStatus = nil
@@ -182,12 +231,14 @@ final class ToolLibraryStore {
         let submittedSelectedToolID = selectedToolID
         let submittedToolName = selectedToolName
         let submittedSandboxEnabled = sandboxEnabled
+        var activeTool: Tool?
         isGenerating = true
         clearPresentedErrorState()
         generationStatus = submittedToolName.map { "Preparing \($0)" } ?? "Preparing new app"
 
         do {
             let selectedTool = try fetchSelectedTool(in: modelContext)
+            activeTool = selectedTool
             if submittedSelectedToolID != nil {
                 clearSelection()
             }
@@ -196,6 +247,25 @@ final class ToolLibraryStore {
             let languageModelContext = try await inferenceStore.makeSelectedAgentLanguageModelContext()
             let sandboxPermissions = inferenceStore.generationPreferences.generatedAppSandboxPermissions
             let resourcePermissions = inferenceStore.generationPreferences.generatedAppResourcePermissions
+            if let selectedTool {
+                markToolGenerating(
+                    selectedTool,
+                    mode: .edit,
+                    phase: .planning,
+                    prompt: trimmedPrompt,
+                    refinedPrompt: nil
+                )
+                try modelContext.save()
+            }
+
+            let activeToolBox = BindingBox(activeTool)
+            let lifecycle = generationLifecycle(
+                modelContext: modelContext,
+                activeTool: activeToolBox
+            ) { tool in
+                activeTool = tool
+                activeToolBox.value = tool
+            }
 
             let result = try await dependencies.generationClient.generateTool(
                 trimmedPrompt,
@@ -203,18 +273,18 @@ final class ToolLibraryStore {
                 submittedSandboxEnabled,
                 sandboxPermissions,
                 resourcePermissions,
-                languageModelContext
+                languageModelContext,
+                lifecycle: lifecycle
             ) { status in
                 self.generationStatus = status
             }
-            try Task.checkCancellation()
 
-            if let selectedTool {
-                selectedTool.executableName = result.executableName
-                selectedTool.bundleIdentifier = result.bundleIdentifier
-                selectedTool.sandboxEnabled = result.sandboxEnabled
-                selectedTool.lastPromptSummary = Self.promptSummary(for: trimmedPrompt)
-                selectedTool.updatedAt = .now
+            if let completedTool = selectedTool ?? activeTool {
+                applyCompletedGenerationResult(
+                    result,
+                    to: completedTool,
+                    prompt: trimmedPrompt
+                )
                 try modelContext.save()
             } else {
                 let tool = Tool(
@@ -223,7 +293,9 @@ final class ToolLibraryStore {
                     bundleIdentifier: result.bundleIdentifier,
                     sandboxEnabled: result.sandboxEnabled,
                     packageRootPath: result.packageRootURL.path,
-                    lastPromptSummary: Self.promptSummary(for: trimmedPrompt)
+                    lastPromptSummary: Self.promptSummary(for: trimmedPrompt),
+                    generationState: .ready,
+                    generationPhase: .completed
                 )
                 let repository = ToolRepository(modelContext: modelContext)
                 repository.insert(tool)
@@ -234,16 +306,32 @@ final class ToolLibraryStore {
             generationStatus = nil
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
         } catch where IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
-            modelContext.rollback()
+            if let activeTool {
+                markToolStopped(activeTool)
+                try? modelContext.save()
+            } else {
+                modelContext.rollback()
+            }
             clearPresentedErrorState()
             generationStatus = nil
         } catch {
-            modelContext.rollback()
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
             if IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
+                if let activeTool {
+                    markToolStopped(activeTool)
+                    try? modelContext.save()
+                } else {
+                    modelContext.rollback()
+                }
                 clearPresentedErrorState()
                 generationStatus = nil
             } else {
+                if let activeTool {
+                    markToolFailed(activeTool, error: error)
+                    try? modelContext.save()
+                } else {
+                    modelContext.rollback()
+                }
                 AgentDiagnosticsLog.append(
                     """
                     Tool generation failed.
@@ -319,6 +407,7 @@ final class ToolLibraryStore {
     }
 
     func viewSource(_ tool: Tool) async {
+        guard tool.isGenerationReady else { return }
         do {
             let contentViewURL = try Self.contentViewURL(for: tool)
             try await dependencies.finderClient.openURL(contentViewURL)
@@ -328,7 +417,7 @@ final class ToolLibraryStore {
     }
 
     func run(_ tool: Tool) async {
-        guard runningToolID == nil else { return }
+        guard tool.isGenerationReady, runningToolID == nil else { return }
         runningToolID = tool.id
         defer { runningToolID = nil }
 
@@ -340,7 +429,7 @@ final class ToolLibraryStore {
     }
 
     func export(_ tool: Tool) async {
-        guard exportingToolID == nil, !isGenerating else { return }
+        guard tool.isGenerationReady, exportingToolID == nil, !isGenerating else { return }
         exportingToolID = tool.id
         generationStatus = "Exporting \(tool.name)"
         defer {
@@ -397,11 +486,208 @@ final class ToolLibraryStore {
         return try modelContext.fetch(descriptor).first
     }
 
+    private func resumeGeneration(
+        _ tool: Tool,
+        modelContext: ModelContext,
+        inferenceStore: InferenceStore
+    ) async {
+        guard canContinueGeneration(tool) else { return }
+        let resumePrompt = (tool.pendingPrompt ?? tool.lastPromptSummary ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !resumePrompt.isEmpty else {
+            presentError("Ironsmith does not have enough saved prompt context to continue this generation.")
+            return
+        }
+
+        isGenerating = true
+        clearPresentedErrorState()
+        generationStatus = "Continuing \(tool.name)"
+        let activeToolBox = BindingBox<Tool?>(tool)
+        let lifecycle = generationLifecycle(
+            modelContext: modelContext,
+            activeTool: activeToolBox
+        ) { _ in }
+
+        do {
+            try await inferenceStore.prepareSelectedModelForGeneration()
+            let languageModelContext = try await inferenceStore.makeSelectedAgentLanguageModelContext()
+            let sandboxPermissions = inferenceStore.generationPreferences.generatedAppSandboxPermissions
+            let resourcePermissions = inferenceStore.generationPreferences.generatedAppResourcePermissions
+            markToolGenerating(
+                tool,
+                mode: tool.generationMode ?? .create,
+                phase: tool.generationPhase ?? .planning,
+                prompt: resumePrompt,
+                refinedPrompt: tool.pendingRefinedPrompt
+            )
+            try modelContext.save()
+
+            let result = try await dependencies.generationClient.generateTool(
+                resumePrompt,
+                tool,
+                tool.sandboxEnabled,
+                sandboxPermissions,
+                resourcePermissions,
+                languageModelContext,
+                lifecycle: lifecycle
+            ) { status in
+                self.generationStatus = status
+            }
+            applyCompletedGenerationResult(result, to: tool, prompt: resumePrompt)
+            try modelContext.save()
+            try Task.checkCancellation()
+            generationStatus = nil
+            await refreshIronsmithCreditsIfNeeded(inferenceStore)
+        } catch where IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
+            markToolStopped(tool)
+            try? modelContext.save()
+            clearPresentedErrorState()
+            generationStatus = nil
+        } catch {
+            await refreshIronsmithCreditsIfNeeded(inferenceStore)
+            if IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
+                markToolStopped(tool)
+                try? modelContext.save()
+                clearPresentedErrorState()
+                generationStatus = nil
+            } else {
+                markToolFailed(tool, error: error)
+                try? modelContext.save()
+                presentGenerationError(error)
+            }
+        }
+
+        isGenerating = false
+        if presentedErrorMessage != nil {
+            generationStatus = nil
+        }
+    }
+
+    private func generationLifecycle(
+        modelContext: ModelContext,
+        activeTool: BindingBox<Tool?>,
+        onPrepared: @escaping (Tool) -> Void = { _ in }
+    ) -> ToolGenerationLifecycle {
+        ToolGenerationLifecycle(
+            preservesCreatedPackageOnCancellation: true,
+            prepareCreatedTool: { preparedTool, prompt, refinedPrompt in
+                try await MainActor.run {
+                    let tool = Tool(
+                        name: preparedTool.name,
+                        executableName: preparedTool.executableName,
+                        bundleIdentifier: preparedTool.bundleIdentifier,
+                        sandboxEnabled: preparedTool.sandboxEnabled,
+                        packageRootPath: preparedTool.packageRootURL.path,
+                        lastPromptSummary: Self.promptSummary(for: prompt),
+                        generationState: .generating,
+                        generationPhase: .generatingSource,
+                        generationMode: .create,
+                        pendingPrompt: prompt,
+                        pendingRefinedPrompt: refinedPrompt
+                    )
+                    modelContext.insert(tool)
+                    try modelContext.save()
+                    activeTool.value = tool
+                    onPrepared(tool)
+                }
+            },
+            updatePhase: { state, phase, errorSummary in
+                try await MainActor.run {
+                    guard let tool = activeTool.value else { return }
+                    tool.generationState = state
+                    tool.generationPhase = phase
+                    if let errorSummary {
+                        tool.generationErrorSummary = Self.shortSummary(for: errorSummary)
+                    } else if state == .generating {
+                        tool.generationErrorSummary = nil
+                    }
+                    tool.updatedAt = .now
+                    try modelContext.save()
+                }
+            }
+        )
+    }
+
+    private func markToolGenerating(
+        _ tool: Tool,
+        mode: ToolGenerationMode,
+        phase: ToolGenerationPhase,
+        prompt: String,
+        refinedPrompt: String?
+    ) {
+        tool.generationState = .generating
+        tool.generationPhase = phase
+        tool.generationMode = mode
+        tool.pendingPrompt = prompt
+        tool.pendingRefinedPrompt = refinedPrompt
+        tool.generationErrorSummary = nil
+        tool.updatedAt = .now
+    }
+
+    private func markToolStopped(_ tool: Tool) {
+        tool.generationState = .stopped
+        tool.generationErrorSummary = nil
+        tool.updatedAt = .now
+    }
+
+    private func markToolFailed(_ tool: Tool, error: Error) {
+        tool.generationState = .failed
+        tool.generationErrorSummary = Self.shortSummary(for: generationErrorMessage(for: error))
+        tool.updatedAt = .now
+    }
+
+    private func applyCompletedGenerationResult(
+        _ result: ToolGenerationResult,
+        to tool: Tool,
+        prompt: String
+    ) {
+        tool.name = result.toolName
+        tool.executableName = result.executableName
+        tool.bundleIdentifier = result.bundleIdentifier
+        tool.sandboxEnabled = result.sandboxEnabled
+        tool.packageRootPath = result.packageRootURL.path
+        tool.lastPromptSummary = Self.promptSummary(for: prompt)
+        clearPendingGeneration(on: tool)
+    }
+
+    private func clearPendingGeneration(on tool: Tool) {
+        tool.generationState = .ready
+        tool.generationPhase = .completed
+        tool.generationMode = nil
+        tool.pendingPrompt = nil
+        tool.pendingRefinedPrompt = nil
+        tool.generationErrorSummary = nil
+        removePendingDraft(for: tool)
+        tool.updatedAt = .now
+    }
+
+    private func canContinueGeneration(_ tool: Tool) -> Bool {
+        !isGenerating && (tool.generationState == .stopped || tool.generationState == .failed)
+    }
+
+    private func removePendingDraft(for tool: Tool) {
+        let draftURL = ToolPackageLayout.pendingContentViewDraftURL(for: tool.packageRootURL)
+        guard FileManager.default.fileExists(atPath: draftURL.path) else { return }
+        try? FileManager.default.removeItem(at: draftURL)
+    }
+
+    private func removePackageIfExists(_ packageRootURL: URL) throws {
+        guard FileManager.default.fileExists(atPath: packageRootURL.path) else { return }
+        try FileManager.default.removeItem(at: packageRootURL)
+    }
+
     private static func promptSummary(for prompt: String) -> String {
         let singleLine = prompt
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return String(singleLine.prefix(160))
+    }
+
+    private static func shortSummary(for message: String) -> String {
+        let singleLine = message
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return String(singleLine.prefix(240))
     }
 
     private static func contentViewPath(for tool: Tool) throws -> String {

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -24,7 +24,6 @@ private final class BindingBox<Value> {
 final class ToolLibraryStore {
     // Tool-library UI state: which tool is selected, and what the composer should say.
     var prompt: String
-    var generationStatus: String?
     var presentedErrorMessage: String?
     var presentedErrorAction: ToolLibraryPresentedErrorAction?
     var isGenerating = false
@@ -106,7 +105,7 @@ final class ToolLibraryStore {
     }
 
     func delete(_ tool: Tool, in modelContext: ModelContext) {
-        guard !isGenerating else { return }
+        guard !(isGenerating && tool.generationState == .generating) else { return }
         handleDeletedTool(tool)
         modelContext.delete(tool)
 
@@ -158,7 +157,6 @@ final class ToolLibraryStore {
     func cancelGeneration() {
         guard isGenerating else { return }
         clearPresentedErrorState()
-        generationStatus = "Stopping"
         generationTask?.cancel()
     }
 
@@ -200,23 +198,17 @@ final class ToolLibraryStore {
         guard !isGenerating, tool.isGenerationReady else { return }
         isGenerating = true
         clearPresentedErrorState()
-        generationStatus = "Restoring \(tool.name)"
         defer {
             isGenerating = false
-            if presentedErrorMessage != nil {
-                generationStatus = nil
-            }
         }
 
         do {
             let contentViewPath = try Self.contentViewPath(for: tool)
             try dependencies.versionBackupClient.restorePreviousVersion(tool.packageRootURL, contentViewPath)
-            generationStatus = "Building \(tool.name)"
             try await dependencies.buildClient.buildTool(tool)
             clearPendingGeneration(on: tool)
             tool.updatedAt = .now
             try modelContext.save()
-            generationStatus = nil
         } catch {
             modelContext.rollback()
             presentError(error.localizedDescription)
@@ -233,7 +225,6 @@ final class ToolLibraryStore {
         var activeTool: Tool?
         isGenerating = true
         clearPresentedErrorState()
-        generationStatus = submittedToolName.map { "Preparing \($0)" } ?? "Preparing new app"
 
         do {
             let selectedTool = try fetchSelectedTool(in: modelContext)
@@ -273,9 +264,7 @@ final class ToolLibraryStore {
                 resourcePermissions,
                 languageModelContext,
                 lifecycle: lifecycle
-            ) { status in
-                self.generationStatus = status
-            }
+            ) { _ in }
 
             if let completedTool = selectedTool ?? activeTool {
                 applyCompletedGenerationResult(
@@ -300,29 +289,12 @@ final class ToolLibraryStore {
             }
             try Task.checkCancellation()
             prompt = Self.defaultPrompt
-            generationStatus = nil
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
-        } catch where IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
-            if let activeTool {
-                markToolStopped(activeTool)
-                try? modelContext.save()
-            } else {
-                modelContext.rollback()
-            }
-            clearPresentedErrorState()
-            generationStatus = nil
         } catch {
-            await refreshIronsmithCreditsIfNeeded(inferenceStore)
             if IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
-                if let activeTool {
-                    markToolStopped(activeTool)
-                    try? modelContext.save()
-                } else {
-                    modelContext.rollback()
-                }
-                clearPresentedErrorState()
-                generationStatus = nil
+                handleGenerationCancellation(activeTool, in: modelContext)
             } else {
+                await refreshIronsmithCreditsIfNeeded(inferenceStore)
                 if let activeTool {
                     markToolFailed(activeTool, error: error)
                     try? modelContext.save()
@@ -343,9 +315,6 @@ final class ToolLibraryStore {
         }
 
         isGenerating = false
-        if presentedErrorMessage != nil {
-            generationStatus = nil
-        }
     }
 
     private func refreshIronsmithCreditsIfNeeded(_ inferenceStore: InferenceStore) async {
@@ -428,19 +397,13 @@ final class ToolLibraryStore {
     func export(_ tool: Tool) async {
         guard tool.isGenerationReady, exportingToolID == nil, !isGenerating else { return }
         exportingToolID = tool.id
-        generationStatus = "Exporting \(tool.name)"
         defer {
             exportingToolID = nil
-            if presentedErrorMessage != nil {
-                generationStatus = nil
-            }
         }
 
         do {
             let exportedAppURL = try await dependencies.exportClient.exportTool(tool)
-            generationStatus = "Opening Applications"
             try await dependencies.finderClient.revealURL(exportedAppURL)
-            generationStatus = nil
         } catch {
             presentError(error.localizedDescription)
         }
@@ -498,7 +461,6 @@ final class ToolLibraryStore {
 
         isGenerating = true
         clearPresentedErrorState()
-        generationStatus = "Continuing \(tool.name)"
         let activeToolBox = BindingBox<Tool?>(tool)
         let lifecycle = generationLifecycle(
             modelContext: modelContext,
@@ -526,27 +488,16 @@ final class ToolLibraryStore {
                 resourcePermissions,
                 languageModelContext,
                 lifecycle: lifecycle
-            ) { status in
-                self.generationStatus = status
-            }
+            ) { _ in }
             applyCompletedGenerationResult(result, to: tool, prompt: resumePrompt)
             try modelContext.save()
             try Task.checkCancellation()
-            generationStatus = nil
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
-        } catch where IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
-            markToolStopped(tool)
-            try? modelContext.save()
-            clearPresentedErrorState()
-            generationStatus = nil
         } catch {
-            await refreshIronsmithCreditsIfNeeded(inferenceStore)
             if IronsmithErrorPresentation.isCancellation(error) || Task.isCancelled {
-                markToolStopped(tool)
-                try? modelContext.save()
-                clearPresentedErrorState()
-                generationStatus = nil
+                handleGenerationCancellation(tool, in: modelContext)
             } else {
+                await refreshIronsmithCreditsIfNeeded(inferenceStore)
                 markToolFailed(tool, error: error)
                 try? modelContext.save()
                 presentGenerationError(error)
@@ -554,9 +505,16 @@ final class ToolLibraryStore {
         }
 
         isGenerating = false
-        if presentedErrorMessage != nil {
-            generationStatus = nil
+    }
+
+    private func handleGenerationCancellation(_ tool: Tool?, in modelContext: ModelContext) {
+        if let tool {
+            markToolStopped(tool)
+            try? modelContext.save()
+        } else {
+            modelContext.rollback()
         }
+        clearPresentedErrorState()
     }
 
     private func generationLifecycle(
@@ -568,18 +526,35 @@ final class ToolLibraryStore {
             preservesCreatedPackageOnCancellation: true,
             prepareCreatedTool: { preparedTool, prompt in
                 try await MainActor.run {
-                    let tool = Tool(
-                        name: preparedTool.name,
-                        executableName: preparedTool.executableName,
-                        bundleIdentifier: preparedTool.bundleIdentifier,
-                        sandboxEnabled: preparedTool.sandboxEnabled,
-                        packageRootPath: preparedTool.packageRootURL.path,
-                        generationState: .generating,
-                        generationPhase: .generatingIcon,
-                        generationMode: .create,
-                        pendingPrompt: prompt
-                    )
-                    modelContext.insert(tool)
+                    let tool: Tool
+                    if let activePreparedTool = activeTool.value {
+                        tool = activePreparedTool
+                        tool.name = preparedTool.name
+                        tool.executableName = preparedTool.executableName
+                        tool.bundleIdentifier = preparedTool.bundleIdentifier
+                        tool.sandboxEnabled = preparedTool.sandboxEnabled
+                        tool.packageRootPath = preparedTool.packageRootURL.path
+                        tool.generationState = .generating
+                        tool.generationPhase = .planning
+                        tool.generationMode = .create
+                        tool.pendingPrompt = prompt
+                        tool.generationErrorSummary = nil
+                        tool.generationRepairErrorCount = nil
+                        tool.updatedAt = .now
+                    } else {
+                        tool = Tool(
+                            name: preparedTool.name,
+                            executableName: preparedTool.executableName,
+                            bundleIdentifier: preparedTool.bundleIdentifier,
+                            sandboxEnabled: preparedTool.sandboxEnabled,
+                            packageRootPath: preparedTool.packageRootURL.path,
+                            generationState: .generating,
+                            generationPhase: .planning,
+                            generationMode: .create,
+                            pendingPrompt: prompt
+                        )
+                        modelContext.insert(tool)
+                    }
                     try modelContext.save()
                     activeTool.value = tool
                     onPrepared(tool)
@@ -593,11 +568,22 @@ final class ToolLibraryStore {
                     try modelContext.save()
                 }
             },
+            updateRepairErrorCount: { count in
+                try await MainActor.run {
+                    guard let tool = activeTool.value else { return }
+                    tool.generationRepairErrorCount = count
+                    tool.updatedAt = .now
+                    try modelContext.save()
+                }
+            },
             updatePhase: { state, phase, errorSummary in
                 try await MainActor.run {
                     guard let tool = activeTool.value else { return }
                     tool.generationState = state
                     tool.generationPhase = phase
+                    if phase != .generatingRepairDiff && phase != .repairing {
+                        tool.generationRepairErrorCount = nil
+                    }
                     if let errorSummary {
                         tool.generationErrorSummary = Self.shortSummary(for: errorSummary)
                     } else if state == .generating {
@@ -621,18 +607,21 @@ final class ToolLibraryStore {
         tool.generationMode = mode
         tool.pendingPrompt = prompt
         tool.generationErrorSummary = nil
+        tool.generationRepairErrorCount = nil
         tool.updatedAt = .now
     }
 
     private func markToolStopped(_ tool: Tool) {
         tool.generationState = .stopped
         tool.generationErrorSummary = nil
+        tool.generationRepairErrorCount = nil
         tool.updatedAt = .now
     }
 
     private func markToolFailed(_ tool: Tool, error: Error) {
         tool.generationState = .failed
         tool.generationErrorSummary = Self.shortSummary(for: generationErrorMessage(for: error))
+        tool.generationRepairErrorCount = nil
         tool.updatedAt = .now
     }
 
@@ -655,6 +644,7 @@ final class ToolLibraryStore {
         tool.generationMode = nil
         tool.pendingPrompt = nil
         tool.generationErrorSummary = nil
+        tool.generationRepairErrorCount = nil
         removePendingDraft(for: tool)
         tool.updatedAt = .now
     }

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -213,7 +213,6 @@ final class ToolLibraryStore {
             try dependencies.versionBackupClient.restorePreviousVersion(tool.packageRootURL, contentViewPath)
             generationStatus = "Building \(tool.name)"
             try await dependencies.buildClient.buildTool(tool)
-            tool.lastPromptSummary = "Reverted to previous version"
             clearPendingGeneration(on: tool)
             tool.updatedAt = .now
             try modelContext.save()
@@ -252,8 +251,7 @@ final class ToolLibraryStore {
                     selectedTool,
                     mode: .edit,
                     phase: .planning,
-                    prompt: trimmedPrompt,
-                    refinedPrompt: nil
+                    prompt: trimmedPrompt
                 )
                 try modelContext.save()
             }
@@ -293,7 +291,6 @@ final class ToolLibraryStore {
                     bundleIdentifier: result.bundleIdentifier,
                     sandboxEnabled: result.sandboxEnabled,
                     packageRootPath: result.packageRootURL.path,
-                    lastPromptSummary: Self.promptSummary(for: trimmedPrompt),
                     generationState: .ready,
                     generationPhase: .completed
                 )
@@ -492,7 +489,7 @@ final class ToolLibraryStore {
         inferenceStore: InferenceStore
     ) async {
         guard canContinueGeneration(tool) else { return }
-        let resumePrompt = (tool.pendingPrompt ?? tool.lastPromptSummary ?? "")
+        let resumePrompt = (tool.pendingPrompt ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !resumePrompt.isEmpty else {
             presentError("Ironsmith does not have enough saved prompt context to continue this generation.")
@@ -517,8 +514,7 @@ final class ToolLibraryStore {
                 tool,
                 mode: tool.generationMode ?? .create,
                 phase: tool.generationPhase ?? .planning,
-                prompt: resumePrompt,
-                refinedPrompt: tool.pendingRefinedPrompt
+                prompt: resumePrompt
             )
             try modelContext.save()
 
@@ -570,7 +566,7 @@ final class ToolLibraryStore {
     ) -> ToolGenerationLifecycle {
         ToolGenerationLifecycle(
             preservesCreatedPackageOnCancellation: true,
-            prepareCreatedTool: { preparedTool, prompt, refinedPrompt in
+            prepareCreatedTool: { preparedTool, prompt in
                 try await MainActor.run {
                     let tool = Tool(
                         name: preparedTool.name,
@@ -578,17 +574,23 @@ final class ToolLibraryStore {
                         bundleIdentifier: preparedTool.bundleIdentifier,
                         sandboxEnabled: preparedTool.sandboxEnabled,
                         packageRootPath: preparedTool.packageRootURL.path,
-                        lastPromptSummary: Self.promptSummary(for: prompt),
                         generationState: .generating,
-                        generationPhase: .generatingSource,
+                        generationPhase: .generatingIcon,
                         generationMode: .create,
-                        pendingPrompt: prompt,
-                        pendingRefinedPrompt: refinedPrompt
+                        pendingPrompt: prompt
                     )
                     modelContext.insert(tool)
                     try modelContext.save()
                     activeTool.value = tool
                     onPrepared(tool)
+                }
+            },
+            updatePendingPrompt: { prompt in
+                try await MainActor.run {
+                    guard let tool = activeTool.value else { return }
+                    tool.pendingPrompt = prompt
+                    tool.updatedAt = .now
+                    try modelContext.save()
                 }
             },
             updatePhase: { state, phase, errorSummary in
@@ -612,14 +614,12 @@ final class ToolLibraryStore {
         _ tool: Tool,
         mode: ToolGenerationMode,
         phase: ToolGenerationPhase,
-        prompt: String,
-        refinedPrompt: String?
+        prompt: String
     ) {
         tool.generationState = .generating
         tool.generationPhase = phase
         tool.generationMode = mode
         tool.pendingPrompt = prompt
-        tool.pendingRefinedPrompt = refinedPrompt
         tool.generationErrorSummary = nil
         tool.updatedAt = .now
     }
@@ -646,7 +646,6 @@ final class ToolLibraryStore {
         tool.bundleIdentifier = result.bundleIdentifier
         tool.sandboxEnabled = result.sandboxEnabled
         tool.packageRootPath = result.packageRootURL.path
-        tool.lastPromptSummary = Self.promptSummary(for: prompt)
         clearPendingGeneration(on: tool)
     }
 
@@ -655,7 +654,6 @@ final class ToolLibraryStore {
         tool.generationPhase = .completed
         tool.generationMode = nil
         tool.pendingPrompt = nil
-        tool.pendingRefinedPrompt = nil
         tool.generationErrorSummary = nil
         removePendingDraft(for: tool)
         tool.updatedAt = .now
@@ -674,13 +672,6 @@ final class ToolLibraryStore {
     private func removePackageIfExists(_ packageRootURL: URL) throws {
         guard FileManager.default.fileExists(atPath: packageRootURL.path) else { return }
         try FileManager.default.removeItem(at: packageRootURL)
-    }
-
-    private static func promptSummary(for prompt: String) -> String {
-        let singleLine = prompt
-            .replacingOccurrences(of: "\n", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return String(singleLine.prefix(160))
     }
 
     private static func shortSummary(for message: String) -> String {

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
@@ -12,23 +12,15 @@ extension AgentPipelineTests {
         let toolsDirectory = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: toolsDirectory) }
 
-        let cancellationCapture = CancellationCapture()
-        let model = StubAgentLanguageModel { _, _ in
-            await cancellationCapture.recordStarted()
-            do {
-                try await Task.sleep(nanoseconds: 10_000_000_000)
-            } catch is CancellationError {
-                await cancellationCapture.recordCancelled()
-                throw CancellationError()
-            }
-            return """
+        let probe = StreamingResponseProbe()
+        let model = PartialThenSuspendingLanguageModel(
+            partialResponse: """
             import SwiftUI
 
             struct ContentView: View {
-                var body: some View { Text("Too late") }
-            }
-            """
-        }
+            """,
+            probe: probe
+        )
         let runtime = Self.makeRuntime(
             languageModel: model,
             generationOptions: GenerationOptions(),
@@ -45,7 +37,7 @@ extension AgentPipelineTests {
             try await runtime.generateTool(for: "Build a cancellable tool", status: { _ in })
         }
         await Self.eventually {
-            await cancellationCapture.hasStarted
+            await probe.didStart
         }
         task.cancel()
 
@@ -57,7 +49,6 @@ extension AgentPipelineTests {
         }
 
         let packageRoot = toolsDirectory.appendingPathComponent("cancel-tool", isDirectory: true)
-        #expect(await cancellationCapture.wasCancelled)
         #expect(!(FileManager.default.fileExists(atPath: packageRoot.path)))
     }
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
@@ -77,6 +77,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: .noOp(),
+            iconClient: .noOp,
             metadataClient: .fallback()
         )
         let store = ToolLibraryStore(
@@ -156,6 +157,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: appBundleClient,
+            iconClient: .noOp,
             metadataClient: ToolMetadataClient { _ in
                 ToolMetadataSuggestion(
                     displayName: "Focus Pad",
@@ -193,7 +195,7 @@ extension AgentPipelineTests {
         let tool = try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
         #expect(tool.name == "Focus Pad")
         #expect(tool.executableName == "FocusPad")
-        #expect(tool.lastPromptSummary == "Build a focused notes helper with quick tags")
+        #expect(tool.pendingPrompt == nil)
         #expect(tool.packageRootURL.lastPathComponent == "focus-pad")
         #expect(FileManager.default.fileExists(atPath: tool.packageRootURL.appendingPathComponent("Sources/FocusPad/FocusPad.swift").path))
         #expect(await appBundleCapture.builtRequests.first?.iconPrompt == iconPrompt)
@@ -237,6 +239,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: .noOp(),
+            iconClient: .noOp,
             metadataClient: .fallback()
         )
         let store = ToolLibraryStore(
@@ -302,6 +305,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: .noOp(),
+            iconClient: .noOp,
             metadataClient: .fallback()
         )
         let store = ToolLibraryStore(

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
@@ -72,7 +72,7 @@ extension AgentPipelineTests {
         let tools = try context.fetch(FetchDescriptor<StoredTool>())
         #expect(tools.count == 1)
         #expect(tools.first?.id == existingTool.id)
-        #expect(tools.first?.lastPromptSummary == "Add down payment support")
+        #expect(tools.first?.pendingPrompt == nil)
         #expect(!(tools.first?.sandboxEnabled ?? false))
         #expect(await capture.existingToolID == existingTool.id)
         #expect(!((await capture.sandboxEnabled) ?? false))

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -203,8 +203,7 @@ extension AgentPipelineTests {
             bundleIdentifier: "com.ironsmith.tests.sandboxed-tool",
             packageRootURL: packageRoot,
             sandboxEnabled: true,
-            resourcePermissions: GeneratedAppResourcePermissions(GeneratedAppResourcePermission.allCases),
-            promptSummary: "Build a sandboxed tool"
+            resourcePermissions: GeneratedAppResourcePermissions(GeneratedAppResourcePermission.allCases)
         )
 
         let appURL = try await client.buildInternalApp(request)
@@ -271,8 +270,7 @@ extension AgentPipelineTests {
                 bundleIdentifier: "com.ironsmith.tests.\(executableName.lowercased())",
                 packageRootURL: packageRoot,
                 sandboxEnabled: true,
-                sandboxPermissions: sandboxPermissions,
-                promptSummary: nil
+                sandboxPermissions: sandboxPermissions
             )
             let client = ToolAppBundleClient.live(
                 processClient: processClient,
@@ -399,8 +397,7 @@ extension AgentPipelineTests {
             bundleIdentifier: "com.ironsmith.tests.exported-tool",
             packageRootURL: packageRoot,
             sandboxEnabled: false,
-            resourcePermissions: GeneratedAppResourcePermissions([.contacts, .photoLibrary, .appleEvents]),
-            promptSummary: nil
+            resourcePermissions: GeneratedAppResourcePermissions([.contacts, .photoLibrary, .appleEvents])
         )
 
         let appURL = try await client.exportApp(request, applicationsDirectory)
@@ -479,8 +476,7 @@ extension AgentPipelineTests {
             executableName: "RestoredTool",
             bundleIdentifier: "com.ironsmith.tests.restored-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: false,
-            promptSummary: nil
+            sandboxEnabled: false
         )
 
         do {
@@ -541,8 +537,7 @@ extension AgentPipelineTests {
             executableName: "NoIconTool",
             bundleIdentifier: "com.ironsmith.tests.no-icon-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: true,
-            promptSummary: nil
+            sandboxEnabled: true
         )
 
         let appURL = try await client.buildInternalApp(request)
@@ -589,7 +584,6 @@ extension AgentPipelineTests {
         let iconURL = try await client.ensureIconAssets(
             ToolIconRequest(
                 displayName: "Fallback Icon",
-                promptSummary: "Build a test tool",
                 iconPrompt: iconPrompt,
                 layout: layout
             )
@@ -628,14 +622,12 @@ extension AgentPipelineTests {
         _ = try await client.ensureIconAssets(
             ToolIconRequest(
                 displayName: "Amber Oak",
-                promptSummary: nil,
                 layout: amberLayout
             )
         )
         _ = try await client.ensureIconAssets(
             ToolIconRequest(
                 displayName: "Azure Opal",
-                promptSummary: nil,
                 layout: azureLayout
             )
         )

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
@@ -7,6 +7,69 @@ import Testing
 extension AgentPipelineTests {
     @MainActor
     @Test
+    func createGenerationPersistsPlaceholderToolBeforeMetadataCompletes() async throws {
+        let toolsDirectory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let metadataGate = MetadataGenerationGate()
+        defer {
+            Task {
+                await metadataGate.release()
+            }
+        }
+
+        let generationClient = ToolGenerationClient.live(
+            toolsDirectoryURL: toolsDirectory,
+            processClient: Self.successfulProcessClient(),
+            appBundleClient: .noOp(),
+            iconClient: .noOp,
+            metadataClient: ToolMetadataClient { _ in
+                await metadataGate.waitForRelease()
+                return ToolMetadataSuggestion(displayName: "Named Later", iconPrompt: "")
+            },
+            promptRefinementClient: .disabled()
+        )
+        let store = ToolLibraryStore(
+            dependencies: ToolLibraryDependencies(
+                generationClient: generationClient,
+                runnerClient: ToolRunnerClient { _ in }
+            )
+        )
+        let inferenceStore = Self.inferenceStore(
+            languageModel: StubAgentLanguageModel.fixed(Self.simpleContentViewSource(text: "ready"))
+        )
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+
+        let prompt = "Build a named later app"
+        store.prompt = prompt
+        store.startPromptSubmission(modelContext: context, inferenceStore: inferenceStore)
+
+        let placeholderTool = try await waitForFirstTool(in: context) { tool in
+            tool.name == "New App"
+                && tool.generationState == .generating
+                && tool.generationPhase == .planning
+                && tool.generationMode == .create
+        }
+
+        #expect(placeholderTool.pendingPrompt == prompt)
+        #expect(!(FileManager.default.fileExists(atPath: placeholderTool.packageManifestURL.path)))
+
+        await metadataGate.release()
+        let completedTool = try await waitForFirstTool(in: context) { tool in
+            tool.id == placeholderTool.id && tool.generationState == .ready
+        }
+
+        #expect(completedTool.name == "Named Later")
+        #expect(completedTool.executableName == "NamedLater")
+        #expect(completedTool.packageRootURL.lastPathComponent == "named-later")
+        #expect(FileManager.default.fileExists(atPath: completedTool.packageManifestURL.path))
+        #expect(store.presentedErrorMessage == nil)
+        #expect(!(store.isGenerating))
+    }
+
+    @MainActor
+    @Test
     func createGenerationPersistsStoppedToolAndDraftWhenCancelledDuringSourceStream() async throws {
         let toolsDirectory = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: toolsDirectory) }
@@ -69,7 +132,6 @@ extension AgentPipelineTests {
         #expect(stoppedTool.pendingPrompt == prompt)
         #expect(FileManager.default.fileExists(atPath: draftURL.path))
         #expect(store.presentedErrorMessage == nil)
-        #expect(store.generationStatus == nil)
         #expect(!(store.isGenerating))
     }
 
@@ -219,5 +281,24 @@ extension AgentPipelineTests {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
         return try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
+    }
+}
+
+private actor MetadataGenerationGate {
+    private var isReleased = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func waitForRelease() async {
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        continuation?.resume()
+        continuation = nil
     }
 }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
@@ -1,0 +1,223 @@
+import AnyLanguageModel
+import Foundation
+import SwiftData
+import Testing
+@testable import Ironsmith
+
+extension AgentPipelineTests {
+    @MainActor
+    @Test
+    func createGenerationPersistsStoppedToolAndDraftWhenCancelledDuringSourceStream() async throws {
+        let toolsDirectory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let partialSource = """
+        import SwiftUI
+
+        struct ContentView: View {
+        """
+        let probe = StreamingResponseProbe()
+        let generationClient = ToolGenerationClient.live(
+            toolsDirectoryURL: toolsDirectory,
+            processClient: Self.successfulProcessClient(),
+            appBundleClient: .noOp(),
+            metadataClient: ToolMetadataClient { _ in
+                ToolMetadataSuggestion(displayName: "Paused Tool", iconPrompt: "")
+            },
+            promptRefinementClient: .disabled()
+        )
+        let store = ToolLibraryStore(
+            dependencies: ToolLibraryDependencies(
+                generationClient: generationClient,
+                runnerClient: ToolRunnerClient { _ in }
+            )
+        )
+        let inferenceStore = Self.inferenceStore(
+            languageModel: PartialThenSuspendingLanguageModel(
+                partialResponse: partialSource,
+                probe: probe
+            )
+        )
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+
+        let prompt = "Build a tool that can pause"
+        store.prompt = prompt
+        store.startPromptSubmission(modelContext: context, inferenceStore: inferenceStore)
+
+        let generatingTool = try await waitForFirstTool(in: context) { tool in
+            let draftURL = ToolPackageLayout.pendingContentViewDraftURL(for: tool.packageRootURL)
+            return tool.generationState == .generating
+                && tool.generationPhase == .generatingSource
+                && FileManager.default.fileExists(atPath: draftURL.path)
+        }
+        let draftURL = ToolPackageLayout.pendingContentViewDraftURL(for: generatingTool.packageRootURL)
+        #expect(generatingTool.generationMode == .create)
+        #expect(generatingTool.pendingPrompt == prompt)
+        #expect(try String(contentsOf: draftURL, encoding: .utf8) == partialSource)
+        #expect(await probe.didStart)
+
+        store.cancelGeneration()
+        let stoppedTool = try await waitForFirstTool(in: context) { tool in
+            tool.generationState == .stopped
+        }
+
+        #expect(stoppedTool.id == generatingTool.id)
+        #expect(stoppedTool.generationPhase == .generatingSource)
+        #expect(stoppedTool.generationMode == .create)
+        #expect(stoppedTool.pendingPrompt == prompt)
+        #expect(FileManager.default.fileExists(atPath: draftURL.path))
+        #expect(store.presentedErrorMessage == nil)
+        #expect(store.generationStatus == nil)
+        #expect(!(store.isGenerating))
+    }
+
+    @MainActor
+    @Test
+    func resumePartialSourceContinuesDraftBeforeBuilding() async throws {
+        let toolsDirectory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let executableName = "ResumeCreate"
+        let tool = try Self.makeExistingTool(
+            toolsDirectory: toolsDirectory,
+            executableName: executableName,
+            source: ""
+        )
+        let layout = ToolPackageLayout(packageRootURL: tool.packageRootURL, executableName: executableName)
+        let partialSource = """
+        import SwiftUI
+
+        struct ContentView: View {
+            var body: some View {
+                Text("res
+        """
+        let continuation = """
+        umed")
+            }
+        }
+        """
+        try FileManager.default.createDirectory(at: layout.packageMetadataDirectoryURL, withIntermediateDirectories: true)
+        try partialSource.write(to: layout.pendingContentViewDraftURL, atomically: true, encoding: .utf8)
+        tool.generationState = .stopped
+        tool.generationPhase = .generatingSource
+        tool.generationMode = .create
+        tool.pendingPrompt = "Build a resumable source app"
+        tool.pendingRefinedPrompt = "Build a focused resumable source app"
+
+        let promptCapture = PromptCapture()
+        let runtime = Self.makeRuntime(
+            languageModel: StubAgentLanguageModel { prompt, _ in
+                await promptCapture.record(prompt)
+                return continuation
+            },
+            repairStrategy: .deterministicOnly,
+            toolsDirectoryURL: toolsDirectory,
+            processClient: Self.successfulProcessClient(),
+            appBundleClient: .noOp(),
+            metadataClient: .fallback()
+        )
+
+        let result = try await runtime.generateTool(
+            for: "ignored because pending prompt is stored",
+            existingTool: tool,
+            status: { _ in }
+        )
+
+        let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
+        #expect(contentView.contains(#"Text("resumed")"#))
+        #expect(!(FileManager.default.fileExists(atPath: layout.pendingContentViewDraftURL.path)))
+        let prompts = await promptCapture.prompts
+        #expect(prompts.count == 1)
+        #expect(prompts.first?.contains("Continue the exact Swift source response") == true)
+        #expect(prompts.first?.contains(partialSource) == true)
+    }
+
+    @MainActor
+    @Test
+    func resumePartialEditDiffContinuesDraftAndAppliesCombinedDiff() async throws {
+        let toolsDirectory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let executableName = "ResumeEdit"
+        let tool = try Self.makeExistingTool(
+            toolsDirectory: toolsDirectory,
+            executableName: executableName,
+            source: Self.originalEditableSource
+        )
+        let layout = ToolPackageLayout(packageRootURL: tool.packageRootURL, executableName: executableName)
+        let contentViewURL = layout.sourceDirectoryURL.appendingPathComponent(layout.defaultContentViewFileName)
+        let partialDiff = """
+        --- ContentView.swift
+        +++ ContentView.swift
+        @@
+         struct ContentView: View {
+             var body: some View {
+        -        Text("old")
+        +        Text("
+        """
+        let continuation = """
+        new")
+             }
+         }
+        """
+        try FileManager.default.createDirectory(at: layout.packageMetadataDirectoryURL, withIntermediateDirectories: true)
+        try partialDiff.write(to: layout.pendingContentViewDraftURL, atomically: true, encoding: .utf8)
+        tool.generationState = .stopped
+        tool.generationPhase = .generatingEditDiff
+        tool.generationMode = .edit
+        tool.pendingPrompt = "Change old to new"
+
+        let sourceBeforeResume = try String(contentsOf: contentViewURL, encoding: .utf8)
+        #expect(sourceBeforeResume.contains(#"Text("old")"#))
+
+        let promptCapture = PromptCapture()
+        let runtime = Self.makeRuntime(
+            languageModel: StubAgentLanguageModel { prompt, _ in
+                await promptCapture.record(prompt)
+                return continuation
+            },
+            repairStrategy: .modelDiff(maxHunksPerTurn: 1),
+            toolsDirectoryURL: toolsDirectory,
+            processClient: Self.successfulProcessClient(),
+            appBundleClient: .noOp(),
+            metadataClient: .fallback()
+        )
+
+        let result = try await runtime.generateTool(
+            for: "ignored because pending prompt is stored",
+            existingTool: tool,
+            status: { _ in }
+        )
+
+        let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
+        let previousSource = try String(
+            contentsOf: layout.previousContentViewVersionURL,
+            encoding: .utf8
+        )
+        #expect(contentView.contains(#"Text("new")"#))
+        #expect(!(contentView.contains(#"Text("old")"#)))
+        #expect(previousSource.contains(#"Text("old")"#))
+        #expect(!(FileManager.default.fileExists(atPath: layout.pendingContentViewDraftURL.path)))
+        let prompts = await promptCapture.prompts
+        #expect(prompts.count == 1)
+        #expect(prompts.first?.contains("Continue the exact unified diff response") == true)
+        #expect(prompts.first?.contains(partialDiff) == true)
+    }
+
+    @MainActor
+    private func waitForFirstTool(
+        in context: ModelContext,
+        matching predicate: (StoredTool) -> Bool
+    ) async throws -> StoredTool {
+        let deadline = DispatchTime.now().uptimeNanoseconds + 1_000_000_000
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            let tools = try context.fetch(FetchDescriptor<StoredTool>())
+            if let tool = tools.first(where: predicate) {
+                return tool
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
+    }
+}

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
@@ -21,6 +21,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
+            iconClient: .noOp,
             metadataClient: ToolMetadataClient { _ in
                 ToolMetadataSuggestion(displayName: "Paused Tool", iconPrompt: "")
             },
@@ -102,8 +103,7 @@ extension AgentPipelineTests {
         tool.generationState = .stopped
         tool.generationPhase = .generatingSource
         tool.generationMode = .create
-        tool.pendingPrompt = "Build a resumable source app"
-        tool.pendingRefinedPrompt = "Build a focused resumable source app"
+        tool.pendingPrompt = "Build a focused resumable source app"
 
         let promptCapture = PromptCapture()
         let runtime = Self.makeRuntime(

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
@@ -272,7 +272,7 @@ extension AgentPipelineTests {
         in context: ModelContext,
         matching predicate: (StoredTool) -> Bool
     ) async throws -> StoredTool {
-        let deadline = DispatchTime.now().uptimeNanoseconds + 1_000_000_000
+        let deadline = DispatchTime.now().uptimeNanoseconds + 5_000_000_000
         while DispatchTime.now().uptimeNanoseconds < deadline {
             let tools = try context.fetch(FetchDescriptor<StoredTool>())
             if let tool = tools.first(where: predicate) {
@@ -280,7 +280,9 @@ extension AgentPipelineTests {
             }
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        return try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
+        let tools = try context.fetch(FetchDescriptor<StoredTool>())
+        let matchingTool = tools.first(where: predicate)
+        return try #require(matchingTool)
     }
 }
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
@@ -337,6 +337,10 @@ actor PromptCapture {
     func record(_ prompt: Prompt) {
         prompts.append(String(describing: prompt))
     }
+
+    func record(_ promptDescription: String) {
+        prompts.append(promptDescription)
+    }
 }
 
 actor GenerationOptionsCapture {
@@ -679,24 +683,98 @@ struct StubAgentLanguageModel: LanguageModel {
         options: GenerationOptions
     ) -> sending LanguageModelSession.ResponseStream<Content> where Content: Generable {
         let responseProvider = self.responseProvider
+        let yieldState = SingleYieldState()
+        let stream = AsyncThrowingStream<LanguageModelSession.ResponseStream<Content>.Snapshot, any Error>(
+            unfolding: {
+                guard await yieldState.claim() else { return nil }
+                guard type == String.self else {
+                    throw FakeAgentError.unsupportedStructuredGeneration
+                }
+                let text = try await responseProvider(prompt, options)
+                return .init(
+                    content: (text as! Content).asPartiallyGenerated(),
+                    rawContent: GeneratedContent(text)
+                )
+            }
+        )
+        return LanguageModelSession.ResponseStream(stream: stream)
+    }
+}
+
+private actor SingleYieldState {
+    private var hasYielded = false
+
+    func claim() -> Bool {
+        guard !hasYielded else { return false }
+        hasYielded = true
+        return true
+    }
+}
+
+actor StreamingResponseProbe {
+    private(set) var prompts: [String] = []
+    private(set) var didStart = false
+    private(set) var didCancel = false
+
+    func recordStart(promptDescription: String) {
+        didStart = true
+        prompts.append(promptDescription)
+    }
+
+    func recordCancel() {
+        didCancel = true
+    }
+}
+
+struct PartialThenSuspendingLanguageModel: LanguageModel {
+    typealias UnavailableReason = Never
+
+    let partialResponse: String
+    let probe: StreamingResponseProbe
+
+    func respond<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) async throws -> LanguageModelSession.Response<Content> where Content: Generable {
+        throw FakeAgentError.expected
+    }
+
+    func streamResponse<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) -> sending LanguageModelSession.ResponseStream<Content> where Content: Generable {
+        let partialResponse = self.partialResponse
+        let probe = self.probe
+        let promptDescription = String(describing: prompt)
         let stream = AsyncThrowingStream<LanguageModelSession.ResponseStream<Content>.Snapshot, any Error> {
             continuation in
-            Task {
+            let task = Task {
                 do {
                     guard type == String.self else {
                         throw FakeAgentError.unsupportedStructuredGeneration
                     }
-                    let text = try await responseProvider(prompt, options)
+                    await probe.recordStart(promptDescription: promptDescription)
                     continuation.yield(
                         .init(
-                            content: (text as! Content).asPartiallyGenerated(),
-                            rawContent: GeneratedContent(text)
+                            content: (partialResponse as! Content).asPartiallyGenerated(),
+                            rawContent: GeneratedContent(partialResponse)
                         )
                     )
+                    try await Task.sleep(nanoseconds: 10_000_000_000)
                     continuation.finish()
                 } catch {
+                    await probe.recordCancel()
                     continuation.finish(throwing: error)
                 }
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
             }
         }
         return LanguageModelSession.ResponseStream(stream: stream)

--- a/IronsmithTests/Core/Persistence/PersistenceTests.swift
+++ b/IronsmithTests/Core/Persistence/PersistenceTests.swift
@@ -42,6 +42,53 @@ struct PersistenceTests {
         #expect(tool.appBundleURL.lastPathComponent == "Clipboard Cleaner.app")
     }
 
+    @MainActor
+    @Test
+    func diskBackedModelContainerReopensCurrentToolSchema() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ironsmith-persistence-tests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let storeURL = root.appendingPathComponent("ironsmith.sqlite")
+        let config = ModelConfiguration(url: storeURL)
+
+        do {
+            let container = try ModelContainer(
+                for: Tool.self,
+                ModelConfig.self,
+                ProviderConfig.self,
+                configurations: config
+            )
+            let context = ModelContext(container)
+            context.insert(
+                Tool(
+                    name: "Incomplete",
+                    packageRootPath: "/tmp/incomplete",
+                    generationState: .stopped,
+                    generationPhase: .generatingSource,
+                    generationMode: .create,
+                    pendingPrompt: "Build a resumable app"
+                )
+            )
+            try context.save()
+        }
+
+        do {
+            let container = try ModelContainer(
+                for: Tool.self,
+                ModelConfig.self,
+                ProviderConfig.self,
+                configurations: config
+            )
+            let context = ModelContext(container)
+            let tool = try #require(try context.fetch(FetchDescriptor<Tool>()).first)
+            #expect(tool.generationState == .stopped)
+            #expect(tool.generationPhase == .generatingSource)
+            #expect(tool.generationMode == .create)
+            #expect(tool.pendingPrompt == "Build a resumable app")
+        }
+    }
+
     @Test
     func generatedBundleIdentifiersUseASCIISafeComponents() throws {
         let id = try #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
@@ -27,7 +27,6 @@ extension ToolLibraryTests {
         await store.submitPrompt(modelContext: context, inferenceStore: inferenceStore)
 
         #expect(store.presentedErrorMessage == nil)
-        #expect(store.generationStatus == nil)
         #expect(!(store.isGenerating))
     }
 
@@ -56,7 +55,6 @@ extension ToolLibraryTests {
         await store.submitPrompt(modelContext: context, inferenceStore: inferenceStore)
 
         #expect(store.presentedErrorMessage == nil)
-        #expect(store.generationStatus == nil)
         #expect(!(store.isGenerating))
     }
 
@@ -73,7 +71,6 @@ extension ToolLibraryTests {
 
         #expect(store.presentedErrorMessage == InferenceMessages.noAvailableModels)
         #expect(store.presentedErrorAction == nil)
-        #expect(store.generationStatus == nil)
         #expect(!(store.isGenerating))
     }
 
@@ -114,7 +111,6 @@ extension ToolLibraryTests {
 
         #expect(store.presentedErrorMessage == InferenceStoreError.insufficientIronsmithCredits.localizedDescription)
         #expect(store.presentedErrorAction == .buyIronsmithCredits)
-        #expect(store.generationStatus == nil)
         #expect(!(store.isGenerating))
     }
 
@@ -154,7 +150,6 @@ extension ToolLibraryTests {
 
         #expect(store.presentedErrorMessage == "There was an error generating your app. Please try again.")
         #expect(store.presentedErrorAction == nil)
-        #expect(store.generationStatus == nil)
         #expect(!(store.isGenerating))
     }
 

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
@@ -60,6 +60,115 @@ extension ToolLibraryTests {
 
     @MainActor
     @Test
+    func toolLibraryStoreKeepsLateCanceledSuccessfulCreateReady() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let inferenceStore = InferenceStore(dependencies: Self.inferenceDependencies())
+        await inferenceStore.loadIfNeeded(modelContext: context)
+
+        let packageRoot = root.appendingPathComponent("LateCreate", isDirectory: true)
+        let manifest = ToolManifest(displayName: "Late Create", executableName: "LateCreate", files: [])
+        let gate = LateGenerationCompletionGate()
+        let store = ToolLibraryStore(
+            dependencies: ToolLibraryDependencies(
+                generationClient: ToolGenerationClient(withLifecycle: { prompt, _, sandboxEnabled, _, _, _, lifecycle, _ in
+                    try await lifecycle.prepareCreatedTool(
+                        ToolGenerationPreparedTool(
+                            name: "Late Create",
+                            executableName: "LateCreate",
+                            bundleIdentifier: ToolBundleIdentifier.make(executableName: "LateCreate"),
+                            sandboxEnabled: sandboxEnabled,
+                            packageRootURL: packageRoot,
+                            manifest: manifest
+                        ),
+                        prompt
+                    )
+                    await gate.startAndWaitForRelease()
+                    return ToolGenerationResult(
+                        toolName: "Late Create",
+                        executableName: "LateCreate",
+                        packageRootURL: packageRoot,
+                        manifest: manifest
+                    )
+                }),
+                runnerClient: ToolRunnerClient { _ in }
+            )
+        )
+        store.prompt = "Build a late finishing create"
+        store.startPromptSubmission(modelContext: context, inferenceStore: inferenceStore)
+
+        await gate.waitForStart()
+        store.cancelGeneration()
+        await gate.release()
+        await Self.waitForIdle(store)
+
+        let tool = try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
+        #expect(tool.generationState == .ready)
+        #expect(tool.generationPhase == .completed)
+        #expect(tool.generationMode == nil)
+        #expect(tool.pendingPrompt == nil)
+        #expect(store.presentedErrorMessage == nil)
+    }
+
+    @MainActor
+    @Test
+    func toolLibraryStoreKeepsLateCanceledSuccessfulResumeReady() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let inferenceStore = InferenceStore(dependencies: Self.inferenceDependencies())
+        await inferenceStore.loadIfNeeded(modelContext: context)
+
+        let packageRoot = root.appendingPathComponent("LateResume", isDirectory: true)
+        let manifest = ToolManifest(displayName: "Late Resume", executableName: "LateResume", files: [])
+        let tool = StoredTool(
+            name: "Late Resume",
+            executableName: "LateResume",
+            packageRootPath: packageRoot.path,
+            generationState: .stopped,
+            generationPhase: .generatingSource,
+            generationMode: .create,
+            pendingPrompt: "Resume a late finishing app"
+        )
+        context.insert(tool)
+        try context.save()
+
+        let gate = LateGenerationCompletionGate()
+        let store = ToolLibraryStore(
+            dependencies: ToolLibraryDependencies(
+                generationClient: ToolGenerationClient(withLifecycle: { _, _, _, _, _, _, _, _ in
+                    await gate.startAndWaitForRelease()
+                    return ToolGenerationResult(
+                        toolName: "Late Resume",
+                        executableName: "LateResume",
+                        packageRootURL: packageRoot,
+                        manifest: manifest
+                    )
+                }),
+                runnerClient: ToolRunnerClient { _ in }
+            )
+        )
+        store.continueGeneration(tool, modelContext: context, inferenceStore: inferenceStore)
+
+        await gate.waitForStart()
+        store.cancelGeneration()
+        await gate.release()
+        await Self.waitForIdle(store)
+
+        #expect(tool.generationState == .ready)
+        #expect(tool.generationPhase == .completed)
+        #expect(tool.generationMode == nil)
+        #expect(tool.pendingPrompt == nil)
+        #expect(store.presentedErrorMessage == nil)
+    }
+
+    @MainActor
+    @Test
     func toolLibraryStoreShowsNoModelMessageWhenGenerationHasNoSelectedModel() async throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
@@ -200,5 +309,47 @@ extension ToolLibraryTests {
         #expect(inferenceStore.ironsmithAccountSummary?.credits.balanceCredits == 84)
         #expect(store.presentedErrorMessage == nil)
         #expect(!(store.isGenerating))
+    }
+}
+
+private actor LateGenerationCompletionGate {
+    private var isStarted = false
+    private var isReleased = false
+    private var startContinuations: [CheckedContinuation<Void, Never>] = []
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+
+    func startAndWaitForRelease() async {
+        isStarted = true
+        startContinuations.forEach { $0.resume() }
+        startContinuations.removeAll()
+
+        guard !isReleased else { return }
+        await withCheckedContinuation { continuation in
+            releaseContinuation = continuation
+        }
+    }
+
+    func waitForStart() async {
+        guard !isStarted else { return }
+        await withCheckedContinuation { continuation in
+            startContinuations.append(continuation)
+        }
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        releaseContinuation?.resume()
+        releaseContinuation = nil
+    }
+}
+
+extension ToolLibraryTests {
+    @MainActor
+    static func waitForIdle(_ store: ToolLibraryStore) async {
+        let deadline = DispatchTime.now().uptimeNanoseconds + 1_000_000_000
+        while store.isGenerating && DispatchTime.now().uptimeNanoseconds < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
     }
 }

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -173,7 +173,7 @@ extension ToolLibraryTests {
         #expect(restoredSource == #"Text("previous")"#)
         #expect(swappedPreviousSource == #"Text("current")"#)
         #expect(await buildCapture.builtPackageRoot == packageRoot)
-        #expect(tool.lastPromptSummary == "Reverted to previous version")
+        #expect(tool.generationState == .ready)
         #expect(store.generationStatus == nil)
     }
 

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -102,6 +102,34 @@ extension ToolLibraryTests {
 
     @MainActor
     @Test
+    func toolLibraryStoreDeleteRemovesReadyToolPackage() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let packageRoot = root.appendingPathComponent("ReadyTool", isDirectory: true)
+        try FileManager.default.createDirectory(at: packageRoot, withIntermediateDirectories: true)
+        try "package".write(
+            to: packageRoot.appendingPathComponent("Package.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let tool = Tool(name: "Ready Tool", packageRootPath: packageRoot.path)
+        context.insert(tool)
+        try context.save()
+
+        let store = ToolLibraryStore()
+        store.delete(tool, in: context)
+
+        #expect(try context.fetch(FetchDescriptor<StoredTool>()).isEmpty)
+        #expect(!(FileManager.default.fileExists(atPath: packageRoot.path)))
+        #expect(store.presentedErrorMessage == nil)
+    }
+
+    @MainActor
+    @Test
     func toolLibraryStoreDoesNotDeleteActiveGeneratingTool() throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -75,6 +75,57 @@ extension ToolLibraryTests {
 
     @MainActor
     @Test
+    func toolLibraryStoreDeletesReadyToolWhileAnotherToolIsGenerating() throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let readyTool = Tool(name: "Ready Tool", packageRootPath: "/tmp/ready-tool")
+        let generatingTool = Tool(
+            name: "Generating Tool",
+            packageRootPath: "/tmp/generating-tool",
+            generationState: .generating,
+            generationPhase: .generatingSource,
+            generationMode: .create
+        )
+        context.insert(readyTool)
+        context.insert(generatingTool)
+        try context.save()
+
+        let store = ToolLibraryStore()
+        store.isGenerating = true
+        store.delete(readyTool, in: context)
+
+        let tools = try context.fetch(FetchDescriptor<StoredTool>())
+        #expect(!tools.contains { $0.id == readyTool.id })
+        #expect(tools.contains { $0.id == generatingTool.id })
+        #expect(store.presentedErrorMessage == nil)
+    }
+
+    @MainActor
+    @Test
+    func toolLibraryStoreDoesNotDeleteActiveGeneratingTool() throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let generatingTool = Tool(
+            name: "Generating Tool",
+            packageRootPath: "/tmp/generating-tool",
+            generationState: .generating,
+            generationPhase: .generatingSource,
+            generationMode: .create
+        )
+        context.insert(generatingTool)
+        try context.save()
+
+        let store = ToolLibraryStore()
+        store.isGenerating = true
+        store.delete(generatingTool, in: context)
+
+        let tools = try context.fetch(FetchDescriptor<StoredTool>())
+        #expect(tools.contains { $0.id == generatingTool.id })
+        #expect(store.presentedErrorMessage == nil)
+    }
+
+    @MainActor
+    @Test
     func toolLibraryStoreManualRunCallsRunner() async {
         let tool = Tool(name: "Runner", packageRootPath: "/tmp/runner")
         let runCapture = ToolRunCapture()
@@ -174,7 +225,6 @@ extension ToolLibraryTests {
         #expect(swappedPreviousSource == #"Text("current")"#)
         #expect(await buildCapture.builtPackageRoot == packageRoot)
         #expect(tool.generationState == .ready)
-        #expect(store.generationStatus == nil)
     }
 
     @MainActor
@@ -217,7 +267,6 @@ extension ToolLibraryTests {
         #expect(await capture.exportedToolID == tool.id)
         #expect(await finderCapture.openedURL == URL(fileURLWithPath: "/Applications/Exporter.app", isDirectory: true))
         #expect(store.exportingToolID == nil)
-        #expect(store.generationStatus == nil)
         #expect(store.presentedErrorMessage == nil)
     }
 

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -350,4 +350,80 @@ extension ToolLibraryTests {
         #expect(await capture.openedURL == nil)
         #expect(store.presentedErrorMessage?.contains("outside the generated package") == true)
     }
+
+    @MainActor
+    @Test
+    func toolLibraryStoreDiscardRemovesIncompleteCreateToolAndPackage() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let packageRoot = root.appendingPathComponent("IncompleteCreate", isDirectory: true)
+        let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: "IncompleteCreate")
+        try FileManager.default.createDirectory(at: layout.packageMetadataDirectoryURL, withIntermediateDirectories: true)
+        try "partial source".write(to: layout.pendingContentViewDraftURL, atomically: true, encoding: .utf8)
+
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let tool = Tool(
+            name: "Incomplete Create",
+            executableName: "IncompleteCreate",
+            packageRootPath: packageRoot.path,
+            generationState: .failed,
+            generationPhase: .generatingSource,
+            generationMode: .create,
+            pendingPrompt: "Build an incomplete create"
+        )
+        context.insert(tool)
+        try context.save()
+
+        let store = ToolLibraryStore()
+        store.discardGeneration(tool, in: context)
+
+        #expect(try context.fetch(FetchDescriptor<StoredTool>()).isEmpty)
+        #expect(!(FileManager.default.fileExists(atPath: packageRoot.path)))
+        #expect(store.presentedErrorMessage == nil)
+    }
+
+    @MainActor
+    @Test
+    func toolLibraryStoreDiscardClearsIncompleteEditAndKeepsPackage() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let packageRoot = root.appendingPathComponent("IncompleteEdit", isDirectory: true)
+        let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: "IncompleteEdit")
+        let contentViewURL = layout.sourceDirectoryURL.appendingPathComponent(layout.defaultContentViewFileName)
+        try FileManager.default.createDirectory(at: layout.sourceDirectoryURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: layout.packageMetadataDirectoryURL, withIntermediateDirectories: true)
+        try #"Text("last ready")"#.write(to: contentViewURL, atomically: true, encoding: .utf8)
+        try "partial diff".write(to: layout.pendingContentViewDraftURL, atomically: true, encoding: .utf8)
+
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let tool = Tool(
+            name: "Incomplete Edit",
+            executableName: "IncompleteEdit",
+            packageRootPath: packageRoot.path,
+            generationState: .stopped,
+            generationPhase: .generatingEditDiff,
+            generationMode: .edit,
+            pendingPrompt: "Edit this app",
+            generationErrorSummary: "Stopped"
+        )
+        context.insert(tool)
+        try context.save()
+
+        let store = ToolLibraryStore()
+        store.discardGeneration(tool, in: context)
+
+        #expect(tool.generationState == .ready)
+        #expect(tool.generationPhase == .completed)
+        #expect(tool.generationMode == nil)
+        #expect(tool.pendingPrompt == nil)
+        #expect(tool.generationErrorSummary == nil)
+        #expect(FileManager.default.fileExists(atPath: packageRoot.path))
+        #expect(!(FileManager.default.fileExists(atPath: layout.pendingContentViewDraftURL.path)))
+        #expect(try String(contentsOf: contentViewURL, encoding: .utf8) == #"Text("last ready")"#)
+        #expect(store.presentedErrorMessage == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Add support for continuing interrupted tool generation and editing flows across the agent pipeline.
- Tighten build-repair and model-repair loops so generation can recover more reliably from compile failures.
- Update app bundle, icon, runtime context, and tool metadata plumbing to match the new generation flow.
- Refresh tool library UI/state to reflect generation progress, selection, and action handling during resumable runs.
- Expand coverage for create, edit, package/process, persistence, and tool library behaviors.

## Testing
- Added and updated unit tests for resumable generation, repair loops, packaging/process integration, persistence, and tool library actions.
- Validated the affected flows at a high level through the new test coverage and targeted local behavior checks.