### PR TITLE
feat: allow diagnostics logging in production builds via opt-in preference

### DIFF
--- a/Ironsmith/Core/AgentPipeline/Diagnostics/AgentDiagnosticsLog.swift
+++ b/Ironsmith/Core/AgentPipeline/Diagnostics/AgentDiagnosticsLog.swift
@@ -11,10 +11,10 @@ enum AgentDiagnosticsLog {
 
     nonisolated static func append(
         _ message: String,
-        to logURL: URL = defaultURL
+        to logURL: URL = defaultURL,
+        userDefaults: UserDefaults = .standard
     ) {
-#if DEBUG
-        guard shouldWrite(to: logURL) else {
+        guard shouldWrite(to: logURL, userDefaults: userDefaults) else {
             return
         }
 
@@ -41,7 +41,6 @@ enum AgentDiagnosticsLog {
         } catch {
             print("[Ironsmith][DiagnosticsLog] Failed to append diagnostics: \(error.localizedDescription)")
         }
-#endif
     }
 
     nonisolated static func renderDiagnostics(
@@ -259,11 +258,14 @@ enum AgentDiagnosticsLog {
         return lines
     }
 
-    nonisolated private static func shouldWrite(to logURL: URL) -> Bool {
+    nonisolated private static func shouldWrite(
+        to logURL: URL,
+        userDefaults: UserDefaults
+    ) -> Bool {
         if IronsmithRuntimeEnvironment.isRunningTests, logURL == defaultURL {
             return false
         }
 
-        return true
+        return userDefaults.bool(forKey: IronsmithPreferenceKeys.diagnosticsLoggingEnabled)
     }
 }

--- a/Ironsmith/Core/Persistence/Configuration/IronsmithPreferenceKeys.swift
+++ b/Ironsmith/Core/Persistence/Configuration/IronsmithPreferenceKeys.swift
@@ -2,6 +2,7 @@ enum IronsmithPreferenceKeys {
     nonisolated static let showSandboxOverride = "showSandboxOverride"
     nonisolated static let hasCompletedWelcomeOnboarding = "welcomeOnboarding.hasCompleted"
     nonisolated static let hasPresentedOllamaModelDownloadNudge = "ollama.hasPresentedModelDownloadNudge"
+    nonisolated static let diagnosticsLoggingEnabled = "diagnosticsLoggingEnabled"
 
     #if DEBUG
     nonisolated static let debugAlwaysShowWelcomeOnboarding = "debug.alwaysShowWelcomeOnboarding"

--- a/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct SettingsPreferencesSectionView: View {
     @Environment(InferenceStore.self) private var inferenceStore
     @AppStorage(IronsmithPreferenceKeys.showSandboxOverride) private var showSandboxOverride = false
+    @AppStorage(IronsmithPreferenceKeys.diagnosticsLoggingEnabled) private var diagnosticsLoggingEnabled = false
     @State private var isConfirmingUnsandboxedTools = false
 
     var body: some View {
@@ -36,6 +37,21 @@ struct SettingsPreferencesSectionView: View {
                             + "You should always read the source code of any unsandboxed app before using it."
                     )
                 }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle(
+                    "Write generation diagnostics log",
+                    isOn: $diagnosticsLoggingEnabled
+                )
+                .toggleStyle(.switch)
+
+                Text(
+                    "Records detailed generation logs to a file on disk so you can share "
+                        + "them when reporting a problem. Off by default."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
         } header: {
             Text("Preferences")
         }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineDiagnosticsLogTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineDiagnosticsLogTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import Ironsmith
+
+extension AgentPipelineTests {
+    @Test
+    func diagnosticsLogWritesWhenPreferenceEnabled() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory.appendingPathComponent("diagnostics.log")
+        let userDefaults = try Self.makeIsolatedUserDefaults()
+        userDefaults.set(true, forKey: IronsmithPreferenceKeys.diagnosticsLoggingEnabled)
+
+        AgentDiagnosticsLog.append("first entry", to: logURL, userDefaults: userDefaults)
+        #expect(FileManager.default.fileExists(atPath: logURL.path))
+
+        let afterFirst = try String(contentsOf: logURL, encoding: .utf8)
+        #expect(afterFirst.contains("first entry"))
+
+        AgentDiagnosticsLog.append("second entry", to: logURL, userDefaults: userDefaults)
+        let afterSecond = try String(contentsOf: logURL, encoding: .utf8)
+        #expect(afterSecond.contains("first entry"))
+        #expect(afterSecond.contains("second entry"))
+        #expect(afterSecond.count > afterFirst.count)
+    }
+
+    @Test
+    func diagnosticsLogIsNoOpWhenPreferenceDisabled() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory.appendingPathComponent("diagnostics.log")
+        let userDefaults = try Self.makeIsolatedUserDefaults()
+        // Preference unset (default off).
+
+        AgentDiagnosticsLog.append("ignored entry", to: logURL, userDefaults: userDefaults)
+
+        #expect(!FileManager.default.fileExists(atPath: logURL.path))
+    }
+
+    @Test
+    func diagnosticsLogSuppressesDefaultURLDuringTests() throws {
+        let userDefaults = try Self.makeIsolatedUserDefaults()
+        userDefaults.set(true, forKey: IronsmithPreferenceKeys.diagnosticsLoggingEnabled)
+
+        let existedBefore = FileManager.default.fileExists(atPath: AgentDiagnosticsLog.defaultURL.path)
+
+        // Default URL writes are suppressed under the test runtime even when enabled.
+        AgentDiagnosticsLog.append("should not write to default URL", userDefaults: userDefaults)
+
+        let existsAfter = FileManager.default.fileExists(atPath: AgentDiagnosticsLog.defaultURL.path)
+        #expect(existsAfter == existedBefore)
+    }
+
+    @Test
+    func diagnosticsLogCreatesMissingDirectory() throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let logURL = directory
+            .appendingPathComponent("nested", isDirectory: true)
+            .appendingPathComponent("diagnostics.log")
+        let userDefaults = try Self.makeIsolatedUserDefaults()
+        userDefaults.set(true, forKey: IronsmithPreferenceKeys.diagnosticsLoggingEnabled)
+
+        AgentDiagnosticsLog.append("entry", to: logURL, userDefaults: userDefaults)
+
+        #expect(FileManager.default.fileExists(atPath: logURL.path))
+    }
+}

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
@@ -111,6 +111,13 @@ extension AgentPipelineTests {
         }
     }
 
+    static func makeIsolatedUserDefaults() throws -> UserDefaults {
+        let suiteName = "IronsmithTests.AgentPipeline.DiagnosticsLog.\(UUID().uuidString)"
+        let userDefaults = try #require(UserDefaults(suiteName: suiteName))
+        userDefaults.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+
     static func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("ironsmith-agent-tests-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

Adds an opt-in preference that lets the agent diagnostics log be written in production builds, not just `DEBUG` builds. Previously the diagnostics write was entirely compiled out of release builds, so production users had no way to capture detailed generation logs even when something went wrong.

The diagnostics write body used to be wrapped in `#if DEBUG`, which meant release builds never emitted these logs. That body now lives outside the compile-time gate and is instead gated at runtime on a new `diagnosticsLoggingEnabled` user preference that defaults to off. The existing test-suppression guard (skipping writes to the default log URL while tests run) is preserved, and the on-disk log format, log path, and all render helpers are unchanged, so nothing about the format users already see is affected. A user-facing "Write generation diagnostics log" toggle now appears in the production-visible Preferences settings section, giving users a single switch to turn logging on when they need it.

## Why this matters

Issue #5 asked for two things when an unstable provider interrupts generation: better retry/resume, and detailed logs to see what actually happened. The retry/resume half already shipped in PR #6, so this change covers the remaining logging half. The maintainer endorsed exactly this: "the debug version of ironsmith does output detailed logs during generation but I've disabled for the production version. It probably makes sense to have those logs output in the production version as well."

Keeping the preference off by default means production logging stays disabled unless a user explicitly opts in, so the default privacy posture is unchanged while still giving people a one-toggle way to capture logs they can attach to a bug report.

## Testing

Both a debug build (`swift build`) and a release build (`swift build -c release`) complete cleanly. New tests in `AgentPipelineDiagnosticsLogTests.swift` cover the behavior: a write happens and appends to the target log when the preference is enabled, nothing is written and no file is created when the preference is off, writes to the default URL are still suppressed under the test runtime even when enabled, and a missing parent directory is created before writing.

Refs #5
