### PR TITLE
Feat: Add support for menu bar apps

### DIFF
--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
@@ -78,14 +78,6 @@ struct ToolAppBundleClient {
         processClient: SwiftPackageProcessClient,
         iconClient: ToolIconClient
     ) async throws -> URL {
-        let appEntryURL = try request.layout.packageFileURL(for: request.layout.appEntrySourcePath)
-        try fileManager.createDirectory(
-            at: appEntryURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        try request.layout.fixedAppEntrySource(displayName: request.displayName, settings: request.settings)
-            .write(to: appEntryURL, atomically: true, encoding: .utf8)
-
         let buildResult = try await processClient.buildRelease(request.packageRootURL)
         guard buildResult.succeeded else {
             throw ToolAppBundleError.releaseBuildFailed(buildResult.combinedOutput)

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
@@ -50,7 +50,7 @@ struct ToolAppBundleClient {
                 return try await buildApp(
                     request: request,
                     destinationAppURL: destinationURL,
-                    showsInDock: true,
+                    showsInDock: request.appKind == .window,
                     fileManager: fileManager,
                     fileClient: fileClient,
                     processClient: processClient,

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
@@ -35,6 +35,7 @@ struct ToolAppBundleClient {
                     request: request,
                     destinationAppURL: request.internalAppBundleURL,
                     showsInDock: false,
+                    quitsOnLastWindowClose: request.appKind == .window,
                     fileManager: fileManager,
                     fileClient: fileClient,
                     processClient: processClient,
@@ -51,6 +52,7 @@ struct ToolAppBundleClient {
                     request: request,
                     destinationAppURL: destinationURL,
                     showsInDock: request.appKind == .window,
+                    quitsOnLastWindowClose: false,
                     fileManager: fileManager,
                     fileClient: fileClient,
                     processClient: processClient,
@@ -70,11 +72,20 @@ struct ToolAppBundleClient {
         request: ToolAppBundleRequest,
         destinationAppURL: URL,
         showsInDock: Bool,
+        quitsOnLastWindowClose: Bool,
         fileManager: FileManager,
         fileClient: AgentFileClient,
         processClient: SwiftPackageProcessClient,
         iconClient: ToolIconClient
     ) async throws -> URL {
+        let appEntryURL = try request.layout.packageFileURL(for: request.layout.appEntrySourcePath)
+        try fileManager.createDirectory(
+            at: appEntryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try request.layout.fixedAppEntrySource(displayName: request.displayName, settings: request.settings)
+            .write(to: appEntryURL, atomically: true, encoding: .utf8)
+
         let buildResult = try await processClient.buildRelease(request.packageRootURL)
         guard buildResult.succeeded else {
             throw ToolAppBundleError.releaseBuildFailed(buildResult.combinedOutput)
@@ -121,6 +132,7 @@ struct ToolAppBundleClient {
             for: request,
             to: infoPlistURL,
             showsInDock: showsInDock,
+            quitsOnLastWindowClose: quitsOnLastWindowClose,
             iconFileName: iconFileName
         )
 
@@ -237,6 +249,7 @@ struct ToolAppBundleClient {
         for request: ToolAppBundleRequest,
         to url: URL,
         showsInDock: Bool,
+        quitsOnLastWindowClose: Bool,
         iconFileName: String?
     ) throws {
         var plist: [String: Any] = [
@@ -259,6 +272,10 @@ struct ToolAppBundleClient {
 
         if !showsInDock {
             plist["LSUIElement"] = true
+        }
+
+        if quitsOnLastWindowClose {
+            plist["IronsmithQuitOnLastWindowClose"] = true
         }
 
         for permission in request.resourcePermissions.enabledPermissions {

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleRequest.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleRequest.swift
@@ -5,10 +5,22 @@ struct ToolAppBundleRequest: Equatable, Sendable {
     let executableName: String
     let bundleIdentifier: String
     let packageRootURL: URL
-    let sandboxEnabled: Bool
+    let settings: ToolGenerationSettings
     let sandboxPermissions: GeneratedAppSandboxPermissions
     let resourcePermissions: GeneratedAppResourcePermissions
     let iconPrompt: String?
+
+    var appKind: ToolAppKind {
+        settings.appKind
+    }
+
+    var menuBarSystemImage: String {
+        settings.menuBarSystemImage
+    }
+
+    var sandboxEnabled: Bool {
+        settings.sandboxEnabled
+    }
 
     init(
         displayName: String,
@@ -18,15 +30,25 @@ struct ToolAppBundleRequest: Equatable, Sendable {
         sandboxEnabled: Bool,
         sandboxPermissions: GeneratedAppSandboxPermissions = .default,
         resourcePermissions: GeneratedAppResourcePermissions = .none,
+        appKind: ToolAppKind = .window,
+        menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
+        settings: ToolGenerationSettings? = nil,
         iconPrompt: String? = nil
     ) {
         self.displayName = displayName
         self.executableName = executableName
         self.bundleIdentifier = bundleIdentifier
         self.packageRootURL = packageRootURL
-        self.sandboxEnabled = sandboxEnabled
-        self.sandboxPermissions = sandboxPermissions
-        self.resourcePermissions = resourcePermissions
+        let resolvedSettings = settings ?? ToolGenerationSettings(
+            appKind: appKind,
+            menuBarSystemImage: menuBarSystemImage,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions
+        )
+        self.settings = resolvedSettings
+        self.sandboxPermissions = resolvedSettings.sandboxPermissions
+        self.resourcePermissions = resolvedSettings.resourcePermissions
         self.iconPrompt = iconPrompt
     }
 
@@ -52,8 +74,10 @@ struct ToolAppBundleRequest: Equatable, Sendable {
             bundleIdentifier: tool.bundleIdentifier,
             packageRootURL: tool.packageRootURL,
             sandboxEnabled: tool.sandboxEnabled,
-            sandboxPermissions: sandboxPermissions,
-            resourcePermissions: resourcePermissions,
+            settings: tool.generationSettings(
+                defaultSandboxPermissions: sandboxPermissions,
+                defaultResourcePermissions: resourcePermissions
+            ),
             iconPrompt: nil
         )
     }

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -270,6 +270,8 @@ struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static let pendingContentViewDraftPath = "\(packageMetadataDirectoryName)/\(pendingContentViewDraftFilename)"
     nonisolated static let pendingContentViewVersionFilename = "pending-ContentView.swift"
     nonisolated static let previousContentViewVersionFilename = "previous-ContentView.swift"
+    nonisolated static let pendingBuildSettingsVersionFilename = "pending-build-settings.json"
+    nonisolated static let previousBuildSettingsVersionFilename = "previous-build-settings.json"
 
     let packageRootURL: URL
     let executableName: String
@@ -300,6 +302,14 @@ struct ToolPackageLayout: Equatable, Sendable {
 
     nonisolated var previousContentViewVersionURL: URL {
         Self.previousContentViewVersionURL(for: packageRootURL)
+    }
+
+    nonisolated var pendingBuildSettingsVersionURL: URL {
+        Self.pendingBuildSettingsVersionURL(for: packageRootURL)
+    }
+
+    nonisolated var previousBuildSettingsVersionURL: URL {
+        Self.previousBuildSettingsVersionURL(for: packageRootURL)
     }
 
     nonisolated var sourceDirectoryURL: URL {
@@ -387,6 +397,16 @@ struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static func previousContentViewVersionURL(for packageRootURL: URL) -> URL {
         versionsDirectoryURL(for: packageRootURL)
             .appendingPathComponent(previousContentViewVersionFilename)
+    }
+
+    nonisolated static func pendingBuildSettingsVersionURL(for packageRootURL: URL) -> URL {
+        versionsDirectoryURL(for: packageRootURL)
+            .appendingPathComponent(pendingBuildSettingsVersionFilename)
+    }
+
+    nonisolated static func previousBuildSettingsVersionURL(for packageRootURL: URL) -> URL {
+        versionsDirectoryURL(for: packageRootURL)
+            .appendingPathComponent(previousBuildSettingsVersionFilename)
     }
 
     nonisolated static func sandboxEntitlementsURL(for packageRootURL: URL) -> URL {

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -420,10 +420,20 @@ struct ToolPackageLayout: Equatable, Sendable {
         switch settings.appKind {
         case .window:
             """
+            import AppKit
             import SwiftUI
+
+            @MainActor
+            private final class IronsmithGeneratedAppDelegate: NSObject, NSApplicationDelegate {
+                func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+                    Bundle.main.object(forInfoDictionaryKey: "IronsmithQuitOnLastWindowClose") as? Bool == true
+                }
+            }
 
             @main
             struct \(executableName): App {
+                @NSApplicationDelegateAdaptor(IronsmithGeneratedAppDelegate.self) private var appDelegate
+
                 var body: some Scene {
                     WindowGroup {
                         ContentView()
@@ -433,13 +443,39 @@ struct ToolPackageLayout: Equatable, Sendable {
             """
         case .menuBar:
             """
+            import AppKit
             import SwiftUI
 
             @main
             struct \(executableName): App {
                 var body: some Scene {
                     MenuBarExtra(\(Self.swiftStringLiteral(displayName ?? executableName)), systemImage: \(Self.swiftStringLiteral(settings.menuBarSystemImage))) {
-                        ContentView()
+                        VStack(spacing: 0) {
+                            HStack {
+                                Text(\(Self.swiftStringLiteral(displayName ?? executableName)))
+                                    .font(.headline)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+
+                                Spacer()
+
+                                Button {
+                                    NSApplication.shared.terminate(nil)
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .imageScale(.medium)
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Quit")
+                                .accessibilityLabel("Quit")
+                            }
+                            .padding(.top, 10)
+                            .padding(.bottom, 12)
+                            .padding(.horizontal, 12)
+
+                            ContentView()
+                        }
                     }
                     .menuBarExtraStyle(.window)
                 }

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -54,6 +54,105 @@ struct ToolManifestFile: Codable, Equatable, Sendable {
     var description: String
 }
 
+enum ToolAppKind: String, Codable, CaseIterable, Equatable, Sendable {
+    case window
+    case menuBar = "menu_bar"
+
+    var displayName: String {
+        switch self {
+        case .window: return "Window App"
+        case .menuBar: return "Menu Bar App"
+        }
+    }
+}
+
+enum ToolMenuBarSymbol {
+    nonisolated static let fallback = "hammer"
+
+    nonisolated static let allowedSymbols = [
+        "hammer",
+        "wrench.and.screwdriver",
+        "sparkles",
+        "bolt",
+        "clock",
+        "timer",
+        "calendar",
+        "checkmark.circle",
+        "list.bullet",
+        "note.text",
+        "tray",
+        "folder",
+        "doc.text",
+        "magnifyingglass",
+        "camera",
+        "mic",
+        "map",
+        "location",
+        "person.crop.circle",
+        "chart.bar",
+        "house",
+        "dollarsign.circle",
+        "cart",
+        "gamecontroller",
+        "paintbrush",
+        "pencil",
+        "book",
+        "bell",
+        "cloud",
+        "globe",
+        "link",
+        "lock",
+        "shield",
+        "terminal",
+    ]
+
+    nonisolated static func validated(_ symbol: String?) -> String {
+        guard let symbol = symbol?.trimmingCharacters(in: .whitespacesAndNewlines),
+              allowedSymbols.contains(symbol)
+        else {
+            return fallback
+        }
+        return symbol
+    }
+
+}
+
+struct ToolGenerationSettings: Equatable, Sendable {
+    var appKind: ToolAppKind
+    var menuBarSystemImage: String
+    var sandboxEnabled: Bool
+    var sandboxPermissions: GeneratedAppSandboxPermissions
+    var resourcePermissions: GeneratedAppResourcePermissions
+
+    nonisolated init(
+        appKind: ToolAppKind = .window,
+        menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
+        sandboxEnabled: Bool = true,
+        sandboxPermissions: GeneratedAppSandboxPermissions = .default,
+        resourcePermissions: GeneratedAppResourcePermissions = .none
+    ) {
+        self.appKind = appKind
+        self.menuBarSystemImage = ToolMenuBarSymbol.validated(menuBarSystemImage)
+        self.sandboxEnabled = sandboxEnabled
+        self.sandboxPermissions = sandboxPermissions
+        self.resourcePermissions = resourcePermissions
+    }
+
+    nonisolated static var `default`: ToolGenerationSettings {
+        ToolGenerationSettings()
+    }
+
+    nonisolated func withMenuBarSystemImage(_ symbol: String) -> ToolGenerationSettings {
+        ToolGenerationSettings(
+            appKind: appKind,
+            menuBarSystemImage: symbol,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions
+        )
+    }
+}
+
 enum ContentViewDeterministicEditOperation: String, Codable, CaseIterable, Equatable, Sendable {
     case addImport
     case addStateProperty
@@ -81,22 +180,27 @@ struct ToolGenerationResult: Equatable, Sendable {
     let toolName: String
     let executableName: String
     let bundleIdentifier: String
-    let sandboxEnabled: Bool
+    let settings: ToolGenerationSettings
     let packageRootURL: URL
     let manifest: ToolManifest
+
+    var sandboxEnabled: Bool {
+        settings.sandboxEnabled
+    }
 
     init(
         toolName: String,
         executableName: String,
         bundleIdentifier: String? = nil,
         sandboxEnabled: Bool = true,
+        settings: ToolGenerationSettings? = nil,
         packageRootURL: URL,
         manifest: ToolManifest
     ) {
         self.toolName = toolName
         self.executableName = executableName
         self.bundleIdentifier = bundleIdentifier ?? ToolBundleIdentifier.make(executableName: executableName)
-        self.sandboxEnabled = sandboxEnabled
+        self.settings = settings ?? ToolGenerationSettings(sandboxEnabled: sandboxEnabled)
         self.packageRootURL = packageRootURL
         self.manifest = manifest
     }
@@ -309,18 +413,42 @@ struct ToolPackageLayout: Equatable, Sendable {
         """
     }
 
-    nonisolated func fixedAppEntrySource() -> String {
-        """
-        import SwiftUI
+    nonisolated func fixedAppEntrySource(
+        displayName: String? = nil,
+        settings: ToolGenerationSettings = .default
+    ) -> String {
+        switch settings.appKind {
+        case .window:
+            """
+            import SwiftUI
 
-        @main
-        struct \(executableName): App {
-            var body: some Scene {
-                WindowGroup {
-                    ContentView()
+            @main
+            struct \(executableName): App {
+                var body: some Scene {
+                    WindowGroup {
+                        ContentView()
+                    }
                 }
             }
+            """
+        case .menuBar:
+            """
+            import SwiftUI
+
+            @main
+            struct \(executableName): App {
+                var body: some Scene {
+                    MenuBarExtra(\(Self.swiftStringLiteral(displayName ?? executableName)), systemImage: \(Self.swiftStringLiteral(settings.menuBarSystemImage))) {
+                        ContentView()
+                    }
+                    .menuBarExtraStyle(.window)
+                }
+            }
+            """
         }
-        """
+    }
+
+    nonisolated private static func swiftStringLiteral(_ value: String) -> String {
+        String(reflecting: value)
     }
 }

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -390,7 +390,11 @@ struct SingleFileToolGenerationRuntime {
             layout.appEntrySourcePath,
             packageRootURL: layout.packageRootURL
         )
-        let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
+        let backup = try context.versionBackupClient.stageCurrentVersion(
+            layout.packageRootURL,
+            contentViewPath,
+            existingTool.generationSettings(defaults: settings)
+        )
 
         AgentDiagnosticsLog.append(
             """

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -12,6 +12,7 @@ struct SingleFileToolGenerationRuntime {
         let contentViewPath: String
         let manifest: ToolManifest
         let iconPrompt: String?
+        let settings: ToolGenerationSettings
     }
 
     func generateTool(
@@ -20,6 +21,26 @@ struct SingleFileToolGenerationRuntime {
         sandboxEnabled: Bool = true,
         sandboxPermissions: GeneratedAppSandboxPermissions = .default,
         resourcePermissions: GeneratedAppResourcePermissions = .none,
+        lifecycle: ToolGenerationLifecycle = .noop,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        try await generateTool(
+            for: prompt,
+            existingTool: existingTool,
+            settings: ToolGenerationSettings(
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions
+            ),
+            lifecycle: lifecycle,
+            status: status
+        )
+    }
+
+    func generateTool(
+        for prompt: String,
+        existingTool: Tool? = nil,
+        settings: ToolGenerationSettings,
         lifecycle: ToolGenerationLifecycle = .noop,
         status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult {
@@ -36,9 +57,7 @@ struct SingleFileToolGenerationRuntime {
                 return try await createTool(
                     prompt: effectivePrompt,
                     existingTool: existingTool,
-                    sandboxEnabled: sandboxEnabled,
-                    sandboxPermissions: sandboxPermissions,
-                    resourcePermissions: resourcePermissions,
+                    settings: settings,
                     lifecycle: lifecycle,
                     status: status
                 )
@@ -46,9 +65,7 @@ struct SingleFileToolGenerationRuntime {
             return try await editTool(
                 prompt: effectivePrompt,
                 existingTool: existingTool,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
+                settings: settings,
                 lifecycle: lifecycle,
                 status: status
             )
@@ -56,9 +73,7 @@ struct SingleFileToolGenerationRuntime {
 
         return try await createTool(
             prompt: trimmedPrompt,
-            sandboxEnabled: sandboxEnabled,
-            sandboxPermissions: sandboxPermissions,
-            resourcePermissions: resourcePermissions,
+            settings: settings,
             lifecycle: lifecycle,
             status: status
         )
@@ -76,7 +91,10 @@ struct SingleFileToolGenerationRuntime {
         return fallback
     }
 
-    private func loadCreateSetup(for tool: Tool) throws -> CreateToolSetup {
+    private func loadCreateSetup(
+        for tool: Tool,
+        settings: ToolGenerationSettings
+    ) throws -> CreateToolSetup {
         let manifest = try context.loadManifest(at: tool.agentManifestURL)
         let layout = ToolPackageLayout(
             packageRootURL: tool.packageRootURL,
@@ -89,17 +107,19 @@ struct SingleFileToolGenerationRuntime {
             layout: layout,
             contentViewPath: manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName),
             manifest: manifest,
-            iconPrompt: nil
+            iconPrompt: nil,
+            settings: settings
         )
     }
 
     private func prepareNewCreateSetup(
         metadata: ToolMetadataSuggestion,
         prompt: String,
-        sandboxEnabled: Bool,
+        settings: ToolGenerationSettings,
         lifecycle: ToolGenerationLifecycle
     ) async throws -> CreateToolSetup {
         let displayName = metadata.displayName
+        let resolvedSettings = settings.withMenuBarSystemImage(metadata.menuBarSystemImage)
         let executableName = ToolNameSanitizer.executableName(from: displayName)
         let bundleIdentifier = ToolBundleIdentifier.make(executableName: executableName)
         let packageRootURL = try context.makeUniquePackageRoot(displayName: displayName)
@@ -118,14 +138,18 @@ struct SingleFileToolGenerationRuntime {
 
         try context.fileClient.createDirectory(layout.sourceDirectoryURL)
         try context.write(layout.packageManifestContent(), to: "Package.swift", packageRootURL: layout.packageRootURL)
-        try context.write(layout.fixedAppEntrySource(), to: layout.appEntrySourcePath, packageRootURL: layout.packageRootURL)
+        try context.write(
+            layout.fixedAppEntrySource(displayName: displayName, settings: resolvedSettings),
+            to: layout.appEntrySourcePath,
+            packageRootURL: layout.packageRootURL
+        )
         try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
         try await lifecycle.prepareCreatedTool(
             ToolGenerationPreparedTool(
                 name: displayName,
                 executableName: executableName,
                 bundleIdentifier: bundleIdentifier,
-                sandboxEnabled: sandboxEnabled,
+                settings: resolvedSettings,
                 packageRootURL: packageRootURL,
                 manifest: manifest
             ),
@@ -139,13 +163,14 @@ struct SingleFileToolGenerationRuntime {
             layout: layout,
             contentViewPath: contentViewPath,
             manifest: manifest,
-            iconPrompt: metadata.iconPrompt
+            iconPrompt: metadata.iconPrompt,
+            settings: resolvedSettings
         )
     }
 
     private func preparePlaceholderCreateTool(
         prompt: String,
-        sandboxEnabled: Bool,
+        settings: ToolGenerationSettings,
         lifecycle: ToolGenerationLifecycle
     ) async throws {
         let displayName = "New App"
@@ -168,7 +193,7 @@ struct SingleFileToolGenerationRuntime {
                 name: displayName,
                 executableName: executableName,
                 bundleIdentifier: ToolBundleIdentifier.make(executableName: executableName),
-                sandboxEnabled: sandboxEnabled,
+                settings: settings,
                 packageRootURL: packageRootURL,
                 manifest: manifest
             ),
@@ -179,22 +204,20 @@ struct SingleFileToolGenerationRuntime {
     private func createTool(
         prompt: String,
         existingTool: Tool? = nil,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
+        settings: ToolGenerationSettings,
         lifecycle: ToolGenerationLifecycle,
         status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult {
         let startingPhase = existingTool?.generationPhase ?? .initializing
         let setup: CreateToolSetup
-        if let existingTool, let resumedSetup = try? loadCreateSetup(for: existingTool) {
+        if let existingTool, let resumedSetup = try? loadCreateSetup(for: existingTool, settings: settings) {
             setup = resumedSetup
         } else {
             status("Naming app")
             if existingTool == nil {
                 try await preparePlaceholderCreateTool(
                     prompt: prompt,
-                    sandboxEnabled: sandboxEnabled,
+                    settings: settings,
                     lifecycle: lifecycle
                 )
             }
@@ -209,7 +232,7 @@ struct SingleFileToolGenerationRuntime {
             setup = try await prepareNewCreateSetup(
                 metadata: metadata,
                 prompt: prompt,
-                sandboxEnabled: sandboxEnabled,
+                settings: settings,
                 lifecycle: lifecycle
             )
         }
@@ -247,7 +270,7 @@ struct SingleFileToolGenerationRuntime {
             } else {
                 contentPrompt = try await contentGenerationPrompt(
                     for: prompt,
-                    sandboxEnabled: sandboxEnabled,
+                    sandboxEnabled: setup.settings.sandboxEnabled,
                     lifecycle: lifecycle
                 )
             }
@@ -259,9 +282,7 @@ struct SingleFileToolGenerationRuntime {
                     bundleIdentifier: setup.bundleIdentifier,
                     packageRootURL: setup.layout.packageRootURL,
                     manifest: setup.manifest,
-                    sandboxEnabled: sandboxEnabled,
-                    sandboxPermissions: sandboxPermissions,
-                    resourcePermissions: resourcePermissions,
+                    settings: setup.settings,
                     iconPrompt: setup.iconPrompt,
                     lifecycle: lifecycle,
                     status: status
@@ -270,7 +291,7 @@ struct SingleFileToolGenerationRuntime {
 
             let generator = createGenerator(
                 userPrompt: contentPrompt,
-                sandboxEnabled: sandboxEnabled,
+                sandboxEnabled: setup.settings.sandboxEnabled,
                 layout: setup.layout,
                 contentViewPath: setup.contentViewPath,
                 lifecycle: lifecycle,
@@ -292,9 +313,7 @@ struct SingleFileToolGenerationRuntime {
                 bundleIdentifier: setup.bundleIdentifier,
                 packageRootURL: setup.layout.packageRootURL,
                 manifest: setup.manifest,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
+                settings: setup.settings,
                 iconPrompt: setup.iconPrompt,
                 lifecycle: lifecycle,
                 status: status
@@ -335,9 +354,7 @@ struct SingleFileToolGenerationRuntime {
     private func editTool(
         prompt: String,
         existingTool: Tool,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
+        settings: ToolGenerationSettings,
         lifecycle: ToolGenerationLifecycle,
         status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult {
@@ -358,15 +375,17 @@ struct SingleFileToolGenerationRuntime {
                 bundleIdentifier: existingTool.bundleIdentifier,
                 packageRootURL: existingTool.packageRootURL,
                 manifest: manifest,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
+                settings: settings,
                 iconPrompt: nil,
                 lifecycle: lifecycle,
                 status: status
             )
         }
         let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
+        let existingAppEntrySource = try context.readIfPresent(
+            layout.appEntrySourcePath,
+            packageRootURL: layout.packageRootURL
+        )
         let backup = try context.versionBackupClient.stageCurrentVersion(layout.packageRootURL, contentViewPath)
 
         AgentDiagnosticsLog.append(
@@ -384,6 +403,11 @@ struct SingleFileToolGenerationRuntime {
 
         do {
             try Task.checkCancellation()
+            try context.write(
+                layout.fixedAppEntrySource(displayName: manifest.displayName, settings: settings),
+                to: layout.appEntrySourcePath,
+                packageRootURL: layout.packageRootURL
+            )
             try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
             let generator = editGenerator(
                 userPrompt: prompt,
@@ -412,15 +436,15 @@ struct SingleFileToolGenerationRuntime {
                     executableName: manifest.executableName,
                     bundleIdentifier: existingTool.bundleIdentifier,
                     packageRootURL: existingTool.packageRootURL,
-                    sandboxEnabled: sandboxEnabled,
-                    sandboxPermissions: sandboxPermissions,
-                    resourcePermissions: resourcePermissions
+                    sandboxEnabled: settings.sandboxEnabled,
+                    settings: settings
                 )
             )
             try? context.fileClient.removeItemIfExists(layout.pendingContentViewDraftURL)
             try context.versionBackupClient.promoteStagedVersion(backup)
         } catch {
             try? context.write(existingSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
+            try? context.write(existingAppEntrySource, to: layout.appEntrySourcePath, packageRootURL: layout.packageRootURL)
             try? context.versionBackupClient.discardStagedVersion(backup)
             AgentDiagnosticsLog.append(
                 """
@@ -441,7 +465,7 @@ struct SingleFileToolGenerationRuntime {
             toolName: manifest.displayName,
             executableName: manifest.executableName,
             bundleIdentifier: existingTool.bundleIdentifier,
-            sandboxEnabled: sandboxEnabled,
+            settings: settings,
             packageRootURL: existingTool.packageRootURL,
             manifest: manifest
         )
@@ -795,9 +819,7 @@ struct SingleFileToolGenerationRuntime {
         bundleIdentifier: String,
         packageRootURL: URL,
         manifest: ToolManifest,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
+        settings: ToolGenerationSettings,
         iconPrompt: String?,
         lifecycle: ToolGenerationLifecycle,
         status: @escaping @MainActor (String) -> Void
@@ -817,9 +839,8 @@ struct SingleFileToolGenerationRuntime {
                 executableName: executableName,
                 bundleIdentifier: bundleIdentifier,
                 packageRootURL: packageRootURL,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
+                sandboxEnabled: settings.sandboxEnabled,
+                settings: settings,
                 iconPrompt: iconPrompt
             )
         )
@@ -829,7 +850,7 @@ struct SingleFileToolGenerationRuntime {
             toolName: displayName,
             executableName: executableName,
             bundleIdentifier: bundleIdentifier,
-            sandboxEnabled: sandboxEnabled,
+            settings: settings,
             packageRootURL: packageRootURL,
             manifest: manifest
         )

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -270,6 +270,7 @@ struct SingleFileToolGenerationRuntime {
             } else {
                 contentPrompt = try await contentGenerationPrompt(
                     for: prompt,
+                    appKind: setup.settings.appKind,
                     sandboxEnabled: setup.settings.sandboxEnabled,
                     lifecycle: lifecycle
                 )
@@ -291,6 +292,7 @@ struct SingleFileToolGenerationRuntime {
 
             let generator = createGenerator(
                 userPrompt: contentPrompt,
+                appKind: setup.settings.appKind,
                 sandboxEnabled: setup.settings.sandboxEnabled,
                 layout: setup.layout,
                 contentViewPath: setup.contentViewPath,
@@ -328,6 +330,7 @@ struct SingleFileToolGenerationRuntime {
 
     private func contentGenerationPrompt(
         for prompt: String,
+        appKind: ToolAppKind,
         sandboxEnabled: Bool,
         lifecycle: ToolGenerationLifecycle
     ) async throws -> String {
@@ -341,6 +344,7 @@ struct SingleFileToolGenerationRuntime {
             userPrompt: prompt,
             languageModel: context.languageModel,
             generationOptions: context.generationOptions,
+            appKind: appKind,
             sandboxEnabled: sandboxEnabled
         )
         try Task.checkCancellation()
@@ -531,6 +535,7 @@ struct SingleFileToolGenerationRuntime {
 
     private func createGenerator(
         userPrompt: String,
+        appKind: ToolAppKind,
         sandboxEnabled: Bool,
         layout: ToolPackageLayout,
         contentViewPath: String,
@@ -543,7 +548,8 @@ struct SingleFileToolGenerationRuntime {
         let originalPrompt = ToolGenerationPrompts.singleFileCreatePrompt(
             userPrompt: userPrompt,
             executableName: layout.executableName,
-            sandboxEnabled: sandboxEnabled
+            sandboxEnabled: sandboxEnabled,
+            appKind: appKind
         )
 
         return ContentViewCandidateGenerator(
@@ -596,6 +602,7 @@ struct SingleFileToolGenerationRuntime {
 
             try await regenerateCreatedContentView(
                 userPrompt: userPrompt,
+                appKind: appKind,
                 sandboxEnabled: sandboxEnabled,
                 layout: layout,
                 contentViewPath: contentViewPath,
@@ -931,6 +938,7 @@ struct SingleFileToolGenerationRuntime {
 
     private func regenerateCreatedContentView(
         userPrompt: String,
+        appKind: ToolAppKind,
         sandboxEnabled: Bool,
         layout: ToolPackageLayout,
         contentViewPath: String,
@@ -940,7 +948,8 @@ struct SingleFileToolGenerationRuntime {
         let prompt = ToolGenerationPrompts.singleFileCreatePrompt(
             userPrompt: userPrompt,
             executableName: layout.executableName,
-            sandboxEnabled: sandboxEnabled
+            sandboxEnabled: sandboxEnabled,
+            appKind: appKind
         )
         let draftPath = ToolPackageLayout.pendingContentViewDraftPath
         do {

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -403,6 +403,7 @@ struct SingleFileToolGenerationRuntime {
 
         do {
             try Task.checkCancellation()
+            // The model only edits ContentView.swift; Ironsmith owns the fixed app scene wrapper.
             try context.write(
                 layout.fixedAppEntrySource(displayName: manifest.displayName, settings: settings),
                 to: layout.appEntrySourcePath,

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -242,11 +242,27 @@ struct ToolRunnerClient {
     static func live(appBundleClient: ToolAppBundleClient = .live()) -> Self {
         Self { tool in
             let request = ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(tool)
-            if !appBundleClient.appExists(request.internalAppBundleURL) {
+            if !appBundleClient.appExists(request.internalAppBundleURL)
+                || needsQuitOnCloseRebuild(request)
+            {
                 _ = try await appBundleClient.buildInternalApp(request)
             }
             try await appBundleClient.launchApp(request.internalAppBundleURL)
         }
+    }
+
+    private static func needsQuitOnCloseRebuild(_ request: ToolAppBundleRequest) -> Bool {
+        guard request.appKind == .window else { return false }
+        let plistURL = request.internalAppBundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        guard let data = try? Data(contentsOf: plistURL),
+              let plist = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil),
+              let dictionary = plist as? [String: Any]
+        else {
+            return true
+        }
+        return dictionary["IronsmithQuitOnLastWindowClose"] as? Bool != true
     }
 }
 

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -4,9 +4,30 @@ struct ToolGenerationPreparedTool {
     let name: String
     let executableName: String
     let bundleIdentifier: String
-    let sandboxEnabled: Bool
+    let settings: ToolGenerationSettings
     let packageRootURL: URL
     let manifest: ToolManifest
+
+    var sandboxEnabled: Bool {
+        settings.sandboxEnabled
+    }
+
+    init(
+        name: String,
+        executableName: String,
+        bundleIdentifier: String,
+        sandboxEnabled: Bool = true,
+        settings: ToolGenerationSettings? = nil,
+        packageRootURL: URL,
+        manifest: ToolManifest
+    ) {
+        self.name = name
+        self.executableName = executableName
+        self.bundleIdentifier = bundleIdentifier
+        self.settings = settings ?? ToolGenerationSettings(sandboxEnabled: sandboxEnabled)
+        self.packageRootURL = packageRootURL
+        self.manifest = manifest
+    }
 }
 
 struct ToolGenerationLifecycle {
@@ -53,13 +74,29 @@ struct ToolGenerationClient {
     private var generateToolWithLifecycle: (
         _ prompt: String,
         _ existingTool: Tool?,
-        _ sandboxEnabled: Bool,
-        _ sandboxPermissions: GeneratedAppSandboxPermissions,
-        _ resourcePermissions: GeneratedAppResourcePermissions,
+        _ settings: ToolGenerationSettings,
         _ languageModelContext: AgentLanguageModelContext,
         _ lifecycle: ToolGenerationLifecycle,
         _ status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult
+
+    func generateTool(
+        _ prompt: String,
+        _ existingTool: Tool?,
+        _ settings: ToolGenerationSettings,
+        _ languageModelContext: AgentLanguageModelContext,
+        lifecycle: ToolGenerationLifecycle = .noop,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> ToolGenerationResult {
+        try await generateToolWithLifecycle(
+            prompt,
+            existingTool,
+            settings,
+            languageModelContext,
+            lifecycle,
+            status
+        )
+    }
 
     func generateTool(
         _ prompt: String,
@@ -71,15 +108,17 @@ struct ToolGenerationClient {
         lifecycle: ToolGenerationLifecycle = .noop,
         status: @escaping @MainActor (String) -> Void
     ) async throws -> ToolGenerationResult {
-        try await generateToolWithLifecycle(
+        try await generateTool(
             prompt,
             existingTool,
-            sandboxEnabled,
-            sandboxPermissions,
-            resourcePermissions,
+            ToolGenerationSettings(
+                sandboxEnabled: sandboxEnabled,
+                sandboxPermissions: sandboxPermissions,
+                resourcePermissions: resourcePermissions
+            ),
             languageModelContext,
-            lifecycle,
-            status
+            lifecycle: lifecycle,
+            status: status
         )
     }
 
@@ -97,18 +136,16 @@ struct ToolGenerationClient {
         self.generateToolWithLifecycle = {
             prompt,
             existingTool,
-            sandboxEnabled,
-            sandboxPermissions,
-            resourcePermissions,
+            settings,
             languageModelContext,
             _,
             status in
             try await generateTool(
                 prompt,
                 existingTool,
-                sandboxEnabled,
-                sandboxPermissions,
-                resourcePermissions,
+                settings.sandboxEnabled,
+                settings.sandboxPermissions,
+                settings.resourcePermissions,
                 languageModelContext,
                 status
             )
@@ -127,6 +164,36 @@ struct ToolGenerationClient {
             _ status: @escaping @MainActor (String) -> Void
         ) async throws -> ToolGenerationResult
     ) {
+        self.generateToolWithLifecycle = {
+            prompt,
+            existingTool,
+            settings,
+            languageModelContext,
+            lifecycle,
+            status in
+            try await generateTool(
+                prompt,
+                existingTool,
+                settings.sandboxEnabled,
+                settings.sandboxPermissions,
+                settings.resourcePermissions,
+                languageModelContext,
+                lifecycle,
+                status
+            )
+        }
+    }
+
+    init(
+        withLifecycle generateTool: @escaping (
+            _ prompt: String,
+            _ existingTool: Tool?,
+            _ settings: ToolGenerationSettings,
+            _ languageModelContext: AgentLanguageModelContext,
+            _ lifecycle: ToolGenerationLifecycle,
+            _ status: @escaping @MainActor (String) -> Void
+        ) async throws -> ToolGenerationResult
+    ) {
         self.generateToolWithLifecycle = generateTool
     }
 
@@ -140,7 +207,7 @@ struct ToolGenerationClient {
         promptRefinementClient: ToolPromptRefinementClient = .live(),
         versionBackupClient: ToolVersionBackupClient = .live
     ) -> Self {
-        Self(withLifecycle: { prompt, existingTool, sandboxEnabled, sandboxPermissions, resourcePermissions, languageModelContext, lifecycle, status in
+        Self(withLifecycle: { prompt, existingTool, settings, languageModelContext, lifecycle, status in
             let context = ToolGenerationRuntimeContext(
                 languageModel: languageModelContext.languageModel,
                 metadataLanguageModel: languageModelContext.metadataLanguageModel,
@@ -161,9 +228,7 @@ struct ToolGenerationClient {
             return try await runtime.generateTool(
                 for: prompt,
                 existingTool: existingTool,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
+                settings: settings,
                 lifecycle: lifecycle,
                 status: status
             )

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
@@ -2,69 +2,70 @@ import Foundation
 
 enum ToolGenerationPrompts {
     static let singleFileCodingInstructions = """
-    You are Ironsmith's Coding Agent.
-    Write exactly one complete Swift file named ContentView.swift for a SwiftUI app based on the user's request.
-    Return only Swift source code.
-    Do not add comments except for MARK.
-    Do not add introductions, explanations, or labels like "Here is the fixed ContentView.swift file:".
-    Define exactly one View-conforming type: struct ContentView: View.
-    Helper types are allowed, but helper types must not conform to View, App, ObservableObject, or Identifiable unless absolutely required.
-    Keep state directly inside ContentView with @State properties.
-    Do not use ObservableObject, @Published, @StateObject, or @ObservedObject.
-    Do not create preview providers or #Preview blocks.
-    Do not create Package.swift, AppDelegate, or SceneDelegate.
-    Do NOT append @main to any struct. This entry point already exists and already calls ContentView
-    This is a macOS SwiftUI app. Do not use iOS-only modifiers such as keyboardType.
-    The generated app is self-contained and runs on the user's Mac, with direct internet requests allowed when the user's request requires them.
-    The prompt states whether the generated app uses the app sandbox. Treat that as runtime context, not a reason to reduce useful scope: when sandboxed, use sandbox-compatible macOS patterns such as user-selected files, and open/save/import panels etc.; when unsandboxed, use what is needed to complete the user's ask, but do not change the user's system unless asked or required.
-    Local persistence is welcome when useful: in-memory state, @AppStorage, UserDefaults, local files, import/export, and open/save panels are all fine if they fit in this single file.
-    Do not add or imply a separate backend service, custom server component, account system, iCloud/CloudKit integration, push notifications, analytics, subscriptions, or cross-device sync.
-    Make the app feel native to macOS: prefer SwiftUI controls such as Form, List, Table, Picker, Toggle, Slider, Stepper, DatePicker, NavigationSplitView, toolbars, menus, keyboard shortcuts, system colors, and adaptive materials.
-    Avoid mobile-first patterns, oversized marketing-style layouts, fake web dashboards, and custom controls when native macOS controls fit better.
-    Games, drawing canvases, and highly visual toys may use custom graphics and game-like UI, but they should still use sensible macOS window sizing, pointer and keyboard behavior, and local-only state.
-    For numeric input, use TextField("Label", value: $number, format: .number), not text: $number.
-    For display rounding, use String(format:) or Text specifiers. Do not call rounded(toPlaces:).
-    Avoid mutating let constants. Assign calculation results directly to @State properties.
-    Avoid checking isEmpty on numeric values. Compare numbers to 0 instead.
-    Don't make anything overly complex. The code needs to fit in a single file.
-    If what the user asks is too complicated, simplify it so it fits in the ContentView.
-    Prefer Apple platform frameworks and native APIs when they fit the request, such as Vision for OCR, PDFKit for PDFs, AVFoundation for media etc.
-    Use these stable sections when possible:
-    // MARK: - State
-    // MARK: - Body
-    // MARK: - Actions
-    // MARK: - Helpers
-    """
+        You are Ironsmith's Coding Agent.
+        Write exactly one complete Swift file named ContentView.swift for a SwiftUI app based on the user's request.
+        Return only Swift source code.
+        Do not add comments except for MARK.
+        Do not add introductions, explanations, or labels like "Here is the fixed ContentView.swift file:".
+        Define exactly one View-conforming type: struct ContentView: View.
+        Helper types are allowed, but helper types must not conform to App.
+        Keep state directly inside ContentView with @State properties.
+        Do not create preview providers or #Preview blocks.
+        Do not create Package.swift, AppDelegate, or SceneDelegate.
+        Do NOT append @main to any struct. This entry point already exists and already calls ContentView
+        This is a macOS SwiftUI app. Do not use iOS-only modifiers such as keyboardType.
+        The prompt states whether ContentView is hosted as a normal window app or a menu bar app. Respect that app type when choosing scope, layout density, and sizing.
+        The generated app is self-contained and runs on the user's Mac, with direct internet requests allowed when the user's request requires them.
+        The prompt states whether the generated app uses the app sandbox. Treat that as runtime context, not a reason to reduce useful scope: when sandboxed, use sandbox-compatible macOS patterns such as user-selected files, and open/save/import panels etc.; when unsandboxed, use what is needed to complete the user's ask, but do not change the user's system unless asked or required.
+        Local persistence is welcome when useful: in-memory state, @AppStorage, UserDefaults, local files, import/export, and open/save panels are all fine if they fit in this single file.
+        Do not add or imply a separate backend service, custom server component, account system, iCloud/CloudKit integration, push notifications, analytics, subscriptions, or cross-device sync.
+        Make the app feel native to macOS: prefer SwiftUI controls such as Form, List, Table, Picker, Toggle, Slider, Stepper, DatePicker, NavigationSplitView, toolbars, menus, keyboard shortcuts, system colors, and adaptive materials.
+        Avoid mobile-first patterns, oversized marketing-style layouts, fake web dashboards, and custom controls when native macOS controls fit better.
+        Games, drawing canvases, and highly visual toys may use custom graphics and game-like UI, but they should still use sensible macOS window sizing, pointer and keyboard behavior, and local-only state.
+        For numeric input, use TextField("Label", value: $number, format: .number), not text: $number.
+        For display rounding, use String(format:) or Text specifiers. Do not call rounded(toPlaces:).
+        Avoid mutating let constants. Assign calculation results directly to @State properties when possible.
+        Avoid checking isEmpty on numeric values. Compare numbers to 0 instead.
+        Don't make anything overly complex. The code needs to fit in a single file.
+        If what the user asks is too complicated, simplify it so it fits in the ContentView.
+        Prefer Apple platform frameworks and native APIs when they fit the request, such as Vision for OCR, PDFKit for PDFs, AVFoundation for media etc.
+        Use these stable sections when possible:
+        // MARK: - State
+        // MARK: - Body
+        // MARK: - Actions
+        // MARK: - Helpers
+        """
 
     static let diffRepairInstructions = """
-    You are Ironsmith's Swift compiler repair agent.
-    You repair exactly one file: ContentView.swift.
-    Return only a unified diff.
-    The diff must edit ContentView.swift only.
-    Use normal unified diff hunks with @@ headers and enough surrounding context to locate each edit.
-    Do not include prose, markdown fences, explanations, or unrelated rewrites in the diff.
-    Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
-    \(validUnifiedDiffShapeExample)
-    Keep each repair turn focused on the listed compiler diagnostics.
-    """
+        You are Ironsmith's Swift compiler repair agent.
+        You repair exactly one file: ContentView.swift.
+        Return only a unified diff.
+        The diff must edit ContentView.swift only.
+        Use normal unified diff hunks with @@ headers and enough surrounding context to locate each edit.
+        Do not include prose, markdown fences, explanations, or unrelated rewrites in the diff.
+        Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
+        \(validUnifiedDiffShapeExample)
+        Keep each repair turn focused on the listed compiler diagnostics.
+        """
 
     static let diffEditInstructions = """
-    You are Ironsmith's Swift edit agent.
-    You edit exactly one file: ContentView.swift.
-    Return only a unified diff.
-    The diff must edit ContentView.swift only.
-    Use normal unified diff hunks with @@ headers and enough surrounding context to locate each edit.
-    Do not include prose, markdown fences, explanations, or unrelated rewrites in the diff.
-    Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
-    \(validUnifiedDiffShapeExample)
-    Keep the edit focused on the user's requested change.
-    Prefer several small, focused hunks over one large hunk when multiple areas need changes.
-    """
+        You are Ironsmith's Swift edit agent.
+        You edit exactly one file: ContentView.swift.
+        Return only a unified diff.
+        The diff must edit ContentView.swift only.
+        Use normal unified diff hunks with @@ headers and enough surrounding context to locate each edit.
+        Do not include prose, markdown fences, explanations, or unrelated rewrites in the diff.
+        Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
+        \(validUnifiedDiffShapeExample)
+        Keep the edit focused on the user's requested change.
+        Prefer several small, focused hunks over one large hunk when multiple areas need changes.
+        """
 
     static func singleFileCreatePrompt(
         userPrompt: String,
         executableName: String,
-        sandboxEnabled: Bool = true
+        sandboxEnabled: Bool = true,
+        appKind: ToolAppKind = .window
     ) -> String {
         """
         Build the smallest complete version of the requested app.
@@ -72,6 +73,7 @@ enum ToolGenerationPrompts {
 
         User request: \(userPrompt)
         Fixed package and target name: \(executableName).
+        \(appPresentationContext(appKind: appKind))
         \(sandboxContext(sandboxEnabled: sandboxEnabled))
         Generate ContentView.swift only.
 
@@ -88,6 +90,23 @@ enum ToolGenerationPrompts {
             """
             App sandbox: disabled.
             The app may use what it needs to complete the user's ask, but it must not make changes to the user's system unless the user asks for them or the request requires them.
+            """
+        }
+    }
+
+    nonisolated static func appPresentationContext(appKind: ToolAppKind) -> String {
+        switch appKind {
+        case .window:
+            """
+            App type: window app.
+            ContentView is hosted in a normal macOS WindowGroup. Build a native desktop layout sized for a regular app window when the user's request calls for it.
+            """
+        case .menuBar:
+            """
+            App type: menu bar app.
+            ContentView is hosted inside a MenuBarExtra popover-style window, not a regular full-size app window.
+            Build it as a compact menu bar utility: concise controls, short labels, focused workflows, bounded width and height, and native macOS controls that work well in a popover.
+            Do not include the app title in the UI, as it will already be visible in the menu bar.
             """
         }
     }
@@ -142,7 +161,7 @@ enum ToolGenerationPrompts {
         Original request context:
         \(originalPrompt)
 
-        Partial ContentView.swift already generated:
+        Partial ContentView.swift already generated that needs to be completed:
         ```swift
         \(partialSource)
         ```
@@ -162,7 +181,7 @@ enum ToolGenerationPrompts {
         Original request context:
         \(originalPrompt)
 
-        Partial unified diff already generated:
+        Partial unified diff already generated that needs to be completed:
         ```diff
         \(partialDiff)
         ```
@@ -249,13 +268,13 @@ enum ToolGenerationPrompts {
     }
 
     private static let validUnifiedDiffShapeExample = """
-    Valid response shape example (format only; do not copy this content):
-    --- ContentView.swift
-    +++ ContentView.swift
-    @@
-    -    Text("Old")
-    +    Text("New")
-    """
+        Valid response shape example (format only; do not copy this content):
+        --- ContentView.swift
+        +++ ContentView.swift
+        @@
+        -    Text("Old")
+        +    Text("New")
+        """
 
     private static func repairExcerptsText(_ snippets: [ContentViewRepairSnippet]) -> String {
         snippets

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -173,6 +173,7 @@ struct ToolMetadataClient: Sendable {
 
 struct ToolPromptRefinementRequest: Sendable {
     let userPrompt: String
+    let appKind: ToolAppKind
     let sandboxEnabled: Bool
     let languageModel: any LanguageModel
     let generationOptions: GenerationOptions
@@ -200,11 +201,13 @@ struct ToolPromptRefinementClient: Sendable {
         userPrompt: String,
         languageModel: any LanguageModel,
         generationOptions: GenerationOptions,
+        appKind: ToolAppKind = .window,
         sandboxEnabled: Bool = true
     ) async -> String? {
         await refinePromptForRequest(
             ToolPromptRefinementRequest(
                 userPrompt: userPrompt,
+                appKind: appKind,
                 sandboxEnabled: sandboxEnabled,
                 languageModel: languageModel,
                 generationOptions: generationOptions
@@ -226,6 +229,7 @@ struct ToolPromptRefinementClient: Sendable {
                 let response: LanguageModelSession.Response<String> = try await session.respond(
                     to: Self.promptRefinementPrompt(
                         for: request.userPrompt,
+                        appKind: request.appKind,
                         sandboxEnabled: request.sandboxEnabled
                     ),
                     options: Self.promptRefinementOptions(from: request.generationOptions)
@@ -266,10 +270,13 @@ struct ToolPromptRefinementClient: Sendable {
 
     nonisolated private static func promptRefinementPrompt(
         for userPrompt: String,
+        appKind: ToolAppKind,
         sandboxEnabled: Bool
     ) -> String {
         """
         Return a plain text prompt to be given to a macOS SwiftUI AI coding agent for the user's request below.
+
+        \(ToolGenerationPrompts.appPresentationContext(appKind: appKind))
 
         \(ToolGenerationPrompts.sandboxContext(sandboxEnabled: sandboxEnabled))
 
@@ -294,6 +301,9 @@ struct ToolPromptRefinementClient: Sendable {
         - Must be under 750 characters.
         - Should expand the user's request with specific product intent, core features, expected interactions, layout and visual design direction, and useful states such as empty, loading, complete, or error states when relevant.
         - Treat every request as a first-version prototype unless the user explicitly asks for a full-featured app.
+        - Must preserve whether the generated app is a window app or menu bar app.
+        - For menu bar apps, describe a compact menu bar popover utility with concise controls, short labels, bounded size, and a focused quick workflow. Do not expand the request into a full-size desktop app, dashboard, sidebar layout, multi-pane workflow, or large complicated UI.
+        - For window apps, describe a normal native macOS window app layout when appropriate.
         - Choose at most 3 core user-facing features.
         - If the user lists many features, preserve the most important ones and explicitly simplify or omit the rest.
         - Prefer one polished primary workflow over many secondary workflows.

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -4,10 +4,16 @@ import Foundation
 struct ToolMetadataSuggestion: Equatable, Sendable {
     let displayName: String
     let iconPrompt: String
+    let menuBarSystemImage: String
 
-    nonisolated init(displayName: String, iconPrompt: String) {
+    nonisolated init(
+        displayName: String,
+        iconPrompt: String,
+        menuBarSystemImage: String = ToolMenuBarSymbol.fallback
+    ) {
         self.displayName = displayName
         self.iconPrompt = iconPrompt
+        self.menuBarSystemImage = ToolMenuBarSymbol.validated(menuBarSystemImage)
     }
 }
 
@@ -18,6 +24,19 @@ struct GeneratedToolMetadata {
 
     @Guide(description: "A tiny app icon concept phrase for an image generator, two to five words. Do not write a sentence.")
     let iconPrompt: String
+
+    @Guide(description: "One SF Symbol name chosen exactly from Ironsmith's allowed menuBarSystemImage list.")
+    let menuBarSystemImage: String
+}
+
+extension GeneratedToolMetadata {
+    nonisolated init(displayName: String, iconPrompt: String) {
+        self.init(
+            displayName: displayName,
+            iconPrompt: iconPrompt,
+            menuBarSystemImage: ToolMenuBarSymbol.fallback
+        )
+    }
 }
 
 struct ToolMetadataRequest: Sendable {
@@ -110,6 +129,9 @@ struct ToolMetadataClient: Sendable {
         """
         User request:
         \(userPrompt)
+
+        Allowed menuBarSystemImage values:
+        \(ToolMenuBarSymbol.allowedSymbols.joined(separator: ", "))
         """
     }
 
@@ -127,6 +149,11 @@ struct ToolMetadataClient: Sendable {
         - Must be 2 to 5 words.
         - Good examples: Calculator in front of house. Gamepad with buttons.
         - Do not mention app icon, macOS, style, text, letters, screenshots, UI, logos, or backgrounds.
+
+        menuBarSystemImage:
+        - Must be one exact SF Symbol name from the allowed list in the prompt.
+        - Choose the closest symbol for the user's requested app.
+        - Do not invent names or include variants outside that list.
         """
 
     nonisolated private static func metadataSuggestion(
@@ -135,9 +162,11 @@ struct ToolMetadataClient: Sendable {
     ) -> ToolMetadataSuggestion {
         let displayName = response.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let iconPrompt = response.iconPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        let menuBarSystemImage = ToolMenuBarSymbol.validated(response.menuBarSystemImage)
         return ToolMetadataSuggestion(
             displayName: displayName.isEmpty ? fallback.displayName : displayName,
-            iconPrompt: iconPrompt.isEmpty ? fallback.iconPrompt : iconPrompt
+            iconPrompt: iconPrompt.isEmpty ? fallback.iconPrompt : iconPrompt,
+            menuBarSystemImage: menuBarSystemImage
         )
     }
 }
@@ -292,7 +321,8 @@ extension ToolMetadataSuggestion {
         let displayName = ToolNameSanitizer.displayName(fromPrompt: userPrompt)
         return ToolMetadataSuggestion(
             displayName: displayName,
-            iconPrompt: ""
+            iconPrompt: "",
+            menuBarSystemImage: ToolMenuBarSymbol.fallback
         )
     }
 }

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolVersionBackupClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolVersionBackupClient.swift
@@ -5,29 +5,41 @@ struct ToolContentVersionBackup: Equatable {
     let contentViewPath: String
     let pendingURL: URL
     let previousURL: URL
+    let pendingBuildSettingsURL: URL
+    let previousBuildSettingsURL: URL
 }
 
 struct ToolVersionBackupClient {
-    var stageCurrentVersion: (_ packageRootURL: URL, _ contentViewPath: String) throws -> ToolContentVersionBackup
+    var stageCurrentVersion: (
+        _ packageRootURL: URL,
+        _ contentViewPath: String,
+        _ settings: ToolGenerationSettings
+    ) throws -> ToolContentVersionBackup
     var promoteStagedVersion: (_ backup: ToolContentVersionBackup) throws -> Void
     var discardStagedVersion: (_ backup: ToolContentVersionBackup) throws -> Void
     var hasPreviousVersion: (_ packageRootURL: URL, _ contentViewPath: String) -> Bool
-    var restorePreviousVersion: (_ packageRootURL: URL, _ contentViewPath: String) throws -> Void
+    var restorePreviousVersion: (
+        _ packageRootURL: URL,
+        _ contentViewPath: String,
+        _ currentSettings: ToolGenerationSettings
+    ) throws -> ToolGenerationSettings
 
     nonisolated static let live = ToolVersionBackupClient(
-        stageCurrentVersion: { packageRootURL, contentViewPath in
+        stageCurrentVersion: { packageRootURL, contentViewPath, settings in
             let contentViewURL = try resolvedContentViewURL(
                 packageRootURL: packageRootURL,
                 contentViewPath: contentViewPath
             )
             let backup = try backupPaths(packageRootURL: packageRootURL, contentViewPath: contentViewPath)
             let source = try String(contentsOf: contentViewURL, encoding: .utf8)
+            let settingsData = try JSONEncoder().encode(ToolVersionBuildSettingsSnapshot(settings: settings))
 
             try FileManager.default.createDirectory(
                 at: backup.pendingURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
             try source.write(to: backup.pendingURL, atomically: true, encoding: .utf8)
+            try settingsData.write(to: backup.pendingBuildSettingsURL, options: .atomic)
             return backup
         },
         promoteStagedVersion: { backup in
@@ -38,10 +50,23 @@ struct ToolVersionBackupClient {
                 try FileManager.default.removeItem(at: backup.previousURL)
             }
             try FileManager.default.moveItem(at: backup.pendingURL, to: backup.previousURL)
+            if FileManager.default.fileExists(atPath: backup.previousBuildSettingsURL.path) {
+                try FileManager.default.removeItem(at: backup.previousBuildSettingsURL)
+            }
+            if FileManager.default.fileExists(atPath: backup.pendingBuildSettingsURL.path) {
+                try FileManager.default.moveItem(
+                    at: backup.pendingBuildSettingsURL,
+                    to: backup.previousBuildSettingsURL
+                )
+            }
         },
         discardStagedVersion: { backup in
-            guard FileManager.default.fileExists(atPath: backup.pendingURL.path) else { return }
-            try FileManager.default.removeItem(at: backup.pendingURL)
+            if FileManager.default.fileExists(atPath: backup.pendingURL.path) {
+                try FileManager.default.removeItem(at: backup.pendingURL)
+            }
+            if FileManager.default.fileExists(atPath: backup.pendingBuildSettingsURL.path) {
+                try FileManager.default.removeItem(at: backup.pendingBuildSettingsURL)
+            }
         },
         hasPreviousVersion: { packageRootURL, contentViewPath in
             guard let backup = try? backupPaths(packageRootURL: packageRootURL, contentViewPath: contentViewPath) else {
@@ -49,7 +74,7 @@ struct ToolVersionBackupClient {
             }
             return FileManager.default.fileExists(atPath: backup.previousURL.path)
         },
-        restorePreviousVersion: { packageRootURL, contentViewPath in
+        restorePreviousVersion: { packageRootURL, contentViewPath, currentSettings in
             let contentViewURL = try resolvedContentViewURL(
                 packageRootURL: packageRootURL,
                 contentViewPath: contentViewPath
@@ -60,12 +85,19 @@ struct ToolVersionBackupClient {
             }
 
             let previousSource = try String(contentsOf: backup.previousURL, encoding: .utf8)
+            let previousSettings = try readBuildSettings(
+                at: backup.previousBuildSettingsURL,
+                fallback: currentSettings
+            )
             let currentSource: String
             if FileManager.default.fileExists(atPath: contentViewURL.path) {
                 currentSource = try String(contentsOf: contentViewURL, encoding: .utf8)
             } else {
                 currentSource = ""
             }
+            let currentSettingsData = try JSONEncoder().encode(
+                ToolVersionBuildSettingsSnapshot(settings: currentSettings)
+            )
 
             try FileManager.default.createDirectory(
                 at: contentViewURL.deletingLastPathComponent(),
@@ -73,6 +105,12 @@ struct ToolVersionBackupClient {
             )
             try previousSource.write(to: contentViewURL, atomically: true, encoding: .utf8)
             try currentSource.write(to: backup.previousURL, atomically: true, encoding: .utf8)
+            try FileManager.default.createDirectory(
+                at: backup.previousBuildSettingsURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try currentSettingsData.write(to: backup.previousBuildSettingsURL, options: .atomic)
+            return previousSettings
         }
     )
 }
@@ -100,7 +138,9 @@ private func backupPaths(
         packageRootURL: packageRootURL,
         contentViewPath: contentViewPath,
         pendingURL: ToolPackageLayout.pendingContentViewVersionURL(for: packageRootURL),
-        previousURL: ToolPackageLayout.previousContentViewVersionURL(for: packageRootURL)
+        previousURL: ToolPackageLayout.previousContentViewVersionURL(for: packageRootURL),
+        pendingBuildSettingsURL: ToolPackageLayout.pendingBuildSettingsVersionURL(for: packageRootURL),
+        previousBuildSettingsURL: ToolPackageLayout.previousBuildSettingsVersionURL(for: packageRootURL)
     )
 }
 
@@ -109,4 +149,41 @@ private func resolvedContentViewURL(
     contentViewPath: String
 ) throws -> URL {
     try ToolPackageLayout.packageFileURL(for: contentViewPath, packageRootURL: packageRootURL)
+}
+
+nonisolated private struct ToolVersionBuildSettingsSnapshot: Codable, Equatable {
+    var appKindRawValue: String
+    var menuBarSystemImage: String
+    var sandboxEnabled: Bool
+    var sandboxPermissionRawValues: String
+    var resourcePermissionRawValues: String
+
+    init(settings: ToolGenerationSettings) {
+        appKindRawValue = settings.appKind.rawValue
+        menuBarSystemImage = settings.menuBarSystemImage
+        sandboxEnabled = settings.sandboxEnabled
+        sandboxPermissionRawValues = settings.sandboxPermissions.rawValueList
+        resourcePermissionRawValues = settings.resourcePermissions.rawValueList
+    }
+
+    var settings: ToolGenerationSettings {
+        ToolGenerationSettings(
+            appKind: ToolAppKind(rawValue: appKindRawValue) ?? .window,
+            menuBarSystemImage: menuBarSystemImage,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: GeneratedAppSandboxPermissions(rawValueList: sandboxPermissionRawValues),
+            resourcePermissions: GeneratedAppResourcePermissions(rawValueList: resourcePermissionRawValues)
+        )
+    }
+}
+
+private func readBuildSettings(
+    at url: URL,
+    fallback: ToolGenerationSettings
+) throws -> ToolGenerationSettings {
+    guard FileManager.default.fileExists(atPath: url.path) else {
+        return fallback
+    }
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(ToolVersionBuildSettingsSnapshot.self, from: data).settings
 }

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -214,18 +214,18 @@ extension Tool {
 }
 
 extension GeneratedAppResourcePermissions {
-    init(rawValueList: String) {
+    nonisolated init(rawValueList: String) {
         let rawValues = Self.rawValues(from: rawValueList)
         self.init(
             GeneratedAppResourcePermission.allCases.filter { rawValues.contains($0.rawValue) }
         )
     }
 
-    var rawValueList: String {
+    nonisolated var rawValueList: String {
         enabledPermissions.map(\.rawValue).joined(separator: ",")
     }
 
-    private static func rawValues(from rawValueList: String) -> Set<String> {
+    nonisolated private static func rawValues(from rawValueList: String) -> Set<String> {
         Set(
             rawValueList
                 .split(separator: ",")
@@ -236,18 +236,18 @@ extension GeneratedAppResourcePermissions {
 }
 
 extension GeneratedAppSandboxPermissions {
-    init(rawValueList: String) {
+    nonisolated init(rawValueList: String) {
         let rawValues = Self.rawValues(from: rawValueList)
         self.init(
             GeneratedAppSandboxPermission.allCases.filter { rawValues.contains($0.rawValue) }
         )
     }
 
-    var rawValueList: String {
+    nonisolated var rawValueList: String {
         enabledPermissions.map(\.rawValue).joined(separator: ",")
     }
 
-    private static func rawValues(from rawValueList: String) -> Set<String> {
+    nonisolated private static func rawValues(from rawValueList: String) -> Set<String> {
         Set(
             rawValueList
                 .split(separator: ",")

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -38,6 +38,10 @@ final class Tool {
     var executableName: String
     var bundleIdentifier: String
     var sandboxEnabled: Bool
+    var appKindRawValue: String = ToolAppKind.window.rawValue
+    var menuBarSystemImage: String = ToolMenuBarSymbol.fallback
+    var sandboxPermissionRawValues: String?
+    var resourcePermissionRawValues: String?
     var packageRootPath: String
     var generationStateRawValue: String = ToolGenerationState.ready.rawValue
     var generationPhaseRawValue: String? = ToolGenerationPhase.completed.rawValue
@@ -54,6 +58,10 @@ final class Tool {
         executableName: String? = nil,
         bundleIdentifier: String? = nil,
         sandboxEnabled: Bool = true,
+        appKind: ToolAppKind = .window,
+        menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
+        sandboxPermissions: GeneratedAppSandboxPermissions? = nil,
+        resourcePermissions: GeneratedAppResourcePermissions? = nil,
         packageRootPath: String,
         generationState: ToolGenerationState = .ready,
         generationPhase: ToolGenerationPhase? = .completed,
@@ -70,6 +78,10 @@ final class Tool {
         self.executableName = resolvedExecutableName
         self.bundleIdentifier = bundleIdentifier ?? ToolBundleIdentifier.make(executableName: resolvedExecutableName)
         self.sandboxEnabled = sandboxEnabled
+        self.appKindRawValue = appKind.rawValue
+        self.menuBarSystemImage = ToolMenuBarSymbol.validated(menuBarSystemImage)
+        self.sandboxPermissionRawValues = sandboxPermissions?.rawValueList
+        self.resourcePermissionRawValues = resourcePermissions?.rawValueList
         self.packageRootPath = packageRootPath
         self.generationStateRawValue = generationState.rawValue
         self.generationPhaseRawValue = generationPhase?.rawValue
@@ -106,6 +118,72 @@ extension Tool {
         }
     }
 
+    var appKind: ToolAppKind {
+        get {
+            ToolAppKind(rawValue: appKindRawValue) ?? .window
+        }
+        set {
+            appKindRawValue = newValue.rawValue
+        }
+    }
+
+    var validatedMenuBarSystemImage: String {
+        get {
+            ToolMenuBarSymbol.validated(menuBarSystemImage)
+        }
+        set {
+            menuBarSystemImage = ToolMenuBarSymbol.validated(newValue)
+        }
+    }
+
+    var storedSandboxPermissions: GeneratedAppSandboxPermissions? {
+        get {
+            guard let sandboxPermissionRawValues else { return nil }
+            return GeneratedAppSandboxPermissions(rawValueList: sandboxPermissionRawValues)
+        }
+        set {
+            sandboxPermissionRawValues = newValue?.rawValueList
+        }
+    }
+
+    var storedResourcePermissions: GeneratedAppResourcePermissions? {
+        get {
+            guard let resourcePermissionRawValues else { return nil }
+            return GeneratedAppResourcePermissions(rawValueList: resourcePermissionRawValues)
+        }
+        set {
+            resourcePermissionRawValues = newValue?.rawValueList
+        }
+    }
+
+    func generationSettings(
+        defaultSandboxPermissions: GeneratedAppSandboxPermissions,
+        defaultResourcePermissions: GeneratedAppResourcePermissions
+    ) -> ToolGenerationSettings {
+        ToolGenerationSettings(
+            appKind: appKind,
+            menuBarSystemImage: validatedMenuBarSystemImage,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: storedSandboxPermissions ?? defaultSandboxPermissions,
+            resourcePermissions: storedResourcePermissions ?? defaultResourcePermissions
+        )
+    }
+
+    func generationSettings(defaults: ToolGenerationSettings) -> ToolGenerationSettings {
+        generationSettings(
+            defaultSandboxPermissions: defaults.sandboxPermissions,
+            defaultResourcePermissions: defaults.resourcePermissions
+        )
+    }
+
+    func applyGenerationSettings(_ settings: ToolGenerationSettings) {
+        appKind = settings.appKind
+        validatedMenuBarSystemImage = settings.menuBarSystemImage
+        sandboxEnabled = settings.sandboxEnabled
+        storedSandboxPermissions = settings.sandboxPermissions
+        storedResourcePermissions = settings.resourcePermissions
+    }
+
     var isGenerationReady: Bool {
         generationState == .ready
     }
@@ -132,6 +210,50 @@ extension Tool {
 
     var appBundleURL: URL {
         packageRootURL.appendingPathComponent("\(ToolNameSanitizer.appBundleName(from: name)).app", isDirectory: true)
+    }
+}
+
+extension GeneratedAppResourcePermissions {
+    init(rawValueList: String) {
+        let rawValues = Self.rawValues(from: rawValueList)
+        self.init(
+            GeneratedAppResourcePermission.allCases.filter { rawValues.contains($0.rawValue) }
+        )
+    }
+
+    var rawValueList: String {
+        enabledPermissions.map(\.rawValue).joined(separator: ",")
+    }
+
+    private static func rawValues(from rawValueList: String) -> Set<String> {
+        Set(
+            rawValueList
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
+    }
+}
+
+extension GeneratedAppSandboxPermissions {
+    init(rawValueList: String) {
+        let rawValues = Self.rawValues(from: rawValueList)
+        self.init(
+            GeneratedAppSandboxPermission.allCases.filter { rawValues.contains($0.rawValue) }
+        )
+    }
+
+    var rawValueList: String {
+        enabledPermissions.map(\.rawValue).joined(separator: ",")
+    }
+
+    private static func rawValues(from rawValueList: String) -> Set<String> {
+        Set(
+            rawValueList
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+        )
     }
 }
 

--- a/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
@@ -65,7 +65,7 @@ struct SettingsPreferencesSectionView: View {
                 }
             }
         } header: {
-            Text("Generated app permissions")
+            Text("Default generated app permissions")
         }
     }
 

--- a/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
@@ -8,12 +8,18 @@ import SwiftUI
 struct PromptComposerView: View {
     @Binding var prompt: String
     @Binding var sandboxEnabled: Bool
+    @Binding var appKind: ToolAppKind
+    @Binding var sandboxPermissions: GeneratedAppSandboxPermissions
+    @Binding var resourcePermissions: GeneratedAppResourcePermissions
+    let usesToolPermissionSettings: Bool
+    let generationPreferences: GenerationPreferencesStore
     let placeholder: String
-    let showsSandboxToggle: Bool
+    let showsSandboxControl: Bool
     let isSubmitEnabled: Bool
     let isSubmitting: Bool
     let onSubmit: () -> Void
     let onCancel: () -> Void
+    @State private var pendingPermission: GeneratedAppResourcePermission?
 
     var body: some View {
         VStack(spacing: 12) {
@@ -31,20 +37,7 @@ struct PromptComposerView: View {
                 .accessibilityIdentifier("tool-prompt-field")
 
             HStack {
-                if showsSandboxToggle {
-                    Toggle(isOn: $sandboxEnabled) {
-                        HStack(spacing: 4) {
-                            Image(systemName: sandboxEnabled ? "lock.fill" : "lock.open.fill")
-                                .frame(width: 14, alignment: .center)
-                                .accessibilityHidden(true)
-                            Text(sandboxLabel)
-                        }
-                    }
-                    .toggleStyle(.switch)
-                    .font(.caption)
-                    .disabled(isSubmitting)
-                    .help(sandboxHelpText)
-                }
+                generationSettingsMenu
 
                 Spacer()
 
@@ -76,6 +69,71 @@ struct PromptComposerView: View {
                 .accessibilityIdentifier(isSubmitting ? "stop-generation-button" : "submit-generation-button")
             }
         }
+        .alert(
+            pendingPermission?.enablementWarningTitle ?? "Allow Access?",
+            isPresented: Binding(
+                get: { pendingPermission != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        pendingPermission = nil
+                    }
+                }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                pendingPermission = nil
+            }
+            Button("Enable") {
+                if let pendingPermission {
+                    setResourcePermission(pendingPermission, enabled: true)
+                }
+                pendingPermission = nil
+            }
+        } message: {
+            Text(pendingPermission?.enablementWarningMessage ?? "")
+        }
+    }
+
+    private var generationSettingsMenu: some View {
+        Menu {
+            Picker("App Type", selection: $appKind) {
+                ForEach(ToolAppKind.allCases, id: \.self) { kind in
+                    Label(kind.displayName, systemImage: kind == .menuBar ? "menubar.rectangle" : "macwindow")
+                        .tag(kind)
+                }
+            }
+
+            if showsSandboxControl {
+                Divider()
+                Toggle(isOn: $sandboxEnabled) {
+                    Label(sandboxLabel, systemImage: sandboxEnabled ? "lock.fill" : "lock.open.fill")
+                }
+                .help(sandboxHelpText)
+            }
+
+            Divider()
+
+            Section("General Access") {
+                ForEach(GeneratedAppResourcePermission.allCases) { permission in
+                    Toggle(permission.displayName, isOn: resourcePermissionBinding(for: permission))
+                }
+            }
+
+            Section("Sandbox Access") {
+                ForEach(GeneratedAppSandboxPermission.allCases) { permission in
+                    Toggle(permission.displayName, isOn: sandboxPermissionBinding(for: permission))
+                }
+            }
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 18, weight: .semibold))
+                .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.plain)
+        .help("Generation settings")
+        .accessibilityLabel("Generation settings")
+        .accessibilityIdentifier("generation-settings-menu")
+        .disabled(isSubmitting)
     }
 
     private var submitButtonForegroundStyle: some ShapeStyle {
@@ -99,14 +157,79 @@ struct PromptComposerView: View {
             ? "Generated apps will include App Sandbox entitlements."
             : "Generated apps will be built without App Sandbox entitlements."
     }
+
+    private func resourcePermissionBinding(for permission: GeneratedAppResourcePermission) -> Binding<Bool> {
+        Binding(
+            get: { currentResourcePermissions.contains(permission) },
+            set: { isEnabled in
+                if isEnabled, permission.enablementWarningMessage != nil {
+                    pendingPermission = permission
+                } else {
+                    setResourcePermission(permission, enabled: isEnabled)
+                }
+            }
+        )
+    }
+
+    private func sandboxPermissionBinding(for permission: GeneratedAppSandboxPermission) -> Binding<Bool> {
+        Binding(
+            get: { currentSandboxPermissions.contains(permission) },
+            set: { setSandboxPermission(permission, enabled: $0) }
+        )
+    }
+
+    private var currentResourcePermissions: GeneratedAppResourcePermissions {
+        usesToolPermissionSettings
+            ? resourcePermissions
+            : generationPreferences.generatedAppResourcePermissions
+    }
+
+    private var currentSandboxPermissions: GeneratedAppSandboxPermissions {
+        usesToolPermissionSettings
+            ? sandboxPermissions
+            : generationPreferences.generatedAppSandboxPermissions
+    }
+
+    private func setResourcePermission(_ permission: GeneratedAppResourcePermission, enabled: Bool) {
+        if usesToolPermissionSettings {
+            var updated = resourcePermissions
+            if enabled {
+                updated.enabled.insert(permission)
+            } else {
+                updated.enabled.remove(permission)
+            }
+            resourcePermissions = updated
+        } else {
+            generationPreferences.setGeneratedAppResourcePermission(permission, enabled: enabled)
+        }
+    }
+
+    private func setSandboxPermission(_ permission: GeneratedAppSandboxPermission, enabled: Bool) {
+        if usesToolPermissionSettings {
+            var updated = sandboxPermissions
+            if enabled {
+                updated.enabled.insert(permission)
+            } else {
+                updated.enabled.remove(permission)
+            }
+            sandboxPermissions = updated
+        } else {
+            generationPreferences.setGeneratedAppSandboxPermission(permission, enabled: enabled)
+        }
+    }
 }
 
 #Preview("Create Prompt") {
     PromptComposerView(
         prompt: .constant(""),
         sandboxEnabled: .constant(true),
+        appKind: .constant(.window),
+        sandboxPermissions: .constant(.default),
+        resourcePermissions: .constant(.none),
+        usesToolPermissionSettings: false,
+        generationPreferences: GenerationPreferencesStore(),
         placeholder: "Describe a new app to build…",
-        showsSandboxToggle: false,
+        showsSandboxControl: false,
         isSubmitEnabled: false,
         isSubmitting: false,
         onSubmit: {},
@@ -120,8 +243,13 @@ struct PromptComposerView: View {
     PromptComposerView(
         prompt: .constant(""),
         sandboxEnabled: .constant(false),
+        appKind: .constant(.menuBar),
+        sandboxPermissions: .constant(.default),
+        resourcePermissions: .constant(GeneratedAppResourcePermissions([.camera])),
+        usesToolPermissionSettings: true,
+        generationPreferences: GenerationPreferencesStore(),
         placeholder: "Describe changes for Clipboard Cleaner…",
-        showsSandboxToggle: true,
+        showsSandboxControl: true,
         isSubmitEnabled: true,
         isSubmitting: false,
         onSubmit: {},

--- a/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
@@ -11,8 +11,6 @@ struct PromptComposerView: View {
     @Binding var appKind: ToolAppKind
     @Binding var sandboxPermissions: GeneratedAppSandboxPermissions
     @Binding var resourcePermissions: GeneratedAppResourcePermissions
-    let usesToolPermissionSettings: Bool
-    let generationPreferences: GenerationPreferencesStore
     let placeholder: String
     let showsSandboxControl: Bool
     let isSubmitEnabled: Bool
@@ -105,23 +103,23 @@ struct PromptComposerView: View {
 
             if showsSandboxControl {
                 Divider()
-                Toggle(isOn: $sandboxEnabled) {
-                    Label(sandboxLabel, systemImage: sandboxEnabled ? "lock.fill" : "lock.open.fill")
-                }
+                Toggle("Sandbox Enabled", isOn: $sandboxEnabled)
                 .help(sandboxHelpText)
             }
 
             Divider()
 
-            Section("General Access") {
-                ForEach(GeneratedAppResourcePermission.allCases) { permission in
-                    Toggle(permission.displayName, isOn: resourcePermissionBinding(for: permission))
+            Menu("Permissions") {
+                Section("General Access") {
+                    ForEach(GeneratedAppResourcePermission.allCases) { permission in
+                        Toggle(permission.displayName, isOn: resourcePermissionBinding(for: permission))
+                    }
                 }
-            }
 
-            Section("Sandbox Access") {
-                ForEach(GeneratedAppSandboxPermission.allCases) { permission in
-                    Toggle(permission.displayName, isOn: sandboxPermissionBinding(for: permission))
+                Section("Sandbox Access") {
+                    ForEach(GeneratedAppSandboxPermission.allCases) { permission in
+                        Toggle(permission.displayName, isOn: sandboxPermissionBinding(for: permission))
+                    }
                 }
             }
         } label: {
@@ -148,14 +146,8 @@ struct PromptComposerView: View {
         return AnyShapeStyle(.secondary)
     }
 
-    private var sandboxLabel: String {
-        sandboxEnabled ? "Sandbox On" : "Sandbox Off"
-    }
-
     private var sandboxHelpText: String {
-        sandboxEnabled
-            ? "Generated apps will include App Sandbox entitlements."
-            : "Generated apps will be built without App Sandbox entitlements."
+        "Controls whether generated apps include App Sandbox entitlements."
     }
 
     private func resourcePermissionBinding(for permission: GeneratedAppResourcePermission) -> Binding<Bool> {
@@ -179,43 +171,31 @@ struct PromptComposerView: View {
     }
 
     private var currentResourcePermissions: GeneratedAppResourcePermissions {
-        usesToolPermissionSettings
-            ? resourcePermissions
-            : generationPreferences.generatedAppResourcePermissions
+        resourcePermissions
     }
 
     private var currentSandboxPermissions: GeneratedAppSandboxPermissions {
-        usesToolPermissionSettings
-            ? sandboxPermissions
-            : generationPreferences.generatedAppSandboxPermissions
+        sandboxPermissions
     }
 
     private func setResourcePermission(_ permission: GeneratedAppResourcePermission, enabled: Bool) {
-        if usesToolPermissionSettings {
-            var updated = resourcePermissions
-            if enabled {
-                updated.enabled.insert(permission)
-            } else {
-                updated.enabled.remove(permission)
-            }
-            resourcePermissions = updated
+        var updated = resourcePermissions
+        if enabled {
+            updated.enabled.insert(permission)
         } else {
-            generationPreferences.setGeneratedAppResourcePermission(permission, enabled: enabled)
+            updated.enabled.remove(permission)
         }
+        resourcePermissions = updated
     }
 
     private func setSandboxPermission(_ permission: GeneratedAppSandboxPermission, enabled: Bool) {
-        if usesToolPermissionSettings {
-            var updated = sandboxPermissions
-            if enabled {
-                updated.enabled.insert(permission)
-            } else {
-                updated.enabled.remove(permission)
-            }
-            sandboxPermissions = updated
+        var updated = sandboxPermissions
+        if enabled {
+            updated.enabled.insert(permission)
         } else {
-            generationPreferences.setGeneratedAppSandboxPermission(permission, enabled: enabled)
+            updated.enabled.remove(permission)
         }
+        sandboxPermissions = updated
     }
 }
 
@@ -226,8 +206,6 @@ struct PromptComposerView: View {
         appKind: .constant(.window),
         sandboxPermissions: .constant(.default),
         resourcePermissions: .constant(.none),
-        usesToolPermissionSettings: false,
-        generationPreferences: GenerationPreferencesStore(),
         placeholder: "Describe a new app to build…",
         showsSandboxControl: false,
         isSubmitEnabled: false,
@@ -246,8 +224,6 @@ struct PromptComposerView: View {
         appKind: .constant(.menuBar),
         sandboxPermissions: .constant(.default),
         resourcePermissions: .constant(GeneratedAppResourcePermissions([.camera])),
-        usesToolPermissionSettings: true,
-        generationPreferences: GenerationPreferencesStore(),
         placeholder: "Describe changes for Clipboard Cleaner…",
         showsSandboxControl: true,
         isSubmitEnabled: true,

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -62,7 +62,10 @@ struct ToolLibraryPopoverView: View {
                                 isExporting: toolLibraryStore.exportingToolID == tool.id,
                                 canRevert: toolLibraryStore.canRestorePreviousVersion(tool),
                                 onSelect: {
-                                    toolLibraryStore.toggleSelection(for: tool)
+                                    toolLibraryStore.toggleSelection(
+                                        for: tool,
+                                        defaultSettings: defaultGenerationSettings
+                                    )
                                 },
                                 onRun: {
                                     Task {
@@ -122,8 +125,13 @@ struct ToolLibraryPopoverView: View {
             PromptComposerView(
                 prompt: $toolLibraryStore.prompt,
                 sandboxEnabled: $toolLibraryStore.sandboxEnabled,
+                appKind: $toolLibraryStore.appKind,
+                sandboxPermissions: $toolLibraryStore.sandboxPermissions,
+                resourcePermissions: $toolLibraryStore.resourcePermissions,
+                usesToolPermissionSettings: toolLibraryStore.hasSelectedTool,
+                generationPreferences: inferenceStore.generationPreferences,
                 placeholder: toolLibraryStore.promptPlaceholder,
-                showsSandboxToggle: showSandboxOverride,
+                showsSandboxControl: showSandboxOverride,
                 isSubmitEnabled: canSubmitPrompt,
                 isSubmitting: toolLibraryStore.isGenerating,
                 onSubmit: {
@@ -167,7 +175,7 @@ struct ToolLibraryPopoverView: View {
             presentWelcomeOnboardingIfNeeded()
         }
         .onChange(of: tools.map(\.id)) { _, _ in
-            toolLibraryStore.syncSelection(with: tools)
+            toolLibraryStore.syncSelection(with: tools, defaultSettings: defaultGenerationSettings)
         }
         .onChange(of: showSandboxOverride) { _, isEnabled in
             if !isEnabled {
@@ -308,6 +316,10 @@ struct ToolLibraryPopoverView: View {
         }
 
         return inferenceStore.selectedModelID
+    }
+
+    private var defaultGenerationSettings: ToolGenerationSettings {
+        ToolLibraryStore.defaultGenerationSettings(from: inferenceStore.generationPreferences)
     }
 
     private func openIronsmithCreditPurchase() {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -124,12 +124,10 @@ struct ToolLibraryPopoverView: View {
 
             PromptComposerView(
                 prompt: $toolLibraryStore.prompt,
-                sandboxEnabled: $toolLibraryStore.sandboxEnabled,
-                appKind: $toolLibraryStore.appKind,
-                sandboxPermissions: $toolLibraryStore.sandboxPermissions,
-                resourcePermissions: $toolLibraryStore.resourcePermissions,
-                usesToolPermissionSettings: toolLibraryStore.hasSelectedTool,
-                generationPreferences: inferenceStore.generationPreferences,
+                sandboxEnabled: sandboxEnabledBinding,
+                appKind: appKindBinding,
+                sandboxPermissions: sandboxPermissionsBinding,
+                resourcePermissions: resourcePermissionsBinding,
                 placeholder: toolLibraryStore.promptPlaceholder,
                 showsSandboxControl: showSandboxOverride,
                 isSubmitEnabled: canSubmitPrompt,
@@ -153,6 +151,7 @@ struct ToolLibraryPopoverView: View {
         .frame(width: 340, height: 520)
         .accessibilityIdentifier("tool-library-root")
         .onAppear {
+            toolLibraryStore.initializeNextGenerationSettingsIfNeeded(defaultGenerationSettings)
             presentWelcomeOnboardingIfNeeded()
         }
         .onDisappear {
@@ -177,9 +176,13 @@ struct ToolLibraryPopoverView: View {
         .onChange(of: tools.map(\.id)) { _, _ in
             toolLibraryStore.syncSelection(with: tools, defaultSettings: defaultGenerationSettings)
         }
+        .onChange(of: defaultGenerationSettings) { _, settings in
+            toolLibraryStore.initializeNextGenerationSettingsIfNeeded(settings)
+        }
         .onChange(of: showSandboxOverride) { _, isEnabled in
             if !isEnabled {
                 toolLibraryStore.sandboxEnabled = true
+                toolLibraryStore.rememberCurrentGenerationSettingsForNextGeneration()
             }
         }
         .alert(
@@ -320,6 +323,46 @@ struct ToolLibraryPopoverView: View {
 
     private var defaultGenerationSettings: ToolGenerationSettings {
         ToolLibraryStore.defaultGenerationSettings(from: inferenceStore.generationPreferences)
+    }
+
+    private var sandboxEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { toolLibraryStore.sandboxEnabled },
+            set: { newValue in
+                toolLibraryStore.sandboxEnabled = newValue
+                toolLibraryStore.rememberCurrentGenerationSettingsForNextGeneration()
+            }
+        )
+    }
+
+    private var appKindBinding: Binding<ToolAppKind> {
+        Binding(
+            get: { toolLibraryStore.appKind },
+            set: { newValue in
+                toolLibraryStore.appKind = newValue
+                toolLibraryStore.rememberCurrentGenerationSettingsForNextGeneration()
+            }
+        )
+    }
+
+    private var sandboxPermissionsBinding: Binding<GeneratedAppSandboxPermissions> {
+        Binding(
+            get: { toolLibraryStore.sandboxPermissions },
+            set: { newValue in
+                toolLibraryStore.sandboxPermissions = newValue
+                toolLibraryStore.rememberCurrentGenerationSettingsForNextGeneration()
+            }
+        )
+    }
+
+    private var resourcePermissionsBinding: Binding<GeneratedAppResourcePermissions> {
+        Binding(
+            get: { toolLibraryStore.resourcePermissions },
+            set: { newValue in
+                toolLibraryStore.resourcePermissions = newValue
+                toolLibraryStore.rememberCurrentGenerationSettingsForNextGeneration()
+            }
+        )
     }
 
     private func openIronsmithCreditPurchase() {

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -237,11 +237,28 @@ final class ToolLibraryStore {
         }
 
         do {
-            let contentViewPath = try Self.contentViewPath(for: tool)
-            try dependencies.versionBackupClient.restorePreviousVersion(tool.packageRootURL, contentViewPath)
+            let manifest = try Self.manifest(for: tool)
+            let layout = ToolPackageLayout(
+                packageRootURL: tool.packageRootURL,
+                executableName: manifest.executableName
+            )
+            let contentViewPath = manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
+            let restoredSettings = try dependencies.versionBackupClient.restorePreviousVersion(
+                tool.packageRootURL,
+                contentViewPath,
+                tool.generationSettings(defaults: .default)
+            )
+            tool.applyGenerationSettings(restoredSettings)
+            try Self.writeAppEntry(
+                layout: layout,
+                displayName: manifest.displayName,
+                settings: restoredSettings
+            )
             try await dependencies.buildClient.buildTool(tool)
             clearPendingGeneration(on: tool)
-            tool.updatedAt = .now
+            if selectedToolID == tool.id {
+                applyComposerSettings(restoredSettings)
+            }
             try modelContext.save()
         } catch {
             modelContext.rollback()
@@ -751,8 +768,7 @@ final class ToolLibraryStore {
     }
 
     private static func contentViewPath(for tool: Tool) throws -> String {
-        let data = try Data(contentsOf: tool.agentManifestURL)
-        let manifest = try JSONDecoder().decode(ToolManifest.self, from: data)
+        let manifest = try manifest(for: tool)
         let layout = ToolPackageLayout(
             packageRootURL: tool.packageRootURL,
             executableName: manifest.executableName
@@ -760,9 +776,28 @@ final class ToolLibraryStore {
         return manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
     }
 
+    private static func manifest(for tool: Tool) throws -> ToolManifest {
+        let data = try Data(contentsOf: tool.agentManifestURL)
+        return try JSONDecoder().decode(ToolManifest.self, from: data)
+    }
+
     private static func contentViewURL(for tool: Tool) throws -> URL {
         let contentViewPath = try contentViewPath(for: tool)
         return try ToolPackageLayout.packageFileURL(for: contentViewPath, packageRootURL: tool.packageRootURL)
+    }
+
+    private static func writeAppEntry(
+        layout: ToolPackageLayout,
+        displayName: String,
+        settings: ToolGenerationSettings
+    ) throws {
+        let appEntryURL = try layout.packageFileURL(for: layout.appEntrySourcePath)
+        try FileManager.default.createDirectory(
+            at: appEntryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try layout.fixedAppEntrySource(displayName: displayName, settings: settings)
+            .write(to: appEntryURL, atomically: true, encoding: .utf8)
     }
 
     private static var defaultPrompt: String {

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -37,6 +37,8 @@ final class ToolLibraryStore {
     private(set) var selectedToolID: UUID?
     private(set) var selectedToolName: String?
     private var restorableToolIDs = Set<UUID>()
+    @ObservationIgnored private var nextGenerationSettings: ToolGenerationSettings?
+    @ObservationIgnored private var hasCustomizedNextGenerationSettings = false
     @ObservationIgnored private var generationTask: Task<Void, Never>?
     private let dependencies: ToolLibraryDependencies
 
@@ -67,6 +69,7 @@ final class ToolLibraryStore {
     }
 
     func toggleSelection(for tool: Tool, defaultSettings: ToolGenerationSettings = .default) {
+        initializeNextGenerationSettingsIfNeeded(defaultSettings)
         if selectedToolID == tool.id {
             clearSelection()
         } else {
@@ -76,6 +79,7 @@ final class ToolLibraryStore {
 
     func selectForEditing(_ tool: Tool, defaultSettings: ToolGenerationSettings = .default) {
         guard tool.isGenerationReady else { return }
+        initializeNextGenerationSettingsIfNeeded(defaultSettings)
         selectedToolID = tool.id
         selectedToolName = tool.name
         applyComposerSettings(tool.generationSettings(defaults: defaultSettings))
@@ -89,6 +93,7 @@ final class ToolLibraryStore {
     }
 
     func syncSelection(with tools: [Tool], defaultSettings: ToolGenerationSettings = .default) {
+        initializeNextGenerationSettingsIfNeeded(defaultSettings)
         restorableToolIDs.formIntersection(tools.map(\.id))
 
         guard let selectedToolID else {
@@ -106,6 +111,19 @@ final class ToolLibraryStore {
 
         selectedToolName = selectedTool.name
         applyComposerSettings(selectedTool.generationSettings(defaults: defaultSettings))
+    }
+
+    func initializeNextGenerationSettingsIfNeeded(_ defaultSettings: ToolGenerationSettings) {
+        guard !hasCustomizedNextGenerationSettings else { return }
+        nextGenerationSettings = defaultSettings
+        if !hasSelectedTool {
+            applyComposerSettings(defaultSettings)
+        }
+    }
+
+    func rememberCurrentGenerationSettingsForNextGeneration() {
+        nextGenerationSettings = currentComposerSettings
+        hasCustomizedNextGenerationSettings = true
     }
 
     func isSelected(_ tool: Tool) -> Bool {
@@ -446,11 +464,17 @@ final class ToolLibraryStore {
     private func clearSelection() {
         selectedToolID = nil
         selectedToolName = nil
-        sandboxEnabled = true
-        appKind = .window
-        menuBarSystemImage = ToolMenuBarSymbol.fallback
-        sandboxPermissions = .default
-        resourcePermissions = .none
+        applyComposerSettings(nextGenerationSettings ?? .default)
+    }
+
+    private var currentComposerSettings: ToolGenerationSettings {
+        ToolGenerationSettings(
+            appKind: appKind,
+            menuBarSystemImage: menuBarSystemImage,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions
+        )
     }
 
     private func applyComposerSettings(_ settings: ToolGenerationSettings) {
@@ -462,12 +486,18 @@ final class ToolLibraryStore {
     }
 
     private func submittedGenerationSettings(defaultSettings: ToolGenerationSettings) -> ToolGenerationSettings {
-        ToolGenerationSettings(
+        let defaultBackedSandboxPermissions = !hasSelectedTool && nextGenerationSettings == nil
+            ? defaultSettings.sandboxPermissions
+            : sandboxPermissions
+        let defaultBackedResourcePermissions = !hasSelectedTool && nextGenerationSettings == nil
+            ? defaultSettings.resourcePermissions
+            : resourcePermissions
+        return ToolGenerationSettings(
             appKind: appKind,
             menuBarSystemImage: menuBarSystemImage,
             sandboxEnabled: sandboxEnabled,
-            sandboxPermissions: hasSelectedTool ? sandboxPermissions : defaultSettings.sandboxPermissions,
-            resourcePermissions: hasSelectedTool ? resourcePermissions : defaultSettings.resourcePermissions
+            sandboxPermissions: defaultBackedSandboxPermissions,
+            resourcePermissions: defaultBackedResourcePermissions
         )
     }
 

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -28,6 +28,10 @@ final class ToolLibraryStore {
     var presentedErrorAction: ToolLibraryPresentedErrorAction?
     var isGenerating = false
     var sandboxEnabled = true
+    var appKind: ToolAppKind = .window
+    var menuBarSystemImage = ToolMenuBarSymbol.fallback
+    var sandboxPermissions = GeneratedAppSandboxPermissions.default
+    var resourcePermissions = GeneratedAppResourcePermissions.none
     var runningToolID: UUID?
     var exportingToolID: UUID?
     private(set) var selectedToolID: UUID?
@@ -58,19 +62,23 @@ final class ToolLibraryStore {
         !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isGenerating
     }
 
-    func toggleSelection(for tool: Tool) {
+    var hasSelectedTool: Bool {
+        selectedToolID != nil
+    }
+
+    func toggleSelection(for tool: Tool, defaultSettings: ToolGenerationSettings = .default) {
         if selectedToolID == tool.id {
             clearSelection()
         } else {
-            selectForEditing(tool)
+            selectForEditing(tool, defaultSettings: defaultSettings)
         }
     }
 
-    func selectForEditing(_ tool: Tool) {
+    func selectForEditing(_ tool: Tool, defaultSettings: ToolGenerationSettings = .default) {
         guard tool.isGenerationReady else { return }
         selectedToolID = tool.id
         selectedToolName = tool.name
-        sandboxEnabled = tool.sandboxEnabled
+        applyComposerSettings(tool.generationSettings(defaults: defaultSettings))
     }
 
     func handleDeletedTool(_ tool: Tool) {
@@ -80,7 +88,7 @@ final class ToolLibraryStore {
         }
     }
 
-    func syncSelection(with tools: [Tool]) {
+    func syncSelection(with tools: [Tool], defaultSettings: ToolGenerationSettings = .default) {
         restorableToolIDs.formIntersection(tools.map(\.id))
 
         guard let selectedToolID else {
@@ -97,7 +105,7 @@ final class ToolLibraryStore {
         }
 
         selectedToolName = selectedTool.name
-        sandboxEnabled = selectedTool.sandboxEnabled
+        applyComposerSettings(selectedTool.generationSettings(defaults: defaultSettings))
     }
 
     func isSelected(_ tool: Tool) -> Bool {
@@ -229,7 +237,9 @@ final class ToolLibraryStore {
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let submittedSelectedToolID = selectedToolID
         let submittedToolName = selectedToolName
-        let submittedSandboxEnabled = sandboxEnabled
+        let submittedSettings = submittedGenerationSettings(
+            defaultSettings: Self.defaultGenerationSettings(from: inferenceStore.generationPreferences)
+        )
         var activeTool: Tool?
         isGenerating = true
         clearPresentedErrorState()
@@ -243,8 +253,6 @@ final class ToolLibraryStore {
 
             try await inferenceStore.prepareSelectedModelForGeneration()
             let languageModelContext = try await inferenceStore.makeSelectedAgentLanguageModelContext()
-            let sandboxPermissions = inferenceStore.generationPreferences.generatedAppSandboxPermissions
-            let resourcePermissions = inferenceStore.generationPreferences.generatedAppResourcePermissions
             if let selectedTool {
                 markToolGenerating(
                     selectedTool,
@@ -267,9 +275,7 @@ final class ToolLibraryStore {
             let result = try await dependencies.generationClient.generateTool(
                 trimmedPrompt,
                 selectedTool,
-                submittedSandboxEnabled,
-                sandboxPermissions,
-                resourcePermissions,
+                submittedSettings,
                 languageModelContext,
                 lifecycle: lifecycle
             ) { _ in }
@@ -286,7 +292,11 @@ final class ToolLibraryStore {
                     name: result.toolName,
                     executableName: result.executableName,
                     bundleIdentifier: result.bundleIdentifier,
-                    sandboxEnabled: result.sandboxEnabled,
+                    sandboxEnabled: result.settings.sandboxEnabled,
+                    appKind: result.settings.appKind,
+                    menuBarSystemImage: result.settings.menuBarSystemImage,
+                    sandboxPermissions: result.settings.sandboxPermissions,
+                    resourcePermissions: result.settings.resourcePermissions,
                     packageRootPath: result.packageRootURL.path,
                     generationState: .ready,
                     generationPhase: .completed
@@ -437,6 +447,36 @@ final class ToolLibraryStore {
         selectedToolID = nil
         selectedToolName = nil
         sandboxEnabled = true
+        appKind = .window
+        menuBarSystemImage = ToolMenuBarSymbol.fallback
+        sandboxPermissions = .default
+        resourcePermissions = .none
+    }
+
+    private func applyComposerSettings(_ settings: ToolGenerationSettings) {
+        sandboxEnabled = settings.sandboxEnabled
+        appKind = settings.appKind
+        menuBarSystemImage = settings.menuBarSystemImage
+        sandboxPermissions = settings.sandboxPermissions
+        resourcePermissions = settings.resourcePermissions
+    }
+
+    private func submittedGenerationSettings(defaultSettings: ToolGenerationSettings) -> ToolGenerationSettings {
+        ToolGenerationSettings(
+            appKind: appKind,
+            menuBarSystemImage: menuBarSystemImage,
+            sandboxEnabled: sandboxEnabled,
+            sandboxPermissions: hasSelectedTool ? sandboxPermissions : defaultSettings.sandboxPermissions,
+            resourcePermissions: hasSelectedTool ? resourcePermissions : defaultSettings.resourcePermissions
+        )
+    }
+
+    static func defaultGenerationSettings(from preferences: GenerationPreferencesStore) -> ToolGenerationSettings {
+        ToolGenerationSettings(
+            sandboxEnabled: true,
+            sandboxPermissions: preferences.generatedAppSandboxPermissions,
+            resourcePermissions: preferences.generatedAppResourcePermissions
+        )
     }
 
     private func fetchSelectedTool(in modelContext: ModelContext) throws -> Tool? {
@@ -477,8 +517,9 @@ final class ToolLibraryStore {
         do {
             try await inferenceStore.prepareSelectedModelForGeneration()
             let languageModelContext = try await inferenceStore.makeSelectedAgentLanguageModelContext()
-            let sandboxPermissions = inferenceStore.generationPreferences.generatedAppSandboxPermissions
-            let resourcePermissions = inferenceStore.generationPreferences.generatedAppResourcePermissions
+            let settings = tool.generationSettings(
+                defaults: Self.defaultGenerationSettings(from: inferenceStore.generationPreferences)
+            )
             markToolGenerating(
                 tool,
                 mode: tool.generationMode ?? .create,
@@ -490,9 +531,7 @@ final class ToolLibraryStore {
             let result = try await dependencies.generationClient.generateTool(
                 resumePrompt,
                 tool,
-                tool.sandboxEnabled,
-                sandboxPermissions,
-                resourcePermissions,
+                settings,
                 languageModelContext,
                 lifecycle: lifecycle
             ) { _ in }
@@ -538,7 +577,7 @@ final class ToolLibraryStore {
                         tool.name = preparedTool.name
                         tool.executableName = preparedTool.executableName
                         tool.bundleIdentifier = preparedTool.bundleIdentifier
-                        tool.sandboxEnabled = preparedTool.sandboxEnabled
+                        tool.applyGenerationSettings(preparedTool.settings)
                         tool.packageRootPath = preparedTool.packageRootURL.path
                         tool.generationState = .generating
                         tool.generationPhase = .planning
@@ -552,7 +591,11 @@ final class ToolLibraryStore {
                             name: preparedTool.name,
                             executableName: preparedTool.executableName,
                             bundleIdentifier: preparedTool.bundleIdentifier,
-                            sandboxEnabled: preparedTool.sandboxEnabled,
+                            sandboxEnabled: preparedTool.settings.sandboxEnabled,
+                            appKind: preparedTool.settings.appKind,
+                            menuBarSystemImage: preparedTool.settings.menuBarSystemImage,
+                            sandboxPermissions: preparedTool.settings.sandboxPermissions,
+                            resourcePermissions: preparedTool.settings.resourcePermissions,
                             packageRootPath: preparedTool.packageRootURL.path,
                             generationState: .generating,
                             generationPhase: .planning,
@@ -639,7 +682,7 @@ final class ToolLibraryStore {
         tool.name = result.toolName
         tool.executableName = result.executableName
         tool.bundleIdentifier = result.bundleIdentifier
-        tool.sandboxEnabled = result.sandboxEnabled
+        tool.applyGenerationSettings(result.settings)
         tool.packageRootPath = result.packageRootURL.path
         clearPendingGeneration(on: tool)
     }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineBundleRunnerExportTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineBundleRunnerExportTests.swift
@@ -33,6 +33,15 @@ extension AgentPipelineTests {
             bundleIdentifier: "com.ironsmith.tests.runner",
             packageRootPath: root.path
         )
+        try Self.writePlistDictionary(
+            [
+                "CFBundleExecutable": "Runner",
+                "IronsmithQuitOnLastWindowClose": true,
+            ],
+            to: tool.appBundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("Info.plist")
+        )
 
         try await runner.runTool(tool)
 
@@ -77,6 +86,49 @@ extension AgentPipelineTests {
         try await runner.runTool(tool)
 
         #expect(await capture.builtRequests.map(\.executableName) == ["Partial"])
+        #expect(await capture.launchedURL == tool.appBundleURL)
+    }
+
+    @MainActor
+    @Test
+    func toolRunnerRebuildsOldInternalWindowBundleBeforeLaunching() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let tool = StoredTool(
+            name: "Old Runner",
+            executableName: "OldRunner",
+            bundleIdentifier: "com.ironsmith.tests.old-runner",
+            packageRootPath: root.path
+        )
+        try Self.writePlistDictionary(
+            [
+                "CFBundleExecutable": "OldRunner"
+            ],
+            to: tool.appBundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("Info.plist")
+        )
+
+        let capture = AppBundleCapture()
+        let appBundleClient = ToolAppBundleClient(
+            buildInternalApp: { request in
+                await capture.recordBuild(request)
+                return request.internalAppBundleURL
+            },
+            exportApp: { request, applicationsDirectoryURL in
+                applicationsDirectoryURL.appendingPathComponent("\(request.displayName).app", isDirectory: true)
+            },
+            launchApp: { url in
+                await capture.recordLaunch(url)
+            },
+            appExists: { _ in true }
+        )
+        let runner = ToolRunnerClient.live(appBundleClient: appBundleClient)
+
+        try await runner.runTool(tool)
+
+        #expect(await capture.builtRequests.map(\.executableName) == ["OldRunner"])
         #expect(await capture.launchedURL == tool.appBundleURL)
     }
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
@@ -161,7 +161,8 @@ extension AgentPipelineTests {
             metadataClient: ToolMetadataClient { _ in
                 ToolMetadataSuggestion(
                     displayName: "Focus Pad",
-                    iconPrompt: iconPrompt
+                    iconPrompt: iconPrompt,
+                    menuBarSystemImage: "note.text"
                 )
             },
             promptRefinementClient: ToolPromptRefinementClient { _ in
@@ -186,20 +187,30 @@ extension AgentPipelineTests {
         let inferenceStore = Self.inferenceStore(
             languageModel: StubAgentLanguageModel.fixed(contentViewSource)
         )
+        inferenceStore.generationPreferences.generatedAppCameraAccessEnabled = true
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
 
+        store.appKind = .menuBar
         store.prompt = "Build a focused notes helper with quick tags"
         await store.submitPrompt(modelContext: context, inferenceStore: inferenceStore)
 
         let tool = try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
         #expect(tool.name == "Focus Pad")
         #expect(tool.executableName == "FocusPad")
+        #expect(tool.appKind == .menuBar)
+        #expect(tool.validatedMenuBarSystemImage == "note.text")
+        #expect(tool.storedResourcePermissions?.enabled == [.camera])
         #expect(tool.pendingPrompt == nil)
         #expect(tool.packageRootURL.lastPathComponent == "focus-pad")
-        #expect(FileManager.default.fileExists(atPath: tool.packageRootURL.appendingPathComponent("Sources/FocusPad/FocusPad.swift").path))
+        let appEntryURL = tool.packageRootURL.appendingPathComponent("Sources/FocusPad/FocusPad.swift")
+        #expect(FileManager.default.fileExists(atPath: appEntryURL.path))
+        let appEntrySource = try String(contentsOf: appEntryURL, encoding: .utf8)
+        #expect(appEntrySource.contains("MenuBarExtra(\"Focus Pad\", systemImage: \"note.text\")"))
         #expect(await appBundleCapture.builtRequests.first?.iconPrompt == iconPrompt)
         #expect(await appBundleCapture.builtRequests.first?.displayName == "Focus Pad")
+        #expect(await appBundleCapture.builtRequests.first?.appKind == .menuBar)
+        #expect(await appBundleCapture.builtRequests.first?.menuBarSystemImage == "note.text")
     }
 
     @MainActor

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
@@ -63,7 +63,10 @@ extension AgentPipelineTests {
         inferenceStore.generationPreferences.generatedAppLocationAccessEnabled = true
         inferenceStore.generationPreferences.generatedAppCalendarAccessEnabled = true
 
-        store.selectForEditing(existingTool)
+        store.selectForEditing(
+            existingTool,
+            defaultSettings: ToolLibraryStore.defaultGenerationSettings(from: inferenceStore.generationPreferences)
+        )
         store.sandboxEnabled = false
         store.prompt = "Add down payment support"
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
@@ -108,6 +108,31 @@ extension AgentPipelineTests {
 
     @MainActor
     @Test
+    func livePromptRefinementClientIncludesMenuBarAppTypeContext() async throws {
+        let promptCapture = PromptCapture()
+        let refinedPrompt = "Build a compact menu bar timer with start, pause, reset, and a current-session summary."
+        let refined = await ToolPromptRefinementClient.live().refinePrompt(
+            userPrompt: "Build a timer",
+            languageModel: StubAgentLanguageModel { prompt, _ in
+                await promptCapture.record(prompt)
+                return refinedPrompt
+            },
+            generationOptions: GenerationOptions(maximumResponseTokens: 4096),
+            appKind: .menuBar,
+            sandboxEnabled: true
+        )
+
+        #expect(refined == refinedPrompt)
+        let prompt = try #require(await promptCapture.prompts.first)
+        #expect(prompt.contains("App type: menu bar app."))
+        #expect(prompt.contains("MenuBarExtra popover-style window"))
+        #expect(prompt.contains("compact menu bar utility"))
+        #expect(prompt.contains("bounded width and height"))
+        #expect(!(prompt.contains("Avoid full-app layouts")))
+    }
+
+    @MainActor
+    @Test
     func livePromptRefinementClientFallsBackToOriginalPromptOnFailure() async throws {
         let refined = await ToolPromptRefinementClient.live().refinePrompt(
             userPrompt: "Build a pantry tracker",
@@ -146,10 +171,17 @@ extension AgentPipelineTests {
             }
         )
 
-        _ = try await runtime.generateTool(for: "Make a timer", status: { _ in })
+        _ = try await runtime.generateTool(
+            for: "Make a timer",
+            settings: ToolGenerationSettings(appKind: .menuBar),
+            status: { _ in }
+        )
 
         let prompts = await promptCapture.prompts
         #expect(prompts.first?.contains(refinedPrompt) == true)
+        #expect(prompts.first?.contains("App type: menu bar app.") == true)
+        #expect(prompts.first?.contains("MenuBarExtra popover-style window") == true)
+        #expect(prompts.first?.contains("compact menu bar utility") == true)
         #expect(!(prompts.first?.contains("User request: Make a timer") ?? false))
     }
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
@@ -8,12 +8,13 @@ import Testing
 extension AgentPipelineTests {
     @MainActor
     @Test
-    func generatedMetadataSchemaIncludesNameAndIconOnly() throws {
+    func generatedMetadataSchemaIncludesNameIconAndMenuBarSymbolOnly() throws {
         let data = try JSONEncoder().encode(GeneratedToolMetadata.generationSchema)
         let schema = try #require(String(data: data, encoding: .utf8))
 
         #expect(schema.contains("displayName"))
         #expect(schema.contains("iconPrompt"))
+        #expect(schema.contains("menuBarSystemImage"))
         #expect(!(schema.contains("refinedPrompt")))
     }
 
@@ -34,12 +35,34 @@ extension AgentPipelineTests {
 
         #expect(suggestion.displayName == "Recipe Board")
         #expect(suggestion.iconPrompt == "Recipe cards")
+        #expect(suggestion.menuBarSystemImage == ToolMenuBarSymbol.fallback)
         let prompt = try #require(await response.prompts.first)
         #expect(prompt.contains("User request:\nrecipes"))
+        #expect(prompt.contains("Allowed menuBarSystemImage values:"))
         #expect(!(prompt.contains("Planning budget:")))
         #expect(!(prompt.contains("Refined prompt:")))
         #expect(!(prompt.contains("backend")))
         #expect(await response.options.first?.maximumResponseTokens == 4096)
+    }
+
+    @MainActor
+    @Test
+    func metadataSuggestionValidatesMenuBarSymbolAgainstAllowlist() async throws {
+        let response = StructuredMetadataResponse(
+            metadata: GeneratedToolMetadata(
+                displayName: "Timer",
+                iconPrompt: "Small timer",
+                menuBarSystemImage: "not.a.real.allowed.symbol"
+            )
+        )
+
+        let suggestion = await ToolMetadataClient.live().suggestMetadata(
+            userPrompt: "Build a timer",
+            languageModel: StructuredMetadataLanguageModel(response: response),
+            generationOptions: GenerationOptions(maximumResponseTokens: 4096)
+        )
+
+        #expect(suggestion.menuBarSystemImage == ToolMenuBarSymbol.fallback)
     }
 
     @MainActor

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -86,10 +86,35 @@ extension AgentPipelineTests {
             settings: ToolGenerationSettings(appKind: .menuBar, menuBarSystemImage: "timer")
         )
 
+        #expect(source.contains("import AppKit"))
         #expect(source.contains("MenuBarExtra(\"Menu Timer\", systemImage: \"timer\")"))
+        #expect(source.contains("Text(\"Menu Timer\")"))
+        #expect(source.contains(".truncationMode(.tail)"))
+        #expect(source.contains("NSApplication.shared.terminate(nil)"))
+        #expect(source.contains(".accessibilityLabel(\"Quit\")"))
         #expect(source.contains("ContentView()"))
+        #expect(source.contains(".padding(.bottom, 12)"))
+        #expect(source.contains(".padding(.horizontal, 12)"))
         #expect(source.contains(".menuBarExtraStyle(.window)"))
         #expect(!(source.contains("WindowGroup")))
+    }
+
+    @MainActor
+    @Test
+    func fixedWindowAppEntrySourceQuitsInternalBuildsAfterLastWindowCloses() {
+        let layout = ToolPackageLayout(
+            packageRootURL: URL(fileURLWithPath: "/tmp/WindowTimer", isDirectory: true),
+            executableName: "WindowTimer"
+        )
+        let source = layout.fixedAppEntrySource(settings: ToolGenerationSettings(appKind: .window))
+
+        #expect(source.contains("import AppKit"))
+        #expect(source.contains("IronsmithGeneratedAppDelegate"))
+        #expect(source.contains("applicationShouldTerminateAfterLastWindowClosed"))
+        #expect(source.contains("IronsmithQuitOnLastWindowClose"))
+        #expect(source.contains("WindowGroup"))
+        #expect(source.contains("ContentView()"))
+        #expect(!(source.contains("MenuBarExtra")))
     }
 
     @MainActor
@@ -276,11 +301,18 @@ extension AgentPipelineTests {
 
         let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
         let entitlements = try Self.plistDictionary(at: request.layout.sandboxEntitlementsURL)
+        let appEntrySource = try String(
+            contentsOf: request.layout.sourceDirectoryURL.appendingPathComponent("SandboxedTool.swift"),
+            encoding: .utf8
+        )
         #expect(appURL == request.internalAppBundleURL)
         #expect(appURL.lastPathComponent == "Sandboxed Tool.app")
         #expect(plist["CFBundleIdentifier"] as? String == request.bundleIdentifier)
         #expect(plist["CFBundleExecutable"] as? String == request.executableName)
         #expect(plist["LSUIElement"] as? Bool == true)
+        #expect(plist["IronsmithQuitOnLastWindowClose"] as? Bool == true)
+        #expect(appEntrySource.contains("IronsmithGeneratedAppDelegate"))
+        #expect(appEntrySource.contains("IronsmithQuitOnLastWindowClose"))
         #expect(entitlements["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(entitlements["com.apple.security.files.user-selected.read-write"] as? Bool == true)
         #expect(entitlements["com.apple.security.network.client"] as? Bool == true)
@@ -503,6 +535,7 @@ extension AgentPipelineTests {
         #expect(appURL == applicationsDirectory.appendingPathComponent("Exported Tool.app", isDirectory: true))
         #expect(plist["CFBundleIdentifier"] as? String == request.bundleIdentifier)
         #expect(plist["LSUIElement"] == nil)
+        #expect(plist["IronsmithQuitOnLastWindowClose"] == nil)
         #expect(plist["NSContactsUsageDescription"] as? String == GeneratedAppResourcePermission.contacts.usageDescription)
         #expect(plist["NSPhotoLibraryUsageDescription"] as? String == GeneratedAppResourcePermission.photoLibrary.usageDescription)
         #expect(plist["NSPhotoLibraryAddUsageDescription"] as? String == GeneratedAppResourcePermission.photoLibrary.usageDescription)
@@ -563,6 +596,7 @@ extension AgentPipelineTests {
 
         let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
         #expect(plist["LSUIElement"] as? Bool == true)
+        #expect(plist["IronsmithQuitOnLastWindowClose"] == nil)
     }
 
     @MainActor

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -301,18 +301,12 @@ extension AgentPipelineTests {
 
         let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
         let entitlements = try Self.plistDictionary(at: request.layout.sandboxEntitlementsURL)
-        let appEntrySource = try String(
-            contentsOf: request.layout.sourceDirectoryURL.appendingPathComponent("SandboxedTool.swift"),
-            encoding: .utf8
-        )
         #expect(appURL == request.internalAppBundleURL)
         #expect(appURL.lastPathComponent == "Sandboxed Tool.app")
         #expect(plist["CFBundleIdentifier"] as? String == request.bundleIdentifier)
         #expect(plist["CFBundleExecutable"] as? String == request.executableName)
         #expect(plist["LSUIElement"] as? Bool == true)
         #expect(plist["IronsmithQuitOnLastWindowClose"] as? Bool == true)
-        #expect(appEntrySource.contains("IronsmithGeneratedAppDelegate"))
-        #expect(appEntrySource.contains("IronsmithQuitOnLastWindowClose"))
         #expect(entitlements["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(entitlements["com.apple.security.files.user-selected.read-write"] as? Bool == true)
         #expect(entitlements["com.apple.security.network.client"] as? Bool == true)
@@ -327,6 +321,76 @@ extension AgentPipelineTests {
         #expect(await capture.signedEntitlementsURL == request.layout.sandboxEntitlementsURL)
         #expect(await capture.verifiedAppURL == appURL)
         #expect(await capture.strippedURL == appURL)
+    }
+
+    @MainActor
+    @Test
+    func appBundlerDoesNotRewritePackageAppEntryWhenBuildingBundle() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let packageRoot = root.appendingPathComponent("ExistingWindowTool", isDirectory: true)
+        let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: "ExistingWindowTool")
+        let appEntryURL = packageRoot.appendingPathComponent(layout.appEntrySourcePath)
+        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
+        let originalAppEntrySource = """
+        import SwiftUI
+
+        @main
+        struct ExistingWindowTool: App {
+            var body: some Scene {
+                WindowGroup {
+                    ContentView()
+                }
+            }
+        }
+        """
+        try FileManager.default.createDirectory(
+            at: appEntryURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try originalAppEntrySource.write(to: appEntryURL, atomically: true, encoding: .utf8)
+
+        let processClient = SwiftPackageProcessClient(
+            build: { _ in
+                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            },
+            buildRelease: { _ in
+                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("ExistingWindowTool"))
+                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            },
+            showBinPath: { _ in releaseBinDirectory },
+            showReleaseBinPath: { _ in releaseBinDirectory },
+            launch: { _ in },
+            launchApp: { _ in },
+            stripQuarantine: { _ in },
+            signAdHoc: { _, _ in
+                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            },
+            verifyCodeSignature: { _ in
+                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            }
+        )
+        let client = ToolAppBundleClient.live(
+            processClient: processClient,
+            iconClient: ToolIconClient { _ in
+                throw ToolAppBundleError.iconEncodingFailed
+            }
+        )
+        let request = ToolAppBundleRequest(
+            displayName: "Existing Window Tool",
+            executableName: "ExistingWindowTool",
+            bundleIdentifier: "com.ironsmith.tests.existing-window-tool",
+            packageRootURL: packageRoot,
+            sandboxEnabled: false,
+            settings: ToolGenerationSettings(appKind: .menuBar)
+        )
+
+        _ = try await client.buildInternalApp(request)
+
+        let currentAppEntrySource = try String(contentsOf: appEntryURL, encoding: .utf8)
+        #expect(currentAppEntrySource == originalAppEntrySource)
     }
 
     @MainActor

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -28,6 +28,72 @@ extension AgentPipelineTests {
 
     @MainActor
     @Test
+    func toolBuildSettingsRoundTripThroughStoredTool() {
+        let tool = StoredTool(
+            name: "Timer",
+            sandboxEnabled: false,
+            appKind: .menuBar,
+            menuBarSystemImage: "timer",
+            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            resourcePermissions: GeneratedAppResourcePermissions([.camera, .microphone]),
+            packageRootPath: "/tmp/timer"
+        )
+
+        #expect(tool.appKind == .menuBar)
+        #expect(tool.validatedMenuBarSystemImage == "timer")
+        #expect(tool.storedSandboxPermissions?.enabled == [.internet])
+        #expect(tool.storedResourcePermissions?.enabled == [.camera, .microphone])
+
+        tool.storedSandboxPermissions = GeneratedAppSandboxPermissions.none
+        tool.storedResourcePermissions = GeneratedAppResourcePermissions.none
+
+        #expect(tool.sandboxPermissionRawValues == "")
+        #expect(tool.resourcePermissionRawValues == "")
+        #expect(tool.storedSandboxPermissions?.enabled.isEmpty == true)
+        #expect(tool.storedResourcePermissions?.enabled.isEmpty == true)
+    }
+
+    @MainActor
+    @Test
+    func legacyToolSettingsUseProvidedPermissionDefaults() {
+        let tool = StoredTool(
+            name: "Legacy",
+            sandboxEnabled: true,
+            packageRootPath: "/tmp/legacy"
+        )
+        let settings = tool.generationSettings(
+            defaults: ToolGenerationSettings(
+                sandboxPermissions: GeneratedAppSandboxPermissions([.userSelectedFiles]),
+                resourcePermissions: GeneratedAppResourcePermissions([.location])
+            )
+        )
+
+        #expect(settings.appKind == .window)
+        #expect(settings.menuBarSystemImage == ToolMenuBarSymbol.fallback)
+        #expect(settings.sandboxPermissions.enabled == [.userSelectedFiles])
+        #expect(settings.resourcePermissions.enabled == [.location])
+    }
+
+    @MainActor
+    @Test
+    func fixedAppEntrySourceCanUseMenuBarExtra() {
+        let layout = ToolPackageLayout(
+            packageRootURL: URL(fileURLWithPath: "/tmp/MenuTimer", isDirectory: true),
+            executableName: "MenuTimer"
+        )
+        let source = layout.fixedAppEntrySource(
+            displayName: "Menu Timer",
+            settings: ToolGenerationSettings(appKind: .menuBar, menuBarSystemImage: "timer")
+        )
+
+        #expect(source.contains("MenuBarExtra(\"Menu Timer\", systemImage: \"timer\")"))
+        #expect(source.contains("ContentView()"))
+        #expect(source.contains(".menuBarExtraStyle(.window)"))
+        #expect(!(source.contains("WindowGroup")))
+    }
+
+    @MainActor
+    @Test
     func agentArtifactsRoundTripThroughJSON() throws {
         let manifest = ToolManifest(
             displayName: "Clipboard Cleaner",
@@ -327,6 +393,37 @@ extension AgentPipelineTests {
         #expect(request.sandboxPermissions.contains(.internet))
         #expect(!(request.sandboxPermissions.contains(.userSelectedFiles)))
 
+        let storedPackageRoot = root.appendingPathComponent("StoredSettingsTool", isDirectory: true)
+        let storedTool = StoredTool(
+            name: "Stored Settings",
+            executableName: "StoredSettingsTool",
+            bundleIdentifier: "com.ironsmith.tests.stored-settings",
+            sandboxEnabled: true,
+            sandboxPermissions: GeneratedAppSandboxPermissions([.userSelectedFiles]),
+            resourcePermissions: GeneratedAppResourcePermissions([.camera]),
+            packageRootPath: storedPackageRoot.path
+        )
+        try Self.writePlistDictionary(
+            [
+                "com.apple.security.app-sandbox": true,
+                "com.apple.security.network.client": true,
+            ],
+            to: ToolPackageLayout.sandboxEntitlementsURL(for: storedPackageRoot)
+        )
+        try Self.writePlistDictionary(
+            [
+                "NSContactsUsageDescription": "artifact contacts access"
+            ],
+            to: storedTool.appBundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("Info.plist")
+        )
+
+        let storedRequest = ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(storedTool)
+
+        #expect(storedRequest.sandboxPermissions.enabled == [.userSelectedFiles])
+        #expect(storedRequest.resourcePermissions.enabled == [.camera])
+
         let legacyPackageRoot = root.appendingPathComponent("LegacyTool", isDirectory: true)
         let legacyTool = StoredTool(
             name: "Legacy",
@@ -415,6 +512,57 @@ extension AgentPipelineTests {
         #expect(signedAppURL != appURL)
         #expect(signedAppURL.deletingLastPathComponent() == appURL.deletingLastPathComponent())
         #expect(await capture.signedEntitlementsURL == nil)
+    }
+
+    @MainActor
+    @Test
+    func appBundlerExportsMenuBarBundleHiddenFromDock() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let packageRoot = root.appendingPathComponent("MenuBarTool", isDirectory: true)
+        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
+        let applicationsDirectory = root.appendingPathComponent("Applications", isDirectory: true)
+        let processClient = SwiftPackageProcessClient(
+            build: { _ in
+                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            },
+            buildRelease: { _ in
+                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("MenuBarTool"))
+                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            },
+            showBinPath: { _ in releaseBinDirectory },
+            showReleaseBinPath: { _ in releaseBinDirectory },
+            launch: { _ in },
+            launchApp: { _ in },
+            stripQuarantine: { _ in },
+            signAdHoc: { _, _ in
+                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            },
+            verifyCodeSignature: { _ in
+                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+            }
+        )
+        let client = ToolAppBundleClient.live(
+            processClient: processClient,
+            iconClient: ToolIconClient { _ in
+                throw ToolAppBundleError.iconEncodingFailed
+            }
+        )
+        let request = ToolAppBundleRequest(
+            displayName: "Menu Bar Tool",
+            executableName: "MenuBarTool",
+            bundleIdentifier: "com.ironsmith.tests.menu-bar-tool",
+            packageRootURL: packageRoot,
+            sandboxEnabled: true,
+            settings: ToolGenerationSettings(appKind: .menuBar)
+        )
+
+        let appURL = try await client.exportApp(request, applicationsDirectory)
+
+        let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
+        #expect(plist["LSUIElement"] as? Bool == true)
     }
 
     @MainActor

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineRepairSupportTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineRepairSupportTests.swift
@@ -418,6 +418,7 @@ extension AgentPipelineTests {
 
         #expect(instructions.contains("self-contained"))
         #expect(instructions.contains("direct internet requests allowed"))
+        #expect(instructions.contains("Respect that app type when choosing scope, layout density, and sizing"))
         #expect(instructions.contains("Treat that as runtime context, not a reason to reduce useful scope"))
         #expect(instructions.contains("sandbox-compatible macOS patterns"))
         #expect(instructions.contains("use what is needed to complete the user's ask"))
@@ -445,6 +446,50 @@ extension AgentPipelineTests {
         #expect(prompt.contains("Generate ContentView.swift only."))
         #expect(!(prompt.contains("capped at")))
         #expect(!(prompt.contains("output tokens")))
+    }
+
+    @Test
+    func singleFilePromptsIncludeAppTypeContext() {
+        let menuBarCreatePrompt = ToolGenerationPrompts.singleFileCreatePrompt(
+            userPrompt: "Build a timer",
+            executableName: "Timer",
+            sandboxEnabled: true,
+            appKind: .menuBar
+        )
+        let menuBarEditPrompt = ToolGenerationPrompts.singleFileEditPrompt(
+            userPrompt: "Make it simpler",
+            executableName: "Timer",
+            existingSource: "import SwiftUI\n\nstruct ContentView: View { var body: some View { Text(\"Timer\") } }"
+        )
+        let menuBarDiffPrompt = ToolGenerationPrompts.singleFileEditDiffPrompt(
+            userPrompt: "Make it simpler",
+            executableName: "Timer",
+            existingSource: "import SwiftUI\n\nstruct ContentView: View { var body: some View { Text(\"Timer\") } }",
+            maximumDiffHunks: nil
+        )
+        let windowCreatePrompt = ToolGenerationPrompts.singleFileCreatePrompt(
+            userPrompt: "Build a planner",
+            executableName: "Planner",
+            sandboxEnabled: true,
+            appKind: .window
+        )
+
+        #expect(menuBarCreatePrompt.contains("App type: menu bar app."))
+        #expect(menuBarCreatePrompt.contains("MenuBarExtra popover-style window"))
+        #expect(menuBarCreatePrompt.contains("not a regular full-size app window"))
+        #expect(menuBarCreatePrompt.contains("compact menu bar utility"))
+        #expect(menuBarCreatePrompt.contains("bounded width and height"))
+        #expect(!(menuBarCreatePrompt.contains("Avoid full-app layouts")))
+
+        for prompt in [menuBarEditPrompt, menuBarDiffPrompt] {
+            #expect(!(prompt.contains("App type: menu bar app.")))
+            #expect(!(prompt.contains("MenuBarExtra popover-style window")))
+            #expect(!(prompt.contains("compact menu bar utility")))
+        }
+
+        #expect(windowCreatePrompt.contains("App type: window app."))
+        #expect(windowCreatePrompt.contains("normal macOS WindowGroup"))
+        #expect(windowCreatePrompt.contains("native desktop layout sized for a regular app window"))
     }
 
     @Test

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
@@ -51,15 +51,25 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: appBundleClient,
-            metadataClient: .fallback()
+            metadataClient: ToolMetadataClient { _ in
+                ToolMetadataSuggestion(
+                    displayName: "Tiny Tool",
+                    iconPrompt: "",
+                    menuBarSystemImage: "timer"
+                )
+            }
         )
 
         let resourcePermissions = GeneratedAppResourcePermissions([.location, .calendar])
         let sandboxPermissions = GeneratedAppSandboxPermissions([.internet])
+        let settings = ToolGenerationSettings(
+            appKind: .menuBar,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions
+        )
         let result = try await runtime.generateTool(
             for: "Build a tiny tool",
-            sandboxPermissions: sandboxPermissions,
-            resourcePermissions: resourcePermissions,
+            settings: settings,
             status: { _ in }
         )
 
@@ -70,7 +80,14 @@ extension AgentPipelineTests {
         #expect(FileManager.default.fileExists(atPath: contentViewURL.path))
         #expect(FileManager.default.fileExists(atPath: appEntryURL.path))
         #expect(result.manifest.files.map(\.path) == ["Sources/\(result.executableName)/ContentView.swift"])
+        #expect(result.settings.appKind == .menuBar)
+        #expect(result.settings.menuBarSystemImage == "timer")
+        let appEntrySource = try String(contentsOf: appEntryURL, encoding: .utf8)
+        #expect(appEntrySource.contains("MenuBarExtra(\"Tiny Tool\", systemImage: \"timer\")"))
+        #expect(appEntrySource.contains(".menuBarExtraStyle(.window)"))
+        #expect(!(appEntrySource.contains("WindowGroup")))
         #expect(await appBundleCapture.builtRequests.first?.sandboxPermissions == sandboxPermissions)
         #expect(await appBundleCapture.builtRequests.first?.resourcePermissions == resourcePermissions)
+        #expect(await appBundleCapture.builtRequests.first?.appKind == .menuBar)
     }
 }

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -61,6 +61,82 @@ extension ToolLibraryTests {
 
     @MainActor
     @Test
+    func toolLibraryStoreUsesStoredBuildSettingsForSelectedTool() {
+        let toolLibraryState = ToolLibraryStore()
+        let tool = Tool(
+            name: "Menu Timer",
+            sandboxEnabled: false,
+            appKind: .menuBar,
+            menuBarSystemImage: "timer",
+            sandboxPermissions: GeneratedAppSandboxPermissions.none,
+            resourcePermissions: GeneratedAppResourcePermissions([.camera]),
+            packageRootPath: "/tmp/menu-timer"
+        )
+        let defaults = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.internet, .userSelectedFiles]),
+            resourcePermissions: GeneratedAppResourcePermissions([.location])
+        )
+
+        toolLibraryState.selectForEditing(tool, defaultSettings: defaults)
+
+        #expect(toolLibraryState.sandboxEnabled == false)
+        #expect(toolLibraryState.appKind == .menuBar)
+        #expect(toolLibraryState.menuBarSystemImage == "timer")
+        #expect(toolLibraryState.sandboxPermissions.enabled.isEmpty)
+        #expect(toolLibraryState.resourcePermissions.enabled == [.camera])
+    }
+
+    @MainActor
+    @Test
+    func toolLibraryStoreUsesGlobalDefaultsForLegacyToolPermissionsWithoutArtifactInference() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let tool = Tool(name: "Legacy Tool", packageRootPath: root.path)
+        let entitlementsURL = ToolPackageLayout.sandboxEntitlementsURL(for: root)
+        try FileManager.default.createDirectory(
+            at: entitlementsURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let entitlementsData = try PropertyListSerialization.data(
+            fromPropertyList: [
+                GeneratedAppSandboxPermission.internet.entitlementKey: true
+            ],
+            format: .xml,
+            options: 0
+        )
+        try entitlementsData.write(to: entitlementsURL, options: .atomic)
+
+        let infoPlistURL = tool.appBundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Info.plist")
+        try FileManager.default.createDirectory(
+            at: infoPlistURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let infoPlistData = try PropertyListSerialization.data(
+            fromPropertyList: [
+                "NSCameraUsageDescription": "artifact camera access"
+            ],
+            format: .xml,
+            options: 0
+        )
+        try infoPlistData.write(to: infoPlistURL, options: .atomic)
+
+        let defaults = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.userSelectedFiles]),
+            resourcePermissions: GeneratedAppResourcePermissions([.location])
+        )
+        let toolLibraryState = ToolLibraryStore()
+
+        toolLibraryState.selectForEditing(tool, defaultSettings: defaults)
+
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.userSelectedFiles])
+        #expect(toolLibraryState.resourcePermissions.enabled == [.location])
+    }
+
+    @MainActor
+    @Test
     func toolLibraryStoreHandleDeletedToolIsNoOpForNonSelectedTool() {
         let toolLibraryState = ToolLibraryStore()
         let selected = Tool(name: "Linter", packageRootPath: "/tmp/linter")

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -48,6 +48,109 @@ extension ToolLibraryTests {
 
     @MainActor
     @Test
+    func toolLibraryStoreKeepsNextGenerationSettingsInMemoryAcrossSelection() {
+        let toolLibraryState = ToolLibraryStore()
+        let tool = Tool(
+            name: "Window Tool",
+            sandboxEnabled: true,
+            appKind: .window,
+            sandboxPermissions: GeneratedAppSandboxPermissions.none,
+            resourcePermissions: GeneratedAppResourcePermissions.none,
+            packageRootPath: "/tmp/window-tool"
+        )
+        let defaults = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.userSelectedFiles]),
+            resourcePermissions: GeneratedAppResourcePermissions([.location])
+        )
+
+        toolLibraryState.initializeNextGenerationSettingsIfNeeded(defaults)
+        toolLibraryState.appKind = .menuBar
+        toolLibraryState.sandboxEnabled = false
+        toolLibraryState.sandboxPermissions = GeneratedAppSandboxPermissions([.internet])
+        toolLibraryState.resourcePermissions = GeneratedAppResourcePermissions([.camera])
+        toolLibraryState.rememberCurrentGenerationSettingsForNextGeneration()
+
+        toolLibraryState.toggleSelection(for: tool, defaultSettings: defaults)
+
+        #expect(toolLibraryState.isSelected(tool))
+        #expect(toolLibraryState.appKind == .window)
+        #expect(toolLibraryState.sandboxEnabled)
+        #expect(toolLibraryState.sandboxPermissions.enabled.isEmpty)
+        #expect(toolLibraryState.resourcePermissions.enabled.isEmpty)
+
+        toolLibraryState.toggleSelection(for: tool, defaultSettings: defaults)
+
+        #expect(!(toolLibraryState.isSelected(tool)))
+        #expect(toolLibraryState.appKind == .menuBar)
+        #expect(!(toolLibraryState.sandboxEnabled))
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.resourcePermissions.enabled == [.camera])
+    }
+
+    @MainActor
+    @Test
+    func toolLibraryStoreSelectedToolChangesBecomeNextGenerationSettings() {
+        let toolLibraryState = ToolLibraryStore()
+        let tool = Tool(
+            name: "Menu Tool",
+            sandboxEnabled: false,
+            appKind: .menuBar,
+            menuBarSystemImage: "timer",
+            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            resourcePermissions: GeneratedAppResourcePermissions([.camera]),
+            packageRootPath: "/tmp/menu-tool"
+        )
+        let defaults = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.userSelectedFiles]),
+            resourcePermissions: GeneratedAppResourcePermissions([.location])
+        )
+
+        toolLibraryState.selectForEditing(tool, defaultSettings: defaults)
+        toolLibraryState.sandboxEnabled = true
+        toolLibraryState.resourcePermissions = GeneratedAppResourcePermissions([.microphone])
+        toolLibraryState.rememberCurrentGenerationSettingsForNextGeneration()
+
+        toolLibraryState.toggleSelection(for: tool, defaultSettings: defaults)
+
+        #expect(!(toolLibraryState.isSelected(tool)))
+        #expect(toolLibraryState.appKind == .menuBar)
+        #expect(toolLibraryState.menuBarSystemImage == "timer")
+        #expect(toolLibraryState.sandboxEnabled)
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.resourcePermissions.enabled == [.microphone])
+    }
+
+    @MainActor
+    @Test
+    func toolLibraryStoreSettingsDefaultsOnlySeedNextGenerationUntilCustomized() {
+        let toolLibraryState = ToolLibraryStore()
+        let initialDefaults = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.userSelectedFiles]),
+            resourcePermissions: GeneratedAppResourcePermissions([.location])
+        )
+        let updatedDefaults = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            resourcePermissions: GeneratedAppResourcePermissions([.camera])
+        )
+
+        toolLibraryState.initializeNextGenerationSettingsIfNeeded(initialDefaults)
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.userSelectedFiles])
+        #expect(toolLibraryState.resourcePermissions.enabled == [.location])
+
+        toolLibraryState.initializeNextGenerationSettingsIfNeeded(updatedDefaults)
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.resourcePermissions.enabled == [.camera])
+
+        toolLibraryState.resourcePermissions = GeneratedAppResourcePermissions([.microphone])
+        toolLibraryState.rememberCurrentGenerationSettingsForNextGeneration()
+        toolLibraryState.initializeNextGenerationSettingsIfNeeded(initialDefaults)
+
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.resourcePermissions.enabled == [.microphone])
+    }
+
+    @MainActor
+    @Test
     func toolLibraryStoreSyncSelectionIsNoOpWhenNothingSelected() {
         let toolLibraryState = ToolLibraryStore()
         let tool = Tool(name: "Formatter", packageRootPath: "/tmp/formatter")

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -383,6 +383,7 @@ extension ToolLibraryTests {
         let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: executableName)
         let contentViewPath = layout.sourcePath(for: layout.defaultContentViewFileName)
         let contentViewURL = packageRoot.appendingPathComponent(contentViewPath)
+        let appEntryURL = packageRoot.appendingPathComponent(layout.appEntrySourcePath)
         let previousURL = layout.previousContentViewVersionURL
         let manifest = ToolManifest(
             displayName: executableName,
@@ -392,14 +393,42 @@ extension ToolLibraryTests {
             ]
         )
         try FileManager.default.createDirectory(at: contentViewURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: previousURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try JSONEncoder().encode(manifest).write(to: layout.agentManifestURL)
+        let previousSettings = ToolGenerationSettings(
+            appKind: .window,
+            sandboxEnabled: true,
+            sandboxPermissions: GeneratedAppSandboxPermissions([.userSelectedFiles]),
+            resourcePermissions: GeneratedAppResourcePermissions([.camera])
+        )
+        let currentSettings = ToolGenerationSettings(
+            appKind: .menuBar,
+            menuBarSystemImage: "timer",
+            sandboxEnabled: false,
+            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            resourcePermissions: GeneratedAppResourcePermissions([.microphone])
+        )
+        try #"Text("previous")"#.write(to: contentViewURL, atomically: true, encoding: .utf8)
+        let backup = try ToolVersionBackupClient.live.stageCurrentVersion(
+            packageRoot,
+            contentViewPath,
+            previousSettings
+        )
+        try ToolVersionBackupClient.live.promoteStagedVersion(backup)
         try #"Text("current")"#.write(to: contentViewURL, atomically: true, encoding: .utf8)
-        try #"Text("previous")"#.write(to: previousURL, atomically: true, encoding: .utf8)
+        try layout.fixedAppEntrySource(displayName: executableName, settings: currentSettings)
+            .write(to: appEntryURL, atomically: true, encoding: .utf8)
 
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
-        let tool = Tool(name: executableName, packageRootPath: packageRoot.path)
+        let tool = Tool(
+            name: executableName,
+            sandboxEnabled: currentSettings.sandboxEnabled,
+            appKind: currentSettings.appKind,
+            menuBarSystemImage: currentSettings.menuBarSystemImage,
+            sandboxPermissions: currentSettings.sandboxPermissions,
+            resourcePermissions: currentSettings.resourcePermissions,
+            packageRootPath: packageRoot.path
+        )
         context.insert(tool)
         try context.save()
 
@@ -428,8 +457,15 @@ extension ToolLibraryTests {
 
         let restoredSource = try String(contentsOf: contentViewURL, encoding: .utf8)
         let swappedPreviousSource = try String(contentsOf: previousURL, encoding: .utf8)
+        let restoredAppEntrySource = try String(contentsOf: appEntryURL, encoding: .utf8)
         #expect(restoredSource == #"Text("previous")"#)
         #expect(swappedPreviousSource == #"Text("current")"#)
+        #expect(tool.appKind == .window)
+        #expect(tool.sandboxEnabled)
+        #expect(tool.storedSandboxPermissions?.enabled == [.userSelectedFiles])
+        #expect(tool.storedResourcePermissions?.enabled == [.camera])
+        #expect(restoredAppEntrySource.contains("WindowGroup"))
+        #expect(!(restoredAppEntrySource.contains("MenuBarExtra")))
         #expect(await buildCapture.builtPackageRoot == packageRoot)
         #expect(tool.generationState == .ready)
     }


### PR DESCRIPTION
## Summary
- Adds menu bar apps support.
- Adds new bottom left generation settings menu to change sandbox setting, app type and permissions for the next generation.
- Fixes bug that caused Ironsmith launched apps to not quit when their window was closed.

## Testing
- Added and updated unit coverage for generation, metadata, repair, packaging, and runtime behavior.
- Added tool library selection/action tests for popover and prompt flow changes.
