### PR TITLE
Improve model diff handling, adds Report an Issue

### DIFF
--- a/Ironsmith/Core/AgentPipeline/ContentRepair/ContentViewRepairDiffApplier.swift
+++ b/Ironsmith/Core/AgentPipeline/ContentRepair/ContentViewRepairDiffApplier.swift
@@ -22,15 +22,19 @@ extension ContentViewRepairSupport {
         guard !hunks.isEmpty else {
             throw invalidRepairDiff(reason: "diff contains no hunks")
         }
+        let changingHunks = hunks.filter(\.containsChangedLine)
+        guard !changingHunks.isEmpty else {
+            throw invalidRepairDiff(reason: "diff contains no changing hunks")
+        }
         if let maximumHunks {
             let boundedMaximumHunks = max(1, maximumHunks)
-            guard hunks.count <= boundedMaximumHunks else {
-                throw invalidRepairDiff(reason: "diff contains \(hunks.count) hunks; expected 1...\(boundedMaximumHunks)")
+            guard changingHunks.count <= boundedMaximumHunks else {
+                throw invalidRepairDiff(reason: "diff contains \(changingHunks.count) hunks; expected 1...\(boundedMaximumHunks)")
             }
         }
 
         var updatedSource = source
-        for hunk in hunks {
+        for hunk in changingHunks {
             updatedSource = try apply(hunk, to: updatedSource)
         }
         return updatedSource
@@ -42,6 +46,12 @@ extension ContentViewRepairSupport {
 
     private struct UnifiedDiffHunk: Equatable {
         var lines: [String]
+
+        var containsChangedLine: Bool {
+            lines.dropFirst().contains { line in
+                line.hasPrefix("+") || line.hasPrefix("-")
+            }
+        }
     }
 
     private static func sanitizedDiff(_ text: String) -> String {

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationPrompts.swift
@@ -39,11 +39,7 @@ enum ToolGenerationPrompts {
     static let diffRepairInstructions = """
         You are Ironsmith's Swift compiler repair agent.
         You repair exactly one file: ContentView.swift.
-        Return only a unified diff.
-        The diff must edit ContentView.swift only.
-        Use normal unified diff hunks with @@ headers and enough surrounding context to locate each edit.
-        Do not include prose, markdown fences, explanations, or unrelated rewrites in the diff.
-        Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
+        \(diffOutputContract)
         \(validUnifiedDiffShapeExample)
         Keep each repair turn focused on the listed compiler diagnostics.
         """
@@ -51,11 +47,7 @@ enum ToolGenerationPrompts {
     static let diffEditInstructions = """
         You are Ironsmith's Swift edit agent.
         You edit exactly one file: ContentView.swift.
-        Return only a unified diff.
-        The diff must edit ContentView.swift only.
-        Use normal unified diff hunks with @@ headers and enough surrounding context to locate each edit.
-        Do not include prose, markdown fences, explanations, or unrelated rewrites in the diff.
-        Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
+        \(diffOutputContract)
         \(validUnifiedDiffShapeExample)
         Keep the edit focused on the user's requested change.
         Prefer several small, focused hunks over one large hunk when multiple areas need changes.
@@ -135,12 +127,7 @@ enum ToolGenerationPrompts {
         User request: \(userPrompt)
         Fixed package and target name: \(executableName).
         Edit ContentView.swift by returning a unified diff only.
-        \(diffHunkLimitInstruction(maximumDiffHunks))
-        The diff must patch ContentView.swift only.
-        Include enough unchanged context in each hunk to make it uniquely applicable.
-        Prefer small focused hunks instead of one broad rewrite.
-        Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
-        Do not rewrite the entire file unless the whole file is malformed.
+        \(diffTurnReminder(maximumDiffHunks))
         Current authoritative ContentView.swift:
         ```swift
         \(existingSource)
@@ -246,18 +233,30 @@ enum ToolGenerationPrompts {
         sections.append(
             """
             Return only a unified diff.
-            \(diffHunkLimitInstruction(maximumDiffHunks))
-            The diff must patch ContentView.swift only.
-            Include enough unchanged context in each hunk to make it uniquely applicable.
-            Do not return a full-file rewrite unless the entire file is malformed.
-            Do not wrap the diff in JSON, markdown, or prose.
-            Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
+            \(diffTurnReminder(maximumDiffHunks))
             Do not reuse removed source from previous repair outcomes.
             Make one coherent repair step, then stop.
             """
         )
 
         return sections.joined(separator: "\n\n")
+    }
+
+    private static let diffOutputContract = """
+        Return only a unified diff.
+        The diff must edit ContentView.swift only.
+        Use normal unified diff hunks with @@ headers and enough surrounding context to locate each edit uniquely.
+        Every @@ hunk must include at least one real + or - changed line; do not use @@ as an ellipsis or section separator.
+        Do not include prose, markdown fences, JSON, explanations, or unrelated rewrites in the diff.
+        Do not include apply-patch markers such as *** Begin Patch or *** End Patch.
+        Do not rewrite the entire file unless the whole file is malformed.
+        """
+
+    private static func diffTurnReminder(_ maximumDiffHunks: Int?) -> String {
+        """
+        \(diffHunkLimitInstruction(maximumDiffHunks))
+        Follow the diff output contract from your instructions.
+        """
     }
 
     private static func diffHunkLimitInstruction(_ maximumDiffHunks: Int?) -> String {
@@ -271,7 +270,7 @@ enum ToolGenerationPrompts {
         Valid response shape example (format only; do not copy this content):
         --- ContentView.swift
         +++ ContentView.swift
-        @@
+        @@ -3,5 +3,5 @@
         -    Text("Old")
         +    Text("New")
         """

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -141,6 +141,7 @@ struct ToolMetadataClient: Sendable {
         displayName:
         - Must be one or two separate words.
         - Must be Title Case.
+        - Must name the user's requested app, task, or workflow, not the icon artwork or symbol.
         - Should feel snappy, playful, and useful for a small macOS app.
         - Do not use punctuation, emoji, or generic suffixes like App or Tool.
 

--- a/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 struct SettingsPreferencesSectionView: View {
     @Environment(InferenceStore.self) private var inferenceStore
     @AppStorage(IronsmithPreferenceKeys.showSandboxOverride) private var showSandboxOverride = false
-    @AppStorage(IronsmithPreferenceKeys.diagnosticsLoggingEnabled) private var diagnosticsLoggingEnabled = false
+    @AppStorage(IronsmithPreferenceKeys.diagnosticsLoggingEnabled) private
+        var diagnosticsLoggingEnabled = false
     @State private var isConfirmingUnsandboxedTools = false
 
     var body: some View {
@@ -46,8 +47,8 @@ struct SettingsPreferencesSectionView: View {
                 .toggleStyle(.switch)
 
                 Text(
-                    "Records detailed generation logs to a file on disk so you can share "
-                        + "them when reporting a problem. Off by default."
+                    "Records detailed generation logs to ~/.ironsmith so you can share "
+                        + "them when reporting a problem."
                 )
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
@@ -2,12 +2,16 @@ import AppKit
 import SwiftUI
 
 struct ToolLibraryPopoverHeaderView: View {
+    @Environment(\.openURL) private var openURL
+
     let appUpdateStore: AppUpdateStore
     let isLoadingModels: Bool
     let shouldShowNoModelMessage: Bool
     let selectedModelStatusText: String?
     let selectedIronsmithCreditWarningText: String?
     let onOpenSettings: () -> Void
+    private static let issueReportURL = URL(
+        string: "https://github.com/Jeidoban/Ironsmith/issues/new")!
 
     var body: some View {
         HStack {
@@ -41,6 +45,10 @@ struct ToolLibraryPopoverHeaderView: View {
                     IronsmithAboutWindowController.shared.show()
                 }
 
+                Button("Report an Issue") {
+                    openURL(Self.issueReportURL)
+                }
+
                 Divider()
 
                 Button("Quit Ironsmith") {
@@ -54,7 +62,7 @@ struct ToolLibraryPopoverHeaderView: View {
             .foregroundStyle(.secondary)
             .help("Ironsmith")
             .accessibilityLabel("Ironsmith menu")
-            .accessibilityHint("Opens settings, about, and quit actions.")
+            .accessibilityHint("Opens about, issue reporting, and quit actions.")
             .accessibilityIdentifier("ironsmith-menu-button")
         }
     }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineRepairSupportTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineRepairSupportTests.swift
@@ -537,12 +537,21 @@ extension AgentPipelineTests {
             #expect(prompt.contains("Valid response shape example"))
             #expect(prompt.contains("--- ContentView.swift"))
             #expect(prompt.contains("+++ ContentView.swift"))
+            #expect(prompt.contains("@@ -3,5 +3,5 @@"))
             #expect(prompt.contains("-    Text(\"Old\")"))
             #expect(prompt.contains("+    Text(\"New\")"))
+            #expect(prompt.contains("Every @@ hunk must include at least one real + or - changed line"))
             #expect(prompt.contains("Do not include apply-patch markers"))
+            #expect(prompt.contains("Do not rewrite the entire file unless the whole file is malformed"))
         }
         #expect(!(editPrompt.contains("Valid response shape example")))
         #expect(!(repairPrompt.contains("Valid response shape example")))
+        #expect(editPrompt.contains("Follow the diff output contract from your instructions."))
+        #expect(repairPrompt.contains("Follow the diff output contract from your instructions."))
+        #expect(!(editPrompt.contains("Every @@ hunk must include at least one real + or - changed line")))
+        #expect(!(repairPrompt.contains("Every @@ hunk must include at least one real + or - changed line")))
+        #expect(!(editPrompt.contains("Do not include apply-patch markers")))
+        #expect(!(repairPrompt.contains("Do not include apply-patch markers")))
     }
 
     @Test

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineValidatedDiffTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineValidatedDiffTests.swift
@@ -99,6 +99,52 @@ extension AgentPipelineTests {
     }
 
     @Test
+    func applyValidatedDiffIgnoresContextOnlySeparatorHunks() throws {
+        let source = """
+        import SwiftUI
+
+        struct ContentView: View {
+          // MARK: - State
+          @State private var pulse = false
+
+          private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+          // MARK: - Body
+          var body: some View {
+            VStack(spacing: 14) {
+              Text("Cookie")
+            }
+          }
+        }
+        """
+        let diff = """
+        --- ContentView.swift
+        +++ ContentView.swift
+        @@
+         struct ContentView: View {
+           // MARK: - State
+           @State private var pulse = false
+        @@
+           private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+        +
+        +  private let punkAccent = Color.pink
+         
+           // MARK: - Body
+           var body: some View {
+        -    VStack(spacing: 14) {
+        +    VStack(spacing: 10) {
+               Text("Cookie")
+             }
+        """
+
+        let updated = try ContentViewRepairSupport.applyValidatedDiff(diff, to: source, maximumHunks: 1)
+
+        #expect(updated.contains("private let punkAccent = Color.pink"))
+        #expect(updated.contains("VStack(spacing: 10)"))
+        #expect(!(updated.contains("VStack(spacing: 14)")))
+    }
+
+    @Test
     func applyValidatedDiffAllowsUnlimitedHunksWhenUnbounded() throws {
         let source = """
         import SwiftUI
@@ -168,6 +214,30 @@ extension AgentPipelineTests {
         #expect(updated.contains("Text(\"Updated\")"))
         #expect(throws: ToolGenerationError.invalidRepairPatch) {
             try ContentViewRepairSupport.applyValidatedDiff(diff, to: source, maximumHunks: 1)
+        }
+    }
+
+    @Test
+    func applyValidatedDiffRejectsDiffWithOnlyContextHunks() {
+        let source = """
+        import SwiftUI
+
+        struct ContentView: View {
+            var body: some View {
+                Text("One")
+            }
+        }
+        """
+        let diff = """
+        --- ContentView.swift
+        +++ ContentView.swift
+        @@
+         struct ContentView: View {
+             var body: some View {
+        """
+
+        #expect(throws: ToolGenerationError.invalidRepairPatch) {
+            try ContentViewRepairSupport.applyValidatedDiff(diff, to: source, maximumHunks: nil)
         }
     }
 


### PR DESCRIPTION
## Summary

- Tolerate context-only `@@` separator hunks in model-generated unified diffs while still rejecting diffs with no real changes.
- Centralize the diff output contract in edit/repair instructions and keep dynamic prompts focused on turn-specific context.
- Add metadata prompt guidance so generated app names refer to the requested app/workflow rather than icon artwork.
- Also adds Report an Issue menu entry.

## Why

Model edit diffs were sometimes using bare `@@` blocks as section separators. The validator treated those as real no-op hunks and rejected the entire diff before reaching valid edits, which caused unnecessary whole-source regeneration and token waste.

## Validation

- `./script/test.sh` passed: 309 tests.