### PR TITLE
Refactor agent pipeline and tighten persistence paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,9 @@
 ## Agent Pipeline
 
 - The active generation runtime is intentionally single-file. `SingleFileToolGenerationRuntime` creates or edits one editable file: `Sources/<ExecutableName>/ContentView.swift`.
-- Generated tools are SwiftPM executable packages under `~/.ironsmith/tools/<tool-slug>/`. `Package.swift`, the fixed `@main` app entry file, and `ironsmith-manifest.json` are written by Ironsmith, not by the model.
+- Generated tools are SwiftPM executable packages under `~/.ironsmith/tools/<tool-slug>/`. `Package.swift` and the fixed `@main` app entry file are written by Ironsmith, not by the model.
 - Generated package toolchain, language mode, and platform settings live in `ToolPackageLayout.packageManifestContent()`. Do not duplicate those values elsewhere.
-- The manifest is small bookkeeping: display name, executable name, and generated file descriptions. It is not an architecture plan, and there is no active `Protocols/` directory or action-plan agent.
+- Tool metadata is stored in SwiftData, and generated-file paths are derived from `ToolPackageLayout`. There is no active `Protocols/` directory or action-plan agent.
 - Create mode asks `ToolMetadataClient` for a short display name and icon prompt, writes the package scaffold, prompts the selected model for a complete `ContentView.swift`, cleans/formats it, compiles it, strips quarantine from the debug binary, and builds an internal app bundle.
 - `ToolMetadataClient.live()` may use local structured generation for nicer metadata, but metadata generation must remain a soft enhancement with a deterministic fallback.
 - Edit mode stages the current `ContentView.swift` in `.ironsmith/versions/pending-ContentView.swift`. Model-diff capable selections start with a bounded unified diff; deterministic-only selections rewrite the whole `ContentView.swift`. Successful edits promote the staged source to `previous-ContentView.swift`; failed edits restore the original source and discard the staged backup.
@@ -117,7 +117,7 @@
 - After Ironsmith-backed generation, refresh account credits so the popover and settings do not show stale balances.
 - Deleting a tool removes it from the SwiftData library. Do not add package-directory deletion unless that product behavior is intentionally changed and tested.
 - The sandbox toggle is hidden unless `IronsmithPreferenceKeys.showSandboxOverride` is enabled in Settings. When hidden, generation forces sandboxing on.
-- Restore-previous-version uses the package manifest to find `ContentView.swift`, swaps it with `.ironsmith/versions/previous-ContentView.swift`, rebuilds the internal app bundle, and updates the tool summary.
+- Restore-previous-version uses `ToolPackageLayout` to find `ContentView.swift`, swaps it with `.ironsmith/versions/previous-ContentView.swift`, rebuilds the internal app bundle, and updates the tool summary.
 
 ## Settings Rules
 
@@ -143,7 +143,7 @@
 - Use `IronsmithModelContainerFactory.make(isRunningTests: true)` for SwiftData tests and previews.
 - Do not silently delete a failed persistent store. The container factory backs up bad sqlite/wal/shm files under `~/.ironsmith/Backups/` before creating a fresh store.
 - App data lives under `~/.ironsmith/`: `ironsmith.sqlite`, `models/`, `tools/`, and the DEBUG diagnostics log.
-- Use `Tool` and `ToolPackageLayout` derived URL helpers for package roots, manifests, metadata, versions, app bundles, cached icons, and entitlements instead of rebuilding those paths at call sites.
+- Use `Tool` and `ToolPackageLayout` derived URL helpers for package roots, package manifests, metadata, versions, app bundles, cached icons, and entitlements instead of rebuilding those paths at call sites.
 - `ToolGenerationRuntimeContext.packageFileURL` and `ToolVersionBackupClient` validate that generated-tool file access stays inside the package root. Preserve those path-escape checks.
 - The generator does not write protocol files, but `Tool.protocolsDirectoryURL` may still exist for compatibility/future work. Do not build new agent flow around protocols unless the runtime is intentionally changed.
 - No Xcode project is committed. Open the root `Package.swift` in Xcode when IDE debugging is needed, and keep build graph changes in SwiftPM/script files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,162 +1,84 @@
 # Ironsmith Agent Guide
 
+## Scope
+
+- This guide covers the macOS app in `Ironsmith/` and its tests in `IronsmithTests/`.
+- `ironsmith-backend/` is a separate nested repository with its own `AGENTS.md`. Work from that directory and follow its guide for backend changes.
+- Source and focused tests are the operational source of truth. Prefer following nearby code patterns over expanding this guide with implementation details.
+
 ## Build And Test
 
-- `Package.swift` is the source of truth for app builds and tests.
-- Build and stage the development app with `script/build.sh`.
-- Build and run the development app with `script/build.sh run`.
-- Build a Developer ID-signed release app with `script/build.sh --release --sign-identity "Developer ID Application: Example (TEAMID)"`.
-- Package and notarize the release app with `script/package.sh --sign-identity "Developer ID Application: Example (TEAMID)"` plus one complete notarization credential option group; pass an explicit `.app` path to package another bundle.
-- Run tests with `script/test.sh`.
-- Remove SwiftPM/script outputs with `script/clean.sh`.
-- Build-time backend values are documented in `Config/.env.example`; local `Config/.env` is gitignored.
-- App tests use Swift Testing (`@Test`, `#expect`, `#require`) rather than XCTest.
+- `Package.swift` is the app build graph and test source of truth. There is no committed Xcode project.
+- Build and stage the app with `script/build.sh`; use `script/build.sh run` to launch it.
+- Run tests with `script/test.sh`. Pass normal `swift test` filters through the script when narrowing a failure.
+- Use `script/clean.sh` to remove SwiftPM and staged build outputs.
+- Release, signing, packaging, and notarization workflows live in `script/build.sh`, `script/package.sh`, and `script/release.sh`; consult their usage text rather than duplicating flags here.
+- Build-time backend values are documented in `Config/.env.example`; `Config/.env` is local and must not be committed.
+- Tests use Swift Testing (`@Test`, `#expect`, `#require`), not XCTest.
 
-## Project Shape
+## Project Map
 
-- Ironsmith is a macOS menu bar app built with SwiftUI, SwiftData, Observation, Foundation Models, AnyLanguageModel, and a small AppKit bridge.
-- The menu bar surface is `IronsmithMenuBarController`, an `NSStatusItem` plus `NSPopover`. Do not reintroduce `MenuBarExtra` unless the app shell is deliberately changed.
-- `Ironsmith/App` owns app-level wiring. `IronsmithApp` should stay focused on model container setup, startup bootstrapping, shared state creation, the AppKit menu bar controller, and the SwiftUI `Settings` scene.
-- `Ironsmith/Core/Models` contains persisted SwiftData model types and stable domain identifiers: `Tool`, `ProviderConfig`, and `ModelConfig`. Do not rename persisted model types or stored properties casually, including `ProviderConfig.baseURLString` with its `originalName`.
-- `Ironsmith/Core/Persistence` owns SwiftData container creation, app data bootstrapping, filesystem paths, preference keys, and the small `ToolRepository`.
-- `Ironsmith/Core/Inference` owns provider catalog metadata, inference state, repository access, credentials, account/credit state, remote model discovery, local MLX downloads, Ollama integration, model selection, generation preferences, and language model construction.
-- `Ironsmith/Core/AgentPipeline` owns generated-tool scaffolding, metadata prompts, source cleanup, Swift package builds, compiler diagnostic parsing, deterministic repairs, optional model-diff repairs, app bundle building, icon generation, launch/export clients, version backups, and diagnostics logging.
-- `Ironsmith/Features/Launch` owns launch routing and Xcode Command Line Tools detection/onboarding.
-- `Ironsmith/Features/ToolLibrary` owns the compact menu bar popover, `ToolLibraryStore`, tool rows, Finder/export actions, restore-previous-version actions, prompt composition, launch state, and export state.
-- `Ironsmith/Features/Settings` owns the settings scene content, provider/model sections, sheets, presentation helpers, and small reusable settings controls.
-- Tests mirror this structure under `IronsmithTests/Core` and `IronsmithTests/Features`; add focused tests beside the behavior you change.
+- `Ironsmith/App`: application startup, AppKit controllers, routing, settings/about window presentation.
+- `Ironsmith/Core/Models`: stable model aliases, domain enums, and application-facing computed behavior.
+- `Ironsmith/Core/Persistence`: SwiftData setup and migrations, app paths/preferences, startup seeding, and repositories.
+- `Ironsmith/Core/Inference`: provider metadata, credentials/accounts, model discovery and selection, local model/Ollama work, language-model construction, and `InferenceStore`.
+- `Ironsmith/Core/AgentPipeline`: generated-package layout, prompts, file/process clients, source cleanup, compile/repair loops, app bundling, icons, and generation runtime.
+- `Ironsmith/Features/Launch`: Command Line Tools detection and launch routing.
+- `Ironsmith/Features/ToolLibrary`: menu bar popover UI, `ToolLibraryStore`, tool actions, and app update checks.
+- `Ironsmith/Features/Settings`: settings UI and provider/model management.
+- `IronsmithTests` mirrors these areas. Put focused tests beside the behavior being changed.
 
-## Architecture Pattern
+## Architecture
 
-- Keep the app simple: views render state and send intent; stores coordinate workflows; repositories wrap data access and persistence; closure clients wrap effectful service/process/filesystem operations.
-- `InferenceStore` is the shared `@Observable` state owner for inference. It exposes providers, persisted local models, transient remote models, selected model state, provider connection issues, Ollama transfer state, Ironsmith account/session/credit state, error/smoke-test state, `GenerationPreferencesStore`, and `ModelSelectionStore`.
-- `ToolLibraryStore` is local `@Observable` state for the popover only. Do not put tool-list UI state, selected tool state, generation progress, export state, launch state, restore availability, prompt text, or sandbox toggle state into `InferenceStore`.
-- `InferenceRepository` is the normal persisted-data access layer for providers and persisted local models. It currently uses SwiftData, but callers should depend on the repository boundary rather than storage details. It should not make network calls, touch Keychain, launch processes, or persist remote model discovery results.
-- `AppDataBootstrapper` is startup seeding logic, not a general repository. It ensures app directories and baseline built-in data exist when their runtime dependencies are available.
-- Closure clients are the main side-effect seams:
-  - `CredentialClient` for Keychain-backed API keys.
-  - `IronsmithAccountClient` for app-side account, session, credit pack, checkout, and account deletion operations.
-  - `RemoteModelClient` for provider model-list requests, provider-specific headers, response decoding, and text-model filtering.
-  - `LocalModelClient` for MLX HuggingFace Hub filesystem/download work.
-  - `OllamaClient` for detecting/starting Ollama and pulling/deleting Ollama models.
-  - `LanguageModelClient` for constructing/running AnyLanguageModel language models.
-  - `ToolGenerationClient`, `ToolRunnerClient`, `ToolBuildClient`, `ToolExportClient`, `ToolFinderClient`, and `ToolVersionBackupClient` for generated-tool effects.
-- `InferenceDependencies.live` and `ToolLibraryDependencies.live` wire production clients. Tests should inject fake closure clients directly instead of adding protocol/mock ceremony.
-- `ProviderCatalog` is the source of truth for built-in provider display names, default base URLs, auth modes, origins, sort order, model-list paths, and response formats.
+- Views render state and send intent. Observable stores coordinate workflows. Repositories own persisted-data access. Small closure clients wrap network, process, Keychain, filesystem, and launch effects.
+- Production dependencies are assembled by the relevant `Dependencies.live` or client factory. Tests should inject lightweight fake clients directly rather than adding test-only abstraction layers.
+- `InferenceStore` owns shared provider, model, account, and generation-preference state. `ToolLibraryStore` owns popover-specific selection, prompt, generation, launch, export, and restore state.
+- Keep network, Keychain, process, and filesystem effects out of SwiftUI views and SwiftData repositories.
+- Prefer request/configuration objects when an operation needs several related values. Avoid compatibility initializers or forwarding wrappers created only to keep old tests compiling; update tests to the current API.
 
-## Startup And State
+## App Shell
 
-- `IronsmithApp.init` creates the SwiftData `ModelContainer`, runs `AppDataBootstrapper.bootstrapIfNeeded`, creates `InferenceStore` and `CommandLineToolsGate`, and installs `IronsmithMenuBarController` outside tests.
-- The app body intentionally exposes only the SwiftUI `Settings` scene; the menu bar popover is owned by the AppKit controller.
-- `LaunchRouterView` calls `gate.start()` and `InferenceStore.loadIfNeeded(modelContext:)` from the menu bar path so inference state warms before users generate from the popover.
-- `SettingsWindowView` calls `InferenceStore.prepareSettings(modelContext:)`, which loads once and refreshes providers that declare model-list behavior through the inference layer.
-- `CommandLineToolsGate` and inference loading are independent. The gate decides checking/onboarding/tool-library routing, while inference loads providers and models.
-- `selectedModelID` is persisted by `ModelSelectionStore` in UserDefaults and must use `providerIdentifier::modelIdentifier` so selection survives remote model refetches.
-- `availableModels` is derived from installed/built-in `persistedModels` plus transient `remoteModels`. Reconciliation rules live in `InferenceStore` and should keep selection valid while surfacing user-visible fallback alerts through `selectedModelFallbackMessage`.
+- Ironsmith is a menu-bar-first macOS app. `IronsmithApplicationController` wires persistence, shared stores, routing, settings, and `IronsmithMenuBarController`.
+- The main menu bar surface is an AppKit `NSStatusItem` and `NSPopover`. Generated tools may independently use SwiftUI window or `MenuBarExtra` app entries.
+- Keep startup wiring in the application layer and feature state in its owning store. Do not introduce a template-style main window flow without an intentional product change.
+- Prefer native macOS SwiftUI controls and small responsibility-focused views. Reuse existing provider/model presentation helpers instead of duplicating display cleanup.
 
-## Model And Provider Rules
+## Inference
 
-- Keep one `ModelConfig` type for built-in local models, downloaded local models, local-server models, Ironsmith provider models, custom providers, and remote hosted provider models.
-- Persist only models that the SwiftData repository explicitly allows. Provider-discovered models should stay transient unless persistence behavior is deliberately changed.
-- Remote/provider-discovered models are transient `ModelConfig` values. They can be shown, selected, and used, but must not be inserted into SwiftData.
-- Use clear naming at call sites:
-  - `persistedModels` for SwiftData-backed local/installable models.
-  - `remoteModels` for transient provider-discovered models.
-  - `availableModels` for the unified in-memory list used by UI and generation.
-- `ProviderKind` and `ProviderCatalog` are the source of truth for provider cases, display names, auth modes, default URLs, sort order, model-list behavior, and response formats. Do not duplicate those tables in UI or tests.
-- Custom OpenAI-compatible providers get unique `custom.<uuid>` identifiers and may be added multiple times.
-- API keys are stored in Keychain through `ProviderCredentialStore`; provider-specific required/optional credential behavior should follow `ProviderConfig.authMode`, `ProviderCatalog`, and `InferenceStore.makeProvider`.
-- Ironsmith provider setup uses account/session/credit state instead of a Keychain API key. Before generation, `InferenceStore.prepareSelectedModelForGeneration()` refreshes account credits and validates that the selected Ironsmith model can generate.
-- `RemoteModelClient` owns provider model-list request construction, response decoding, text-model filtering, and snapshot-alias cleanup. Add or change provider discovery there with focused tests.
-- `LanguageModelClient` owns mapping selected `ModelConfig`/`ProviderConfig` pairs to concrete AnyLanguageModel wrappers. Keep provider-specific API variants and sessions there, not in views.
-- User-facing generation preferences live in `GenerationPreferencesStore` and UserDefaults. Exact keys and source/model defaults belong in `GenerationPreferencesStore` and `ModelGenerationDefaults`, not `ProviderConfig`.
-- Model catalogs such as `MLXModelCatalog` and `OllamaModelCatalog` are source-of-truth lists, not assumptions. UI, previews, and tests must tolerate empty catalogs and provider-discovered models.
-- Keep `ProviderConfig.localProviderIdentifier` and `ModelConfig.appleFoundationIdentifier` as the built-in identifiers.
+- `ProviderCatalog` is the source of truth for built-in provider behavior and presentation metadata. Do not duplicate provider tables in views or tests.
+- `InferenceRepository` persists providers and local/installable models. Provider-discovered models remain transient unless persistence is deliberately redesigned.
+- Treat `persistedModels`, `remoteModels`, and their combined available-model view as distinct concepts at call sites.
+- API keys go through the credential client/Keychain path. Ironsmith account, session, and credit behavior goes through `IronsmithAccountClient`.
+- Provider-specific discovery belongs in `RemoteModelClient`; provider-to-model-wrapper construction belongs in `LanguageModelClient`.
+- User generation preferences and selected-model persistence belong in their dedicated stores, not provider records or views.
 
 ## Agent Pipeline
 
-- The active generation runtime is intentionally single-file. `SingleFileToolGenerationRuntime` creates or edits one editable file: `Sources/<ExecutableName>/ContentView.swift`.
-- Generated tools are SwiftPM executable packages under `~/.ironsmith/tools/<tool-slug>/`. `Package.swift` and the fixed `@main` app entry file are written by Ironsmith, not by the model.
-- Generated package toolchain, language mode, and platform settings live in `ToolPackageLayout.packageManifestContent()`. Do not duplicate those values elsewhere.
-- Tool metadata is stored in SwiftData, and generated-file paths are derived from `ToolPackageLayout`. There is no active `Protocols/` directory or action-plan agent.
-- Create mode asks `ToolMetadataClient` for a short display name and icon prompt, writes the package scaffold, prompts the selected model for a complete `ContentView.swift`, cleans/formats it, compiles it, strips quarantine from the debug binary, and builds an internal app bundle.
-- `ToolMetadataClient.live()` may use local structured generation for nicer metadata, but metadata generation must remain a soft enhancement with a deterministic fallback.
-- Edit mode stages the current `ContentView.swift` in `.ironsmith/versions/pending-ContentView.swift`. Model-diff capable selections start with a bounded unified diff; deterministic-only selections rewrite the whole `ContentView.swift`. Successful edits promote the staged source to `previous-ContentView.swift`; failed edits restore the original source and discard the staged backup.
-- `ContentViewSourceCleanup` runs before compile attempts and repair mutations. It strips fences/thinking blocks/scaffolding, removes generated app/preview blocks, normalizes imports and common macOS SwiftUI footguns, moves loose top-level state into `ContentView`, removes misplaced member-scope view blocks, wraps loose SwiftUI fragments when possible, and then asks `swift-format` to format the file.
-- Builds use `swift build --package-path <packageRoot>` through `SwiftPackageProcessClient`; compiler diagnostics are parsed into `SwiftCompilerDiagnostic` values and filtered to actionable `ContentView.swift` errors.
-- `ContentViewBuildRepairLoop` owns compile/repair/regeneration:
-  - Generate a candidate and clean/format it.
-  - Compile and parse Swift diagnostics.
-  - Apply deterministic repairs repeatedly until stable, compiled, rolled back, or the deterministic pass limit is reached.
-  - If the selected model allows model repair, ask for small validated unified diffs against authoritative `ContentView.swift`, compile accepted mutations, and roll back patches that increase `ContentView` error count or compile to the placeholder scaffold.
-  - Compact a repair conversation once on context-window errors, then regenerate if repair still exceeds context.
-  - Regenerate when the candidate has too many `ContentView` errors, deterministic-only repair stalls, model patches are repeatedly invalid/no-progress/rolled-back, or context-window limits are hit.
-  - Track and restore the best candidate before failing, except edit failure restores the original source.
-- `ToolGenerationRepairPolicy` is the shared policy surface for thresholds, generation attempts, deterministic pass count, initial edit hunk limits, repair hunk limits, invalid-patch stalls, and model repair budget.
-- `ToolRepairStrategy` is selected by `InferenceStore` from model source and capability. Keep strategy choices and numeric budgets in `InferenceStore`/`ToolGenerationRepairPolicy`; avoid scattering model-name heuristics or hunk counts elsewhere.
-- Deterministic repairs should be compiler-shape fixes, not prompt-specific app implementations. Prefer broadly applicable Swift/SwiftUI/macOS corrections tied to a diagnostic pattern. Add focused tests in `AgentPipelineTests` for every new fixer and ensure a failed deterministic edit is safe to skip or roll back.
-- Model repair diffs must remain validated unified diffs. Do not accept prose patches, ambiguous context, full rewrites unless the file is malformed, or edits outside `ContentView.swift`.
-- Diagnostics logging goes through `AgentDiagnosticsLog` and is DEBUG-only at `~/.ironsmith/agent-diagnostics.log`; keep logs compact enough to explain repair loops without dumping entire model responses.
+- The active runtime is single-file: the model creates or edits only `Sources/<ExecutableName>/ContentView.swift`. Ironsmith owns `Package.swift` and the fixed app entry source.
+- Generated tools are SwiftPM packages under `IronsmithPaths.toolsDirectory`. Derive package files and metadata paths through `ToolPackageLayout`; do not reconstruct them at call sites.
+- Create flow prepares metadata and icon assets early, generates source, cleans/formats it, compiles and repairs it, then builds the internal app bundle.
+- Edit flow must preserve the original source and settings until the edited package builds successfully. Keep version staging and restore behavior in `ToolVersionBackupClient`.
+- `ContentViewSourceCleanup` owns model-output normalization. Compiler-driven deterministic repairs should be general Swift/SwiftUI fixes; model repairs must remain validated changes confined to `ContentView.swift`.
+- Keep repair thresholds and strategy selection centralized in `ToolGenerationRepairPolicy`, `ToolRepairStrategy`, and inference model selection logic.
+- `ToolAppBundleClient` owns internal/exported app bundle construction, signing, entitlements, icon copying, verification, replacement, and launch support. Do not duplicate bundle assembly elsewhere.
+- Preserve cancellation/resume state through the generation lifecycle. `ToolLibraryStore` is responsible for reconciling persisted tool state with generation results and failures.
+- Diagnostics use `AgentDiagnosticsLog`; keep logs compact and avoid dumping full model responses or secrets.
 
-## App Bundle And Tool Execution
+## Persistence And Files
 
-- `ToolAppBundleClient` builds internal LSUIElement app bundles inside each generated package and exports Dock-visible bundles to `/Applications`.
-- App bundle builds use release `swift build`, `swift build -c release --show-bin-path`, `Info.plist`, optional sandbox entitlements, ad hoc signing, code-sign verification, staged replacement with backup restore, and quarantine stripping.
-- Generated app bundle metadata is written by `ToolAppBundleClient`; keep deployment/version values aligned with the app target in code and tests rather than copying them into guidance.
-- App icons are cached under `.ironsmith/` inside the generated package. `ToolIconClient` owns icon generation/encoding and must fall back gracefully when richer icon generation is unavailable.
-- `ToolRunnerClient` launches the internal app bundle and rebuilds it first if the bundle is missing or incomplete. Prefer app-bundle launch/export paths over launching raw SwiftPM binaries.
-- `ToolExportClient` rebuilds for the export destination and reuses an existing `/Applications/<name>.app` only when the bundle identifier matches; otherwise it chooses a suffixed app name.
+- Production app data lives under `~/.ironsmith/`; use `IronsmithPaths` instead of hard-coded paths.
+- The SwiftData store is `~/.ironsmith/db/ironsmith.sqlite`. Startup preparation imports the legacy Application Support store only when needed, preserves the source, and snapshots the destination before SwiftData opens it.
+- Startup database backups include SQLite companion files and retain the three newest completed snapshots. Never silently delete or replace a failed user store.
+- Use `IronsmithModelContainerFactory.make(isRunningTests: true)` for tests and previews.
+- Persisted models are declared inside immutable versioned schema files in `Core/Persistence/Migrations`. `Core/Models` points application code at the current schema through typealiases and extensions.
+- Keep one ordered `IronsmithSchemaMigrationPlan`. For each database change, add a new self-contained schema version and the adjacent migration stage; never mutate a shipped historical schema.
+- Persisted model names and stored properties are compatibility surfaces. Use SwiftData rename metadata and a migration when changing them.
+- Generated-package file access must remain inside the package root. Preserve the path validation in `ToolPackageLayout` and generation/version-backup helpers.
 
-## Tool Library Rules
+## Change Discipline
 
-- The menu bar popover is intentionally compact: header/actions at top, tool list first, generation status when needed, and prompt composer at the bottom. Check `ToolLibraryPopoverView` for sizing.
-- The header shows the selected model and, for Ironsmith models, live credit/session status. Keep it concise enough for the popover width.
-- Clicking a tool row toggles edit mode. Running, reverting, exporting, showing in Finder, and deleting live in row controls/context menus.
-- `ToolLibraryStore.startPromptSubmission` owns the cancellable generation task. `cancelGeneration()` should cancel that task, clear stale errors, and leave the UI in a sensible "Stopping" state while the task unwinds.
-- `ToolLibraryStore.submitPrompt` should persist a new or edited `Tool` only after successful generation. If launching after generation fails, the tool may already be persisted and the launch error is surfaced/logged separately.
-- After Ironsmith-backed generation, refresh account credits so the popover and settings do not show stale balances.
-- Deleting a tool removes it from the SwiftData library. Do not add package-directory deletion unless that product behavior is intentionally changed and tested.
-- The sandbox toggle is hidden unless `IronsmithPreferenceKeys.showSandboxOverride` is enabled in Settings. When hidden, generation forces sandboxing on.
-- Restore-previous-version uses `ToolPackageLayout` to find `ContentView.swift`, swaps it with `.ironsmith/versions/previous-ContentView.swift`, rebuilds the internal app bundle, and updates the tool summary.
-
-## Settings Rules
-
-- Settings should remain a separate SwiftUI `Settings` scene opened with `SettingsLink` from the popover.
-- `SettingsWindowView` is a grouped `Form` with model selection/generation settings, providers, preferences, and any diagnostic sections gated by build configuration.
-- Provider add/edit flows live in sheets. `AddProviderSheetView` owns provider selection, credential/base URL entry, and provider-specific onboarding.
-- `ProviderEditorSheetView` owns provider editing, local model management, local-server model management, account rows, credit purchase sheet presentation, sign-out, and account deletion UI.
-- `SettingsModelSelectionSectionView` owns the selected-model row and searchable model picker. Model rows should use `SettingsModelPresentation` plus `ModelLogoView` rather than duplicating display-name/logo cleanup.
-- `SettingsPreferencesSectionView` owns the user-facing sandbox override preference; the popover decides whether to show the toggle and forces sandboxing on when hidden.
-
-## SwiftUI Conventions
-
-- The app is intentionally menu-bar-first. Do not introduce a template-style main window flow.
-- Prefer native macOS `Form`, `Section`, `LabeledContent`, `Picker`, `Toggle`, `Stepper`, `Slider`, `List`, and sheet patterns in Settings.
-- Use `@Environment(InferenceStore.self)` for shared inference state. When a view needs bindings into the store, create a local `@Bindable var inferenceStore = inferenceStore` inside `body`.
-- Keep SwiftUI scene roots and section views small. Extract a view when it names a real responsibility, not just to split lines.
-- Local preview frames should resemble the real surface being previewed, especially popover and settings-window previews.
-- Be careful with previews and tests that index catalogs. Catalog arrays can be empty.
-- Provider/model presentation helpers live in Settings controls (`ProviderLogoView`, `ModelLogoView`, `SettingsModelPresentation`); prefer extending them over duplicating logo/name cleanup logic.
-
-## Persistence And Safety
-
-- Use `IronsmithModelContainerFactory.make(isRunningTests: true)` for SwiftData tests and previews.
-- Do not silently delete a failed persistent store. The container factory backs up bad sqlite/wal/shm files under `~/.ironsmith/Backups/` before creating a fresh store.
-- App data lives under `~/.ironsmith/`: `ironsmith.sqlite`, `models/`, `tools/`, and the DEBUG diagnostics log.
-- Use `Tool` and `ToolPackageLayout` derived URL helpers for package roots, package manifests, metadata, versions, app bundles, cached icons, and entitlements instead of rebuilding those paths at call sites.
-- `ToolGenerationRuntimeContext.packageFileURL` and `ToolVersionBackupClient` validate that generated-tool file access stays inside the package root. Preserve those path-escape checks.
-- The generator does not write protocol files, but `Tool.protocolsDirectoryURL` may still exist for compatibility/future work. Do not build new agent flow around protocols unless the runtime is intentionally changed.
-- No Xcode project is committed. Open the root `Package.swift` in Xcode when IDE debugging is needed, and keep build graph changes in SwiftPM/script files.
-
-## AnyLanguageModel Dependency
-
-- The app depends directly on the `AnyLanguageModel` package from the root `Package.swift`.
-- Do not enable the `AnyLanguageModel` MLX trait during the SwiftPM-first migration unless that product decision changes deliberately.
-- Do not reintroduce `Packages/AnyLanguageModelShim`; it existed for Xcode trait limitations and is no longer part of the default build.
-
-## Product Notes
-
-- Source and tests are the operational source of truth. `docs/ironsmith-spec.md` is useful product background, but parts of it still describe older `MenuBarExtra`, architecture-agent, action-plan, and protocol-file ideas.
-- The active generation pipeline is the single-file `ContentView.swift` runtime plus signed app-bundle packaging. Treat older architecture/action-plan/protocol-file notes as obsolete unless reintroduced deliberately.
-- Generated user tools and downloaded local assets live under paths defined by `IronsmithPaths`; do not hard-code those paths outside the path helpers.
-- Models managed by an external local server should be treated as provider-discovered remote models rather than SwiftData-persisted downloads.
+- Match existing ownership boundaries and naming before introducing a new abstraction.
+- Keep changes scoped; do not refactor unrelated code or overwrite user work in a dirty tree.
+- Add focused tests for behavior changes, especially persistence, generation lifecycle, source repair, provider discovery, and app bundling.
+- Prefer structured parsers and typed models over ad hoc string manipulation where the platform or project already provides them.
+- Before finishing, run the narrowest relevant tests, then `script/test.sh` when the change has shared or user-facing impact. Run `git diff --check` for all changes.

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleRequest.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleRequest.swift
@@ -6,8 +6,6 @@ struct ToolAppBundleRequest: Equatable, Sendable {
     let bundleIdentifier: String
     let packageRootURL: URL
     let settings: ToolGenerationSettings
-    let sandboxPermissions: GeneratedAppSandboxPermissions
-    let resourcePermissions: GeneratedAppResourcePermissions
     let iconPrompt: String?
 
     var appKind: ToolAppKind {
@@ -22,33 +20,27 @@ struct ToolAppBundleRequest: Equatable, Sendable {
         settings.sandboxEnabled
     }
 
+    var sandboxPermissions: GeneratedAppSandboxPermissions {
+        settings.sandboxPermissions
+    }
+
+    var resourcePermissions: GeneratedAppResourcePermissions {
+        settings.resourcePermissions
+    }
+
     init(
         displayName: String,
         executableName: String,
         bundleIdentifier: String,
         packageRootURL: URL,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions = .default,
-        resourcePermissions: GeneratedAppResourcePermissions = .none,
-        appKind: ToolAppKind = .window,
-        menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
-        settings: ToolGenerationSettings? = nil,
+        settings: ToolGenerationSettings,
         iconPrompt: String? = nil
     ) {
         self.displayName = displayName
         self.executableName = executableName
         self.bundleIdentifier = bundleIdentifier
         self.packageRootURL = packageRootURL
-        let resolvedSettings = settings ?? ToolGenerationSettings(
-            appKind: appKind,
-            menuBarSystemImage: menuBarSystemImage,
-            sandboxEnabled: sandboxEnabled,
-            sandboxPermissions: sandboxPermissions,
-            resourcePermissions: resourcePermissions
-        )
-        self.settings = resolvedSettings
-        self.sandboxPermissions = resolvedSettings.sandboxPermissions
-        self.resourcePermissions = resolvedSettings.resourcePermissions
+        self.settings = settings
         self.iconPrompt = iconPrompt
     }
 
@@ -63,33 +55,28 @@ struct ToolAppBundleRequest: Equatable, Sendable {
         )
     }
 
-    static func forTool(
-        _ tool: Tool,
-        sandboxPermissions: GeneratedAppSandboxPermissions = .default,
-        resourcePermissions: GeneratedAppResourcePermissions = .none
-    ) -> ToolAppBundleRequest {
+    static func forTool(_ tool: Tool, defaults: ToolGenerationSettings) -> ToolAppBundleRequest {
         ToolAppBundleRequest(
             displayName: tool.name,
             executableName: tool.executableName,
             bundleIdentifier: tool.bundleIdentifier,
             packageRootURL: tool.packageRootURL,
-            sandboxEnabled: tool.sandboxEnabled,
-            settings: tool.generationSettings(
-                defaultSandboxPermissions: sandboxPermissions,
-                defaultResourcePermissions: resourcePermissions
-            ),
+            settings: tool.generationSettings(defaults: defaults),
             iconPrompt: nil
         )
     }
 
     static func forToolPreservingExistingBundlePermissions(_ tool: Tool) -> ToolAppBundleRequest {
-        forTool(
-            tool,
+        let defaults = ToolGenerationSettings(
+            appKind: tool.appKind,
+            menuBarSystemImage: tool.validatedMenuBarSystemImage,
+            sandboxEnabled: tool.sandboxEnabled,
             sandboxPermissions: GeneratedAppSandboxPermissions.inferred(
                 fromPackageAt: tool.packageRootURL,
                 sandboxEnabled: tool.sandboxEnabled
             ),
             resourcePermissions: GeneratedAppResourcePermissions.inferred(fromAppBundleAt: tool.appBundleURL)
         )
+        return forTool(tool, defaults: defaults)
     }
 }

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -43,17 +43,6 @@ nonisolated struct AgentLanguageModelContext {
     }
 }
 
-struct ToolManifest: Codable, Equatable, Sendable {
-    var displayName: String
-    var executableName: String
-    var files: [ToolManifestFile]
-}
-
-struct ToolManifestFile: Codable, Equatable, Sendable {
-    var path: String
-    var description: String
-}
-
 enum ToolAppKind: String, Codable, CaseIterable, Equatable, Sendable {
     case window
     case menuBar = "menu_bar"
@@ -182,22 +171,19 @@ struct ToolGenerationResult: Equatable, Sendable {
     let bundleIdentifier: String
     let settings: ToolGenerationSettings
     let packageRootURL: URL
-    let manifest: ToolManifest
 
     init(
         toolName: String,
         executableName: String,
         bundleIdentifier: String? = nil,
         settings: ToolGenerationSettings,
-        packageRootURL: URL,
-        manifest: ToolManifest
+        packageRootURL: URL
     ) {
         self.toolName = toolName
         self.executableName = executableName
         self.bundleIdentifier = bundleIdentifier ?? ToolBundleIdentifier.make(executableName: executableName)
         self.settings = settings
         self.packageRootURL = packageRootURL
-        self.manifest = manifest
     }
 }
 
@@ -258,7 +244,6 @@ enum ToolNameSanitizer {
 }
 
 struct ToolPackageLayout: Equatable, Sendable {
-    nonisolated static let agentManifestFilename = "ironsmith-manifest.json"
     nonisolated static let packageMetadataDirectoryName = ".ironsmith"
     nonisolated static let versionsDirectoryName = "versions"
     nonisolated static let pendingContentViewDraftFilename = "pending-ContentView.swift"
@@ -273,10 +258,6 @@ struct ToolPackageLayout: Equatable, Sendable {
 
     nonisolated var packageManifestURL: URL {
         packageRootURL.appendingPathComponent("Package.swift")
-    }
-
-    nonisolated var agentManifestURL: URL {
-        packageRootURL.appendingPathComponent(Self.agentManifestFilename)
     }
 
     nonisolated var packageMetadataDirectoryURL: URL {
@@ -339,6 +320,10 @@ struct ToolPackageLayout: Equatable, Sendable {
 
     nonisolated var defaultContentViewFileName: String {
         "ContentView.swift"
+    }
+
+    nonisolated var contentViewSourcePath: String {
+        sourcePath(for: defaultContentViewFileName)
     }
 
     nonisolated func sourcePath(for fileName: String) -> String {

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -1,7 +1,7 @@
 import AnyLanguageModel
 import Foundation
 
-struct AgentLanguageModelContext {
+nonisolated struct AgentLanguageModelContext {
     let languageModel: any LanguageModel
     let metadataLanguageModel: any LanguageModel
     let options: GenerationOptions
@@ -184,23 +184,18 @@ struct ToolGenerationResult: Equatable, Sendable {
     let packageRootURL: URL
     let manifest: ToolManifest
 
-    var sandboxEnabled: Bool {
-        settings.sandboxEnabled
-    }
-
     init(
         toolName: String,
         executableName: String,
         bundleIdentifier: String? = nil,
-        sandboxEnabled: Bool = true,
-        settings: ToolGenerationSettings? = nil,
+        settings: ToolGenerationSettings,
         packageRootURL: URL,
         manifest: ToolManifest
     ) {
         self.toolName = toolName
         self.executableName = executableName
         self.bundleIdentifier = bundleIdentifier ?? ToolBundleIdentifier.make(executableName: executableName)
-        self.settings = settings ?? ToolGenerationSettings(sandboxEnabled: sandboxEnabled)
+        self.settings = settings
         self.packageRootURL = packageRootURL
         self.manifest = manifest
     }

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/BuildSupport.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/BuildSupport.swift
@@ -2,6 +2,14 @@ import AnyLanguageModel
 import Foundation
 
 extension ContentViewBuildRepairLoop {
+    struct SourceMutationRequest {
+        let source: String
+        let originalSource: String
+        let previousContentViewErrorCount: Int
+        let phase: String
+        let rollbackSubject: String
+    }
+
     func betterCandidate(
         current: SourceCandidate?,
         source: String,
@@ -131,37 +139,30 @@ extension ContentViewBuildRepairLoop {
     }
 
     func compileSourceMutation(
-        _ source: String,
-        originalSource: String,
-        previousContentViewErrorCount: Int,
-        phase: String,
-        statusMessage: String,
-        rollbackSubject: String,
-        status: @escaping @MainActor (String) -> Void
+        _ request: SourceMutationRequest
     ) async throws -> SourceMutationBuildResult {
         try Task.checkCancellation()
-        try context.write(source, to: contentViewPath, packageRootURL: layout.packageRootURL)
+        try context.write(request.source, to: contentViewPath, packageRootURL: layout.packageRootURL)
         try await Self.cleanContentViewSource(contentViewPath, layout: layout, context: context)
 
-        status(statusMessage)
-        guard let state = try await buildCurrentSource(phase: phase) else {
-            if try compiledContentViewIsPlaceholder(phase: phase) {
-                try context.write(originalSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
+        guard let state = try await buildCurrentSource(phase: request.phase) else {
+            if try compiledContentViewIsPlaceholder(phase: request.phase) {
+                try context.write(request.originalSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
                 return .rolledBack
             }
             return .finished
         }
 
-        guard state.contentViewErrors.count <= previousContentViewErrorCount else {
+        guard state.contentViewErrors.count <= request.previousContentViewErrorCount else {
             AgentDiagnosticsLog.append(
                 """
-                \(rollbackSubject) rolled back.
+                \(request.rollbackSubject) rolled back.
                 packageRoot: \(layout.packageRootURL.path)
-                previousContentViewErrorCount: \(previousContentViewErrorCount)
+                previousContentViewErrorCount: \(request.previousContentViewErrorCount)
                 newContentViewErrorCount: \(state.contentViewErrors.count)
                 """
             )
-            try context.write(originalSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
+            try context.write(request.originalSource, to: contentViewPath, packageRootURL: layout.packageRootURL)
             return .rolledBack
         }
 

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/BuildSupport.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/BuildSupport.swift
@@ -133,7 +133,7 @@ extension ContentViewBuildRepairLoop {
         switch generationError {
         case .invalidRepairPatch, .noRepairPatchCandidate:
             return true
-        case .emptyPrompt, .compileFailed, .couldNotEncodeManifest:
+        case .emptyPrompt, .compileFailed:
             return false
         }
     }
@@ -178,7 +178,7 @@ extension ContentViewBuildRepairLoop {
             return .invalidRepairPatch
         case .noRepairPatchCandidate:
             return .noDeterministicRepair
-        case .emptyPrompt, .compileFailed, .couldNotEncodeManifest:
+        case .emptyPrompt, .compileFailed:
             return nil
         }
     }

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
@@ -77,8 +77,7 @@ struct ContentViewBuildRepairLoop {
 
     func run(
         generator: ContentViewCandidateGenerator,
-        failureRecovery: FailureRecovery = .restoreBestCandidate,
-        status: @escaping @MainActor (String) -> Void
+        failureRecovery: FailureRecovery = .restoreBestCandidate
     ) async throws {
         var activeGenerator = generator
         var bestCandidate: SourceCandidate?
@@ -103,8 +102,6 @@ struct ContentViewBuildRepairLoop {
                     )
                 }
 
-                let statusVerb = isInitialAttempt ? activeGenerator.initialStatusVerb : activeGenerator.retryStatusVerb
-                status("\(statusVerb) \(displayName)")
                 do {
                     try await activeGenerator.writeFreshCandidate(makeGenerationSession(instructions: activeGenerator.instructions))
                     try Task.checkCancellation()
@@ -174,7 +171,6 @@ struct ContentViewBuildRepairLoop {
                 }
 
                 let phase = isInitialAttempt ? "initial compile" : "regenerated compile \(generationAttempt - 1)"
-                status("Building \(displayName)")
                 guard var state = try await buildCurrentSource(phase: phase) else {
                     if try compiledContentViewIsPlaceholder(phase: phase) {
                         pendingRegenerationReason = "compiled ContentView.swift was only the placeholder scaffold"
@@ -186,8 +182,7 @@ struct ContentViewBuildRepairLoop {
 
                 guard let stableState = try await applyDeterministicRepairsUntilStable(
                     startingFrom: state,
-                    phasePrefix: "\(phase) deterministic repair",
-                    status: status
+                    phasePrefix: "\(phase) deterministic repair"
                 ) else {
                     return
                 }
@@ -219,7 +214,6 @@ struct ContentViewBuildRepairLoop {
 
                 switch try await runModelRepairForCurrentCandidate(
                     startingFrom: state,
-                    status: status,
                     bestCandidate: &bestCandidate
                 ) {
                 case .finished:

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewCandidateGenerator.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewCandidateGenerator.swift
@@ -5,23 +5,17 @@ struct ContentViewCandidateGenerator {
     struct InvalidCandidateFallback {
         let threshold: Int
         let modeDescription: String
-        let initialStatusVerb: String
-        let retryStatusVerb: String
         let instructions: String
         let writeFreshCandidate: (LanguageModelSession) async throws -> Void
 
         init(
             threshold: Int,
             modeDescription: String,
-            initialStatusVerb: String,
-            retryStatusVerb: String,
             instructions: String = ToolGenerationPrompts.singleFileCodingInstructions,
             writeFreshCandidate: @escaping (LanguageModelSession) async throws -> Void
         ) {
             self.threshold = max(1, threshold)
             self.modeDescription = modeDescription
-            self.initialStatusVerb = initialStatusVerb
-            self.retryStatusVerb = retryStatusVerb
             self.instructions = instructions
             self.writeFreshCandidate = writeFreshCandidate
         }
@@ -29,8 +23,6 @@ struct ContentViewCandidateGenerator {
         func makeGenerator() -> ContentViewCandidateGenerator {
             ContentViewCandidateGenerator(
                 modeDescription: modeDescription,
-                initialStatusVerb: initialStatusVerb,
-                retryStatusVerb: retryStatusVerb,
                 instructions: instructions,
                 writeFreshCandidate: writeFreshCandidate
             )
@@ -38,8 +30,6 @@ struct ContentViewCandidateGenerator {
     }
 
     let modeDescription: String
-    let initialStatusVerb: String
-    let retryStatusVerb: String
     var instructions: String
     var retriesInvalidCandidates: Bool
     var invalidCandidateFallback: InvalidCandidateFallback?
@@ -47,16 +37,12 @@ struct ContentViewCandidateGenerator {
 
     init(
         modeDescription: String,
-        initialStatusVerb: String = "Generating",
-        retryStatusVerb: String = "Regenerating",
         instructions: String = ToolGenerationPrompts.singleFileCodingInstructions,
         retriesInvalidCandidates: Bool = false,
         invalidCandidateFallback: InvalidCandidateFallback? = nil,
         writeFreshCandidate: @escaping (LanguageModelSession) async throws -> Void
     ) {
         self.modeDescription = modeDescription
-        self.initialStatusVerb = initialStatusVerb
-        self.retryStatusVerb = retryStatusVerb
         self.instructions = instructions
         self.retriesInvalidCandidates = retriesInvalidCandidates
         self.invalidCandidateFallback = invalidCandidateFallback

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/DeterministicRepair.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/DeterministicRepair.swift
@@ -4,8 +4,7 @@ import Foundation
 extension ContentViewBuildRepairLoop {
     func applyDeterministicRepairsUntilStable(
         startingFrom initialState: BuildState,
-        phasePrefix: String,
-        status: @escaping @MainActor (String) -> Void
+        phasePrefix: String
     ) async throws -> BuildState? {
         var currentState = initialState
         var seenSignatures = Set<String>()
@@ -44,13 +43,13 @@ extension ContentViewBuildRepairLoop {
             }
 
             switch try await compileSourceMutation(
-                deterministicCandidate.source,
-                originalSource: currentState.source,
-                previousContentViewErrorCount: currentState.contentViewErrors.count,
-                phase: "\(phasePrefix) \(pass)",
-                statusMessage: "Building \(displayName)",
-                rollbackSubject: "Deterministic repair",
-                status: status
+                SourceMutationRequest(
+                    source: deterministicCandidate.source,
+                    originalSource: currentState.source,
+                    previousContentViewErrorCount: currentState.contentViewErrors.count,
+                    phase: "\(phasePrefix) \(pass)",
+                    rollbackSubject: "Deterministic repair"
+                )
             ) {
             case .finished:
                 return nil

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ModelRepair.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ModelRepair.swift
@@ -4,7 +4,6 @@ import Foundation
 extension ContentViewBuildRepairLoop {
     func runModelRepairForCurrentCandidate(
         startingFrom initialState: BuildState,
-        status: @escaping @MainActor (String) -> Void,
         bestCandidate: inout SourceCandidate?
     ) async throws -> CandidateRepairResult {
         var state = initialState
@@ -22,7 +21,6 @@ extension ContentViewBuildRepairLoop {
                 return .failed(state)
             }
             try await lifecycle.updateRepairErrorCount(state.contentViewErrors.count)
-            status(repairStatus(errorCount: state.contentViewErrors.count))
             let originalSource = state.source
             let contentViewErrors = state.contentViewErrors
             let failedCandidateSignature = ContentViewRepairSupport.repairStallKey(
@@ -88,21 +86,20 @@ extension ContentViewBuildRepairLoop {
             }
 
             switch try await compileSourceMutation(
-                repairCandidate.source,
-                originalSource: originalSource,
-                previousContentViewErrorCount: contentViewErrors.count,
-                phase: "repair attempt \(attempt)",
-                statusMessage: "Building \(displayName)",
-                rollbackSubject: "Repair diff",
-                status: status
+                SourceMutationRequest(
+                    source: repairCandidate.source,
+                    originalSource: originalSource,
+                    previousContentViewErrorCount: contentViewErrors.count,
+                    phase: "repair attempt \(attempt)",
+                    rollbackSubject: "Repair diff"
+                )
             ) {
             case .finished:
                 return .finished
             case .accepted(let acceptedState):
                 guard let stableState = try await applyDeterministicRepairsUntilStable(
                     startingFrom: acceptedState,
-                    phasePrefix: "model repair \(attempt) deterministic repair",
-                    status: status
+                    phasePrefix: "model repair \(attempt) deterministic repair"
                 ) else {
                     return .finished
                 }

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/Session.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/Session.swift
@@ -8,9 +8,4 @@ extension ContentViewBuildRepairLoop {
             instructions: instructions
         )
     }
-
-    func repairStatus(errorCount: Int) -> String {
-        let errorLabel = errorCount == 1 ? "error" : "errors"
-        return "Repairing \(errorCount) \(errorLabel)"
-    }
 }

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -18,31 +18,8 @@ struct SingleFileToolGenerationRuntime {
     func generateTool(
         for prompt: String,
         existingTool: Tool? = nil,
-        sandboxEnabled: Bool = true,
-        sandboxPermissions: GeneratedAppSandboxPermissions = .default,
-        resourcePermissions: GeneratedAppResourcePermissions = .none,
-        lifecycle: ToolGenerationLifecycle = .noop,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        try await generateTool(
-            for: prompt,
-            existingTool: existingTool,
-            settings: ToolGenerationSettings(
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions
-            ),
-            lifecycle: lifecycle,
-            status: status
-        )
-    }
-
-    func generateTool(
-        for prompt: String,
-        existingTool: Tool? = nil,
         settings: ToolGenerationSettings,
-        lifecycle: ToolGenerationLifecycle = .noop,
-        status: @escaping @MainActor (String) -> Void
+        lifecycle: ToolGenerationLifecycle = .noop
     ) async throws -> ToolGenerationResult {
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPrompt.isEmpty else {
@@ -58,24 +35,21 @@ struct SingleFileToolGenerationRuntime {
                     prompt: effectivePrompt,
                     existingTool: existingTool,
                     settings: settings,
-                    lifecycle: lifecycle,
-                    status: status
+                    lifecycle: lifecycle
                 )
             }
             return try await editTool(
                 prompt: effectivePrompt,
                 existingTool: existingTool,
                 settings: settings,
-                lifecycle: lifecycle,
-                status: status
+                lifecycle: lifecycle
             )
         }
 
         return try await createTool(
             prompt: trimmedPrompt,
             settings: settings,
-            lifecycle: lifecycle,
-            status: status
+            lifecycle: lifecycle
         )
     }
 
@@ -205,15 +179,13 @@ struct SingleFileToolGenerationRuntime {
         prompt: String,
         existingTool: Tool? = nil,
         settings: ToolGenerationSettings,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
+        lifecycle: ToolGenerationLifecycle
     ) async throws -> ToolGenerationResult {
         let startingPhase = existingTool?.generationPhase ?? .initializing
         let setup: CreateToolSetup
         if let existingTool, let resumedSetup = try? loadCreateSetup(for: existingTool, settings: settings) {
             setup = resumedSetup
         } else {
-            status("Naming app")
             if existingTool == nil {
                 try await preparePlaceholderCreateTool(
                     prompt: prompt,
@@ -285,8 +257,7 @@ struct SingleFileToolGenerationRuntime {
                     manifest: setup.manifest,
                     settings: setup.settings,
                     iconPrompt: setup.iconPrompt,
-                    lifecycle: lifecycle,
-                    status: status
+                    lifecycle: lifecycle
                 )
             }
 
@@ -305,8 +276,7 @@ struct SingleFileToolGenerationRuntime {
                 layout: setup.layout,
                 contentViewPath: setup.contentViewPath,
                 generator: generator,
-                lifecycle: lifecycle,
-                status: status
+                lifecycle: lifecycle
             )
 
             return try await packageTool(
@@ -317,8 +287,7 @@ struct SingleFileToolGenerationRuntime {
                 manifest: setup.manifest,
                 settings: setup.settings,
                 iconPrompt: setup.iconPrompt,
-                lifecycle: lifecycle,
-                status: status
+                lifecycle: lifecycle
             )
         } catch is CancellationError {
             if !lifecycle.preservesCreatedPackageOnCancellation {
@@ -359,8 +328,7 @@ struct SingleFileToolGenerationRuntime {
         prompt: String,
         existingTool: Tool,
         settings: ToolGenerationSettings,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
+        lifecycle: ToolGenerationLifecycle
     ) async throws -> ToolGenerationResult {
         let manifest = try context.loadManifest(at: existingTool.agentManifestURL)
         let layout = ToolPackageLayout(
@@ -381,8 +349,7 @@ struct SingleFileToolGenerationRuntime {
                 manifest: manifest,
                 settings: settings,
                 iconPrompt: nil,
-                lifecycle: lifecycle,
-                status: status
+                lifecycle: lifecycle
             )
         }
         let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
@@ -433,11 +400,9 @@ struct SingleFileToolGenerationRuntime {
                 contentViewPath: contentViewPath,
                 generator: generator,
                 failureRecovery: .restoreOriginalSource(existingSource),
-                lifecycle: lifecycle,
-                status: status
+                lifecycle: lifecycle
             )
             try Task.checkCancellation()
-            status("Packaging \(manifest.displayName)")
             try await lifecycle.updatePhase(.generating, .packaging, nil)
             _ = try await context.appBundleClient.buildInternalApp(
                 ToolAppBundleRequest(
@@ -445,7 +410,6 @@ struct SingleFileToolGenerationRuntime {
                     executableName: manifest.executableName,
                     bundleIdentifier: existingTool.bundleIdentifier,
                     packageRootURL: existingTool.packageRootURL,
-                    sandboxEnabled: settings.sandboxEnabled,
                     settings: settings
                 )
             )
@@ -486,8 +450,7 @@ struct SingleFileToolGenerationRuntime {
         contentViewPath: String,
         generator: ContentViewCandidateGenerator,
         failureRecovery: ContentViewBuildRepairLoop.FailureRecovery = .restoreBestCandidate,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
+        lifecycle: ToolGenerationLifecycle
     ) async throws {
         try await lifecycle.updatePhase(.generating, .repairing, nil)
         let repairLoop = ContentViewBuildRepairLoop(
@@ -501,8 +464,7 @@ struct SingleFileToolGenerationRuntime {
         )
         try await repairLoop.run(
             generator: generator,
-            failureRecovery: failureRecovery,
-            status: status
+            failureRecovery: failureRecovery
         )
     }
 
@@ -557,9 +519,7 @@ struct SingleFileToolGenerationRuntime {
         )
 
         return ContentViewCandidateGenerator(
-            modeDescription: resumePartialSource ? "continue create" : "create",
-            initialStatusVerb: resumePartialSource ? "Continuing" : "Generating",
-            retryStatusVerb: "Regenerating"
+            modeDescription: resumePartialSource ? "continue create" : "create"
         ) { session in
             if useCurrentSourceOnFirstAttempt && !didUseCurrentSource {
                 didUseCurrentSource = true
@@ -646,15 +606,11 @@ struct SingleFileToolGenerationRuntime {
 
         return ContentViewCandidateGenerator(
             modeDescription: resumePartialDiff ? "continue edit diff" : "edit",
-            initialStatusVerb: resumePartialDiff ? "Continuing" : "Editing",
-            retryStatusVerb: "Editing",
             instructions: ToolGenerationPrompts.diffEditInstructions,
             retriesInvalidCandidates: true,
             invalidCandidateFallback: ContentViewCandidateGenerator.InvalidCandidateFallback(
                 threshold: ToolGenerationRepairPolicy.invalidInitialEditDiffsBeforeFullFileEdit,
-                modeDescription: "edit whole-file fallback",
-                initialStatusVerb: "Editing",
-                retryStatusVerb: "Editing"
+                modeDescription: "edit whole-file fallback"
             ) { session in
                 try await regenerateEditedContentView(
                     userPrompt: userPrompt,
@@ -715,9 +671,7 @@ struct SingleFileToolGenerationRuntime {
         )
 
         return ContentViewCandidateGenerator(
-            modeDescription: resumePartialSource ? "continue edit source" : "edit",
-            initialStatusVerb: resumePartialSource ? "Continuing" : "Editing",
-            retryStatusVerb: "Editing"
+            modeDescription: resumePartialSource ? "continue edit source" : "edit"
         ) { session in
             if resumePartialSource && !didAttemptContinuation {
                 didAttemptContinuation = true
@@ -833,8 +787,7 @@ struct SingleFileToolGenerationRuntime {
         manifest: ToolManifest,
         settings: ToolGenerationSettings,
         iconPrompt: String?,
-        lifecycle: ToolGenerationLifecycle,
-        status: @escaping @MainActor (String) -> Void
+        lifecycle: ToolGenerationLifecycle
     ) async throws -> ToolGenerationResult {
         let layout = ToolPackageLayout(packageRootURL: packageRootURL, executableName: executableName)
         try Task.checkCancellation()
@@ -843,7 +796,6 @@ struct SingleFileToolGenerationRuntime {
         await context.processClient.stripQuarantine(binaryURL)
 
         try Task.checkCancellation()
-        status("Packaging \(displayName)")
         try await lifecycle.updatePhase(.generating, .packaging, nil)
         _ = try await context.appBundleClient.buildInternalApp(
             ToolAppBundleRequest(
@@ -851,7 +803,6 @@ struct SingleFileToolGenerationRuntime {
                 executableName: executableName,
                 bundleIdentifier: bundleIdentifier,
                 packageRootURL: packageRootURL,
-                sandboxEnabled: settings.sandboxEnabled,
                 settings: settings,
                 iconPrompt: iconPrompt
             )

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -10,7 +10,6 @@ struct SingleFileToolGenerationRuntime {
         let bundleIdentifier: String
         let layout: ToolPackageLayout
         let contentViewPath: String
-        let manifest: ToolManifest
         let iconPrompt: String?
         let settings: ToolGenerationSettings
     }
@@ -68,19 +67,20 @@ struct SingleFileToolGenerationRuntime {
     private func loadCreateSetup(
         for tool: Tool,
         settings: ToolGenerationSettings
-    ) throws -> CreateToolSetup {
-        let manifest = try context.loadManifest(at: tool.agentManifestURL)
+    ) -> CreateToolSetup? {
         let layout = ToolPackageLayout(
             packageRootURL: tool.packageRootURL,
-            executableName: manifest.executableName
+            executableName: tool.executableName
         )
+        guard context.fileClient.fileExists(layout.packageManifestURL) else {
+            return nil
+        }
         return CreateToolSetup(
-            displayName: manifest.displayName,
-            executableName: manifest.executableName,
+            displayName: tool.name,
+            executableName: tool.executableName,
             bundleIdentifier: tool.bundleIdentifier,
             layout: layout,
-            contentViewPath: manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName),
-            manifest: manifest,
+            contentViewPath: layout.contentViewSourcePath,
             iconPrompt: nil,
             settings: settings
         )
@@ -98,17 +98,7 @@ struct SingleFileToolGenerationRuntime {
         let bundleIdentifier = ToolBundleIdentifier.make(executableName: executableName)
         let packageRootURL = try context.makeUniquePackageRoot(displayName: displayName)
         let layout = ToolPackageLayout(packageRootURL: packageRootURL, executableName: executableName)
-        let contentViewPath = layout.sourcePath(for: layout.defaultContentViewFileName)
-        let manifest = ToolManifest(
-            displayName: displayName,
-            executableName: executableName,
-            files: [
-                ToolManifestFile(
-                    path: contentViewPath,
-                    description: "Primary SwiftUI screen and supporting app logic."
-                )
-            ]
-        )
+        let contentViewPath = layout.contentViewSourcePath
 
         try context.fileClient.createDirectory(layout.sourceDirectoryURL)
         try context.write(layout.packageManifestContent(), to: "Package.swift", packageRootURL: layout.packageRootURL)
@@ -117,15 +107,13 @@ struct SingleFileToolGenerationRuntime {
             to: layout.appEntrySourcePath,
             packageRootURL: layout.packageRootURL
         )
-        try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
         try await lifecycle.prepareCreatedTool(
             ToolGenerationPreparedTool(
                 name: displayName,
                 executableName: executableName,
                 bundleIdentifier: bundleIdentifier,
                 settings: resolvedSettings,
-                packageRootURL: packageRootURL,
-                manifest: manifest
+                packageRootURL: packageRootURL
             ),
             prompt
         )
@@ -136,7 +124,6 @@ struct SingleFileToolGenerationRuntime {
             bundleIdentifier: bundleIdentifier,
             layout: layout,
             contentViewPath: contentViewPath,
-            manifest: manifest,
             iconPrompt: metadata.iconPrompt,
             settings: resolvedSettings
         )
@@ -150,26 +137,13 @@ struct SingleFileToolGenerationRuntime {
         let displayName = "New App"
         let executableName = ToolNameSanitizer.executableName(from: displayName)
         let packageRootURL = try context.makeUniquePackageRoot(displayName: displayName)
-        let layout = ToolPackageLayout(packageRootURL: packageRootURL, executableName: executableName)
-        let contentViewPath = layout.sourcePath(for: layout.defaultContentViewFileName)
-        let manifest = ToolManifest(
-            displayName: displayName,
-            executableName: executableName,
-            files: [
-                ToolManifestFile(
-                    path: contentViewPath,
-                    description: "Primary SwiftUI screen and supporting app logic."
-                )
-            ]
-        )
         try await lifecycle.prepareCreatedTool(
             ToolGenerationPreparedTool(
                 name: displayName,
                 executableName: executableName,
                 bundleIdentifier: ToolBundleIdentifier.make(executableName: executableName),
                 settings: settings,
-                packageRootURL: packageRootURL,
-                manifest: manifest
+                packageRootURL: packageRootURL
             ),
             prompt
         )
@@ -183,7 +157,7 @@ struct SingleFileToolGenerationRuntime {
     ) async throws -> ToolGenerationResult {
         let startingPhase = existingTool?.generationPhase ?? .initializing
         let setup: CreateToolSetup
-        if let existingTool, let resumedSetup = try? loadCreateSetup(for: existingTool, settings: settings) {
+        if let existingTool, let resumedSetup = loadCreateSetup(for: existingTool, settings: settings) {
             setup = resumedSetup
         } else {
             if existingTool == nil {
@@ -254,7 +228,6 @@ struct SingleFileToolGenerationRuntime {
                     executableName: setup.executableName,
                     bundleIdentifier: setup.bundleIdentifier,
                     packageRootURL: setup.layout.packageRootURL,
-                    manifest: setup.manifest,
                     settings: setup.settings,
                     iconPrompt: setup.iconPrompt,
                     lifecycle: lifecycle
@@ -284,7 +257,6 @@ struct SingleFileToolGenerationRuntime {
                 executableName: setup.executableName,
                 bundleIdentifier: setup.bundleIdentifier,
                 packageRootURL: setup.layout.packageRootURL,
-                manifest: setup.manifest,
                 settings: setup.settings,
                 iconPrompt: setup.iconPrompt,
                 lifecycle: lifecycle
@@ -330,23 +302,21 @@ struct SingleFileToolGenerationRuntime {
         settings: ToolGenerationSettings,
         lifecycle: ToolGenerationLifecycle
     ) async throws -> ToolGenerationResult {
-        let manifest = try context.loadManifest(at: existingTool.agentManifestURL)
         let layout = ToolPackageLayout(
             packageRootURL: existingTool.packageRootURL,
-            executableName: manifest.executableName
+            executableName: existingTool.executableName
         )
-        let contentViewPath = manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
+        let contentViewPath = layout.contentViewSourcePath
         let startingPhase = existingTool.isGenerationReady
             ? ToolGenerationPhase.planning
             : (existingTool.generationPhase ?? .generatingEditDiff)
         if !existingTool.isGenerationReady,
            startingPhase == .packaging || startingPhase == .completed {
             return try await packageTool(
-                displayName: manifest.displayName,
-                executableName: manifest.executableName,
+                displayName: existingTool.name,
+                executableName: existingTool.executableName,
                 bundleIdentifier: existingTool.bundleIdentifier,
                 packageRootURL: existingTool.packageRootURL,
-                manifest: manifest,
                 settings: settings,
                 iconPrompt: nil,
                 lifecycle: lifecycle
@@ -367,8 +337,8 @@ struct SingleFileToolGenerationRuntime {
             """
             Tool generation started.
             mode: edit
-            displayName: \(manifest.displayName)
-            executableName: \(manifest.executableName)
+            displayName: \(existingTool.name)
+            executableName: \(existingTool.executableName)
             packageRoot: \(existingTool.packageRootURL.path)
             phase: \(startingPhase.rawValue)
             prompt: \(AgentDiagnosticsLog.compact(prompt, limit: 240))
@@ -380,11 +350,10 @@ struct SingleFileToolGenerationRuntime {
             try Task.checkCancellation()
             // The model only edits ContentView.swift; Ironsmith owns the fixed app scene wrapper.
             try context.write(
-                layout.fixedAppEntrySource(displayName: manifest.displayName, settings: settings),
+                layout.fixedAppEntrySource(displayName: existingTool.name, settings: settings),
                 to: layout.appEntrySourcePath,
                 packageRootURL: layout.packageRootURL
             )
-            try context.writeManifest(manifest, packageRootURL: layout.packageRootURL)
             let generator = editGenerator(
                 userPrompt: prompt,
                 layout: layout,
@@ -395,7 +364,7 @@ struct SingleFileToolGenerationRuntime {
                 resumePartialSource: startingPhase == .generatingSource
             )
             try await compileGeneratedTool(
-                displayName: manifest.displayName,
+                displayName: existingTool.name,
                 layout: layout,
                 contentViewPath: contentViewPath,
                 generator: generator,
@@ -406,8 +375,8 @@ struct SingleFileToolGenerationRuntime {
             try await lifecycle.updatePhase(.generating, .packaging, nil)
             _ = try await context.appBundleClient.buildInternalApp(
                 ToolAppBundleRequest(
-                    displayName: manifest.displayName,
-                    executableName: manifest.executableName,
+                    displayName: existingTool.name,
+                    executableName: existingTool.executableName,
                     bundleIdentifier: existingTool.bundleIdentifier,
                     packageRootURL: existingTool.packageRootURL,
                     settings: settings
@@ -431,16 +400,15 @@ struct SingleFileToolGenerationRuntime {
         }
 
         let binDirectory = try await context.processClient.showBinPath(existingTool.packageRootURL)
-        let binaryURL = binDirectory.appendingPathComponent(manifest.executableName)
+        let binaryURL = binDirectory.appendingPathComponent(existingTool.executableName)
         await context.processClient.stripQuarantine(binaryURL)
 
         return ToolGenerationResult(
-            toolName: manifest.displayName,
-            executableName: manifest.executableName,
+            toolName: existingTool.name,
+            executableName: existingTool.executableName,
             bundleIdentifier: existingTool.bundleIdentifier,
             settings: settings,
-            packageRootURL: existingTool.packageRootURL,
-            manifest: manifest
+            packageRootURL: existingTool.packageRootURL
         )
     }
 
@@ -784,7 +752,6 @@ struct SingleFileToolGenerationRuntime {
         executableName: String,
         bundleIdentifier: String,
         packageRootURL: URL,
-        manifest: ToolManifest,
         settings: ToolGenerationSettings,
         iconPrompt: String?,
         lifecycle: ToolGenerationLifecycle
@@ -814,8 +781,7 @@ struct SingleFileToolGenerationRuntime {
             executableName: executableName,
             bundleIdentifier: bundleIdentifier,
             settings: settings,
-            packageRootURL: packageRootURL,
-            manifest: manifest
+            packageRootURL: packageRootURL
         )
     }
 

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -6,22 +6,19 @@ nonisolated struct ToolGenerationPreparedTool {
     let bundleIdentifier: String
     let settings: ToolGenerationSettings
     let packageRootURL: URL
-    let manifest: ToolManifest
 
     init(
         name: String,
         executableName: String,
         bundleIdentifier: String,
         settings: ToolGenerationSettings,
-        packageRootURL: URL,
-        manifest: ToolManifest
+        packageRootURL: URL
     ) {
         self.name = name
         self.executableName = executableName
         self.bundleIdentifier = bundleIdentifier
         self.settings = settings
         self.packageRootURL = packageRootURL
-        self.manifest = manifest
     }
 }
 

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ToolGenerationPreparedTool {
+nonisolated struct ToolGenerationPreparedTool {
     let name: String
     let executableName: String
     let bundleIdentifier: String
@@ -8,23 +8,18 @@ struct ToolGenerationPreparedTool {
     let packageRootURL: URL
     let manifest: ToolManifest
 
-    var sandboxEnabled: Bool {
-        settings.sandboxEnabled
-    }
-
     init(
         name: String,
         executableName: String,
         bundleIdentifier: String,
-        sandboxEnabled: Bool = true,
-        settings: ToolGenerationSettings? = nil,
+        settings: ToolGenerationSettings,
         packageRootURL: URL,
         manifest: ToolManifest
     ) {
         self.name = name
         self.executableName = executableName
         self.bundleIdentifier = bundleIdentifier
-        self.settings = settings ?? ToolGenerationSettings(sandboxEnabled: sandboxEnabled)
+        self.settings = settings
         self.packageRootURL = packageRootURL
         self.manifest = manifest
     }
@@ -70,169 +65,57 @@ struct ToolGenerationLifecycle {
     }
 }
 
+nonisolated struct ToolGenerationRequest {
+    let prompt: String
+    let existingTool: Tool?
+    let settings: ToolGenerationSettings
+    let languageModelContext: AgentLanguageModelContext
+    let lifecycle: ToolGenerationLifecycle
+
+    init(
+        prompt: String,
+        existingTool: Tool? = nil,
+        settings: ToolGenerationSettings,
+        languageModelContext: AgentLanguageModelContext,
+        lifecycle: ToolGenerationLifecycle = .noop
+    ) {
+        self.prompt = prompt
+        self.existingTool = existingTool
+        self.settings = settings
+        self.languageModelContext = languageModelContext
+        self.lifecycle = lifecycle
+    }
+}
+
 struct ToolGenerationClient {
-    private var generateToolWithLifecycle: (
-        _ prompt: String,
-        _ existingTool: Tool?,
-        _ settings: ToolGenerationSettings,
-        _ languageModelContext: AgentLanguageModelContext,
-        _ lifecycle: ToolGenerationLifecycle,
-        _ status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult
+    private var generate: (ToolGenerationRequest) async throws -> ToolGenerationResult
 
-    func generateTool(
-        _ prompt: String,
-        _ existingTool: Tool?,
-        _ settings: ToolGenerationSettings,
-        _ languageModelContext: AgentLanguageModelContext,
-        lifecycle: ToolGenerationLifecycle = .noop,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        try await generateToolWithLifecycle(
-            prompt,
-            existingTool,
-            settings,
-            languageModelContext,
-            lifecycle,
-            status
-        )
-    }
-
-    func generateTool(
-        _ prompt: String,
-        _ existingTool: Tool?,
-        _ sandboxEnabled: Bool,
-        _ sandboxPermissions: GeneratedAppSandboxPermissions,
-        _ resourcePermissions: GeneratedAppResourcePermissions,
-        _ languageModelContext: AgentLanguageModelContext,
-        lifecycle: ToolGenerationLifecycle = .noop,
-        status: @escaping @MainActor (String) -> Void
-    ) async throws -> ToolGenerationResult {
-        try await generateTool(
-            prompt,
-            existingTool,
-            ToolGenerationSettings(
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions
-            ),
-            languageModelContext,
-            lifecycle: lifecycle,
-            status: status
-        )
+    func generateTool(_ request: ToolGenerationRequest) async throws -> ToolGenerationResult {
+        try await generate(request)
     }
 
     init(
-        _ generateTool: @escaping (
-            _ prompt: String,
-            _ existingTool: Tool?,
-            _ sandboxEnabled: Bool,
-            _ sandboxPermissions: GeneratedAppSandboxPermissions,
-            _ resourcePermissions: GeneratedAppResourcePermissions,
-            _ languageModelContext: AgentLanguageModelContext,
-            _ status: @escaping @MainActor (String) -> Void
-        ) async throws -> ToolGenerationResult
+        _ generate: @escaping (ToolGenerationRequest) async throws -> ToolGenerationResult
     ) {
-        self.generateToolWithLifecycle = {
-            prompt,
-            existingTool,
-            settings,
-            languageModelContext,
-            _,
-            status in
-            try await generateTool(
-                prompt,
-                existingTool,
-                settings.sandboxEnabled,
-                settings.sandboxPermissions,
-                settings.resourcePermissions,
-                languageModelContext,
-                status
-            )
-        }
-    }
-
-    init(
-        withLifecycle generateTool: @escaping (
-            _ prompt: String,
-            _ existingTool: Tool?,
-            _ sandboxEnabled: Bool,
-            _ sandboxPermissions: GeneratedAppSandboxPermissions,
-            _ resourcePermissions: GeneratedAppResourcePermissions,
-            _ languageModelContext: AgentLanguageModelContext,
-            _ lifecycle: ToolGenerationLifecycle,
-            _ status: @escaping @MainActor (String) -> Void
-        ) async throws -> ToolGenerationResult
-    ) {
-        self.generateToolWithLifecycle = {
-            prompt,
-            existingTool,
-            settings,
-            languageModelContext,
-            lifecycle,
-            status in
-            try await generateTool(
-                prompt,
-                existingTool,
-                settings.sandboxEnabled,
-                settings.sandboxPermissions,
-                settings.resourcePermissions,
-                languageModelContext,
-                lifecycle,
-                status
-            )
-        }
-    }
-
-    init(
-        withLifecycle generateTool: @escaping (
-            _ prompt: String,
-            _ existingTool: Tool?,
-            _ settings: ToolGenerationSettings,
-            _ languageModelContext: AgentLanguageModelContext,
-            _ lifecycle: ToolGenerationLifecycle,
-            _ status: @escaping @MainActor (String) -> Void
-        ) async throws -> ToolGenerationResult
-    ) {
-        self.generateToolWithLifecycle = generateTool
+        self.generate = generate
     }
 
     static func live(
-        toolsDirectoryURL: URL = IronsmithPaths.toolsDirectory,
-        fileClient: AgentFileClient = .live,
-        processClient: SwiftPackageProcessClient = .live,
-        appBundleClient: ToolAppBundleClient = .live(),
-        iconClient: ToolIconClient = .live(),
-        metadataClient: ToolMetadataClient = .live(),
-        promptRefinementClient: ToolPromptRefinementClient = .live(),
-        versionBackupClient: ToolVersionBackupClient = .live
+        dependencies: ToolGenerationRuntimeDependencies = .live()
     ) -> Self {
-        Self(withLifecycle: { prompt, existingTool, settings, languageModelContext, lifecycle, status in
+        Self { request in
             let context = ToolGenerationRuntimeContext(
-                languageModel: languageModelContext.languageModel,
-                metadataLanguageModel: languageModelContext.metadataLanguageModel,
-                generationOptions: languageModelContext.options,
-                repairStrategy: languageModelContext.repairStrategy,
-                toolsDirectoryURL: toolsDirectoryURL,
-                fileClient: fileClient,
-                processClient: processClient,
-                appBundleClient: appBundleClient,
-                iconClient: iconClient,
-                metadataClient: metadataClient,
-                promptRefinementClient: promptRefinementClient,
-                promptRefinementEnabled: languageModelContext.promptRefinementEnabled,
-                versionBackupClient: versionBackupClient,
-                afterLanguageModelInvocation: languageModelContext.afterLanguageModelInvocation
+                languageModelContext: request.languageModelContext,
+                dependencies: dependencies
             )
             let runtime = SingleFileToolGenerationRuntime(context: context)
             return try await runtime.generateTool(
-                for: prompt,
-                existingTool: existingTool,
-                settings: settings,
-                lifecycle: lifecycle,
-                status: status
+                for: request.prompt,
+                existingTool: request.existingTool,
+                settings: request.settings,
+                lifecycle: request.lifecycle
             )
-        })
+        }
     }
 }
 

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
@@ -149,21 +149,6 @@ struct ToolGenerationRuntimeContext {
         return candidate
     }
 
-    func loadManifest(at url: URL) throws -> ToolManifest {
-        let data = try Data(contentsOf: url)
-        return try JSONDecoder().decode(ToolManifest.self, from: data)
-    }
-
-    func writeManifest(_ manifest: ToolManifest, packageRootURL: URL) throws {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(manifest)
-        guard let string = String(data: data, encoding: .utf8) else {
-            throw ToolGenerationError.couldNotEncodeManifest
-        }
-        try write(string, to: ToolPackageLayout.agentManifestFilename, packageRootURL: packageRootURL)
-    }
-
     func write(
         _ content: String,
         to path: String,
@@ -263,7 +248,6 @@ struct ToolGenerationRuntimeContext {
 enum ToolGenerationError: LocalizedError, Equatable {
     case emptyPrompt
     case compileFailed(String)
-    case couldNotEncodeManifest
     case invalidRepairPatch
     case noRepairPatchCandidate
 
@@ -273,8 +257,6 @@ enum ToolGenerationError: LocalizedError, Equatable {
             return "Enter a prompt before building an app."
         case .compileFailed(let output):
             return output.isEmpty ? "The generated package did not compile." : output
-        case .couldNotEncodeManifest:
-            return "Ironsmith could not encode the generated app manifest."
         case .invalidRepairPatch:
             return "The repair model returned an invalid patch."
         case .noRepairPatchCandidate:

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
@@ -1,6 +1,59 @@
 import AnyLanguageModel
 import Foundation
 
+struct ToolGenerationRuntimeDependencies {
+    let toolsDirectoryURL: URL
+    let fileClient: AgentFileClient
+    let processClient: SwiftPackageProcessClient
+    let appBundleClient: ToolAppBundleClient
+    let iconClient: ToolIconClient
+    let metadataClient: ToolMetadataClient
+    let promptRefinementClient: ToolPromptRefinementClient
+    let versionBackupClient: ToolVersionBackupClient
+
+    init(
+        toolsDirectoryURL: URL,
+        fileClient: AgentFileClient,
+        processClient: SwiftPackageProcessClient,
+        appBundleClient: ToolAppBundleClient,
+        iconClient: ToolIconClient = .noOp,
+        metadataClient: ToolMetadataClient = .fallback(),
+        promptRefinementClient: ToolPromptRefinementClient = .disabled(),
+        versionBackupClient: ToolVersionBackupClient
+    ) {
+        self.toolsDirectoryURL = toolsDirectoryURL
+        self.fileClient = fileClient
+        self.processClient = processClient
+        self.appBundleClient = appBundleClient
+        self.iconClient = iconClient
+        self.metadataClient = metadataClient
+        self.promptRefinementClient = promptRefinementClient
+        self.versionBackupClient = versionBackupClient
+    }
+
+    static func live(
+        toolsDirectoryURL: URL = IronsmithPaths.toolsDirectory,
+        fileClient: AgentFileClient = .live,
+        processClient: SwiftPackageProcessClient = .live,
+        appBundleClient: ToolAppBundleClient = .live(),
+        iconClient: ToolIconClient = .live(),
+        metadataClient: ToolMetadataClient = .live(),
+        promptRefinementClient: ToolPromptRefinementClient = .live(),
+        versionBackupClient: ToolVersionBackupClient = .live
+    ) -> Self {
+        Self(
+            toolsDirectoryURL: toolsDirectoryURL,
+            fileClient: fileClient,
+            processClient: processClient,
+            appBundleClient: appBundleClient,
+            iconClient: iconClient,
+            metadataClient: metadataClient,
+            promptRefinementClient: promptRefinementClient,
+            versionBackupClient: versionBackupClient
+        )
+    }
+}
+
 struct ToolGenerationRuntimeContext {
     let languageModel: any LanguageModel
     let metadataLanguageModel: any LanguageModel
@@ -18,68 +71,23 @@ struct ToolGenerationRuntimeContext {
     let afterLanguageModelInvocation: @MainActor @Sendable () async -> Void
 
     init(
-        languageModel: any LanguageModel,
-        metadataLanguageModel: (any LanguageModel)?,
-        generationOptions: GenerationOptions,
-        repairStrategy: ToolRepairStrategy,
-        toolsDirectoryURL: URL,
-        fileClient: AgentFileClient,
-        processClient: SwiftPackageProcessClient,
-        appBundleClient: ToolAppBundleClient,
-        iconClient: ToolIconClient = .noOp,
-        metadataClient: ToolMetadataClient = .fallback(),
-        promptRefinementClient: ToolPromptRefinementClient = .disabled(),
-        promptRefinementEnabled: Bool = true,
-        versionBackupClient: ToolVersionBackupClient,
-        afterLanguageModelInvocation: @escaping @MainActor @Sendable () async -> Void = {}
+        languageModelContext: AgentLanguageModelContext,
+        dependencies: ToolGenerationRuntimeDependencies
     ) {
-        self.languageModel = languageModel
-        self.metadataLanguageModel = metadataLanguageModel ?? AnyLanguageModel.SystemLanguageModel.default
-        self.generationOptions = generationOptions
-        self.repairStrategy = repairStrategy
-        self.toolsDirectoryURL = toolsDirectoryURL
-        self.fileClient = fileClient
-        self.processClient = processClient
-        self.appBundleClient = appBundleClient
-        self.iconClient = iconClient
-        self.metadataClient = metadataClient
-        self.promptRefinementClient = promptRefinementClient
-        self.promptRefinementEnabled = promptRefinementEnabled
-        self.versionBackupClient = versionBackupClient
-        self.afterLanguageModelInvocation = afterLanguageModelInvocation
-    }
-
-    init(
-        languageModel: any LanguageModel,
-        generationOptions: GenerationOptions,
-        repairStrategy: ToolRepairStrategy,
-        toolsDirectoryURL: URL,
-        fileClient: AgentFileClient,
-        processClient: SwiftPackageProcessClient,
-        appBundleClient: ToolAppBundleClient,
-        iconClient: ToolIconClient = .noOp,
-        metadataClient: ToolMetadataClient = .fallback(),
-        promptRefinementClient: ToolPromptRefinementClient = .disabled(),
-        promptRefinementEnabled: Bool = true,
-        versionBackupClient: ToolVersionBackupClient,
-        afterLanguageModelInvocation: @escaping @MainActor @Sendable () async -> Void = {}
-    ) {
-        self.init(
-            languageModel: languageModel,
-            metadataLanguageModel: nil,
-            generationOptions: generationOptions,
-            repairStrategy: repairStrategy,
-            toolsDirectoryURL: toolsDirectoryURL,
-            fileClient: fileClient,
-            processClient: processClient,
-            appBundleClient: appBundleClient,
-            iconClient: iconClient,
-            metadataClient: metadataClient,
-            promptRefinementClient: promptRefinementClient,
-            promptRefinementEnabled: promptRefinementEnabled,
-            versionBackupClient: versionBackupClient,
-            afterLanguageModelInvocation: afterLanguageModelInvocation
-        )
+        self.languageModel = languageModelContext.languageModel
+        self.metadataLanguageModel = languageModelContext.metadataLanguageModel
+        self.generationOptions = languageModelContext.options
+        self.repairStrategy = languageModelContext.repairStrategy
+        self.toolsDirectoryURL = dependencies.toolsDirectoryURL
+        self.fileClient = dependencies.fileClient
+        self.processClient = dependencies.processClient
+        self.appBundleClient = dependencies.appBundleClient
+        self.iconClient = dependencies.iconClient
+        self.metadataClient = dependencies.metadataClient
+        self.promptRefinementClient = dependencies.promptRefinementClient
+        self.promptRefinementEnabled = languageModelContext.promptRefinementEnabled
+        self.versionBackupClient = dependencies.versionBackupClient
+        self.afterLanguageModelInvocation = languageModelContext.afterLanguageModelInvocation
     }
 
     func respond<Content, PromptContent>(

--- a/Ironsmith/Core/Models/ModelConfig.swift
+++ b/Ironsmith/Core/Models/ModelConfig.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import SwiftData
 
 enum ModelSource: String, Codable, CaseIterable {
     case appleFoundation = "apple_foundation"
@@ -20,41 +19,7 @@ enum ModelInstallState: String, Codable, CaseIterable {
     case failed
 }
 
-@Model
-final class ModelConfig {
-    @Attribute(.unique) var id: UUID
-    var identifier: String
-    var displayName: String
-    var providerIdentifier: String
-    var source: ModelSource
-    // For MLX models, identifier IS the HuggingFace Hub ID (e.g. "mlx-community/gemma-4-e4b-it-4bit")
-    var localDirectoryPath: String? // Path to downloaded model directory
-    var downloadProgress: Double?   // 0–1 during download, nil otherwise
-    var installStateRaw: String
-    var estimatedToolCredits: Int?
-
-    init(
-        id: UUID = UUID(),
-        identifier: String,
-        displayName: String,
-        providerIdentifier: String,
-        source: ModelSource,
-        installState: ModelInstallState = .downloadable,
-        localDirectoryPath: String? = nil,
-        downloadProgress: Double? = nil,
-        estimatedToolCredits: Int? = nil
-    ) {
-        self.id = id
-        self.identifier = identifier
-        self.displayName = displayName
-        self.providerIdentifier = providerIdentifier
-        self.source = source
-        self.installStateRaw = installState.rawValue
-        self.localDirectoryPath = localDirectoryPath
-        self.downloadProgress = downloadProgress
-        self.estimatedToolCredits = estimatedToolCredits
-    }
-}
+typealias ModelConfig = IronsmithSchemaV1.ModelConfig
 
 extension ModelConfig {
     static let appleFoundationIdentifier = "apple.foundation"

--- a/Ironsmith/Core/Models/ProviderConfig.swift
+++ b/Ironsmith/Core/Models/ProviderConfig.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import SwiftData
 
 enum ProviderKind: String, Codable, CaseIterable, Identifiable {
     case local
@@ -29,34 +28,7 @@ enum ProviderAuthMode: String, Codable, CaseIterable {
     case platformCredits = "platform_credits"
 }
 
-@Model
-final class ProviderConfig {
-    @Attribute(.unique) var id: UUID
-    var identifier: String
-    var displayName: String
-    @Attribute(originalName: "baseURLTemplate") var baseURLString: String
-    var authMode: ProviderAuthMode
-    var origin: ProviderOrigin
-    var isEnabled: Bool
-
-    init(
-        id: UUID = UUID(),
-        identifier: String,
-        displayName: String,
-        baseURLString: String,
-        authMode: ProviderAuthMode,
-        origin: ProviderOrigin,
-        isEnabled: Bool = true
-    ) {
-        self.id = id
-        self.identifier = identifier
-        self.displayName = displayName
-        self.baseURLString = baseURLString
-        self.authMode = authMode
-        self.origin = origin
-        self.isEnabled = isEnabled
-    }
-}
+typealias ProviderConfig = IronsmithSchemaV1.ProviderConfig
 
 extension ProviderConfig {
     static let localProviderIdentifier = "local"

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -196,12 +196,12 @@ extension Tool {
         packageRootURL.appendingPathComponent("Package.swift")
     }
 
-    var agentManifestURL: URL {
-        packageRootURL.appendingPathComponent(ToolPackageLayout.agentManifestFilename)
+    var packageLayout: ToolPackageLayout {
+        ToolPackageLayout(packageRootURL: packageRootURL, executableName: executableName)
     }
 
-    var manifestURL: URL {
-        agentManifestURL
+    var contentViewSourcePath: String {
+        packageLayout.contentViewSourcePath
     }
 
     var protocolsDirectoryURL: URL {

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -4,7 +4,6 @@
 //
 
 import Foundation
-import SwiftData
 
 enum ToolGenerationState: String, Codable, CaseIterable, Equatable, Sendable {
     case ready
@@ -31,68 +30,7 @@ enum ToolGenerationMode: String, Codable, CaseIterable, Equatable, Sendable {
     case edit
 }
 
-@Model
-final class Tool {
-    @Attribute(.unique) var id: UUID
-    var name: String
-    var executableName: String
-    var bundleIdentifier: String
-    var sandboxEnabled: Bool
-    var appKindRawValue: String = ToolAppKind.window.rawValue
-    var menuBarSystemImage: String = ToolMenuBarSymbol.fallback
-    var sandboxPermissionRawValues: String?
-    var resourcePermissionRawValues: String?
-    var packageRootPath: String
-    var generationStateRawValue: String = ToolGenerationState.ready.rawValue
-    var generationPhaseRawValue: String? = ToolGenerationPhase.completed.rawValue
-    var generationModeRawValue: String?
-    var pendingPrompt: String?
-    var generationErrorSummary: String?
-    var generationRepairErrorCount: Int? = nil
-    var createdAt: Date
-    var updatedAt: Date
-
-    init(
-        id: UUID = UUID(),
-        name: String,
-        executableName: String? = nil,
-        bundleIdentifier: String? = nil,
-        sandboxEnabled: Bool = true,
-        appKind: ToolAppKind = .window,
-        menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
-        sandboxPermissions: GeneratedAppSandboxPermissions? = nil,
-        resourcePermissions: GeneratedAppResourcePermissions? = nil,
-        packageRootPath: String,
-        generationState: ToolGenerationState = .ready,
-        generationPhase: ToolGenerationPhase? = .completed,
-        generationMode: ToolGenerationMode? = nil,
-        pendingPrompt: String? = nil,
-        generationErrorSummary: String? = nil,
-        generationRepairErrorCount: Int? = nil,
-        createdAt: Date = .now,
-        updatedAt: Date = .now
-    ) {
-        self.id = id
-        self.name = name
-        let resolvedExecutableName = executableName ?? ToolNameSanitizer.executableName(from: name)
-        self.executableName = resolvedExecutableName
-        self.bundleIdentifier = bundleIdentifier ?? ToolBundleIdentifier.make(executableName: resolvedExecutableName)
-        self.sandboxEnabled = sandboxEnabled
-        self.appKindRawValue = appKind.rawValue
-        self.menuBarSystemImage = ToolMenuBarSymbol.validated(menuBarSystemImage)
-        self.sandboxPermissionRawValues = sandboxPermissions?.rawValueList
-        self.resourcePermissionRawValues = resourcePermissions?.rawValueList
-        self.packageRootPath = packageRootPath
-        self.generationStateRawValue = generationState.rawValue
-        self.generationPhaseRawValue = generationPhase?.rawValue
-        self.generationModeRawValue = generationMode?.rawValue
-        self.pendingPrompt = pendingPrompt
-        self.generationErrorSummary = generationErrorSummary
-        self.generationRepairErrorCount = generationRepairErrorCount
-        self.createdAt = createdAt
-        self.updatedAt = updatedAt
-    }
-}
+typealias Tool = IronsmithSchemaV1.Tool
 
 extension Tool {
     var generationState: ToolGenerationState {

--- a/Ironsmith/Core/Persistence/Bootstrap/IronsmithModelContainerFactory.swift
+++ b/Ironsmith/Core/Persistence/Bootstrap/IronsmithModelContainerFactory.swift
@@ -4,14 +4,19 @@ enum IronsmithModelContainerFactory {
     static func make(isRunningTests: Bool) throws -> ModelContainer {
         if isRunningTests {
             let config = ModelConfiguration(isStoredInMemoryOnly: true)
-            return try ModelContainer(
-                for: Tool.self,
-                ModelConfig.self,
-                ProviderConfig.self,
-                configurations: config
-            )
+            return try make(configuration: config)
         }
 
-        return try ModelContainer(for: Tool.self, ModelConfig.self, ProviderConfig.self)
+        let locations = try IronsmithPersistentStoreLocations.live()
+        try IronsmithPersistentStorePreparer(locations: locations).prepare()
+        return try make(configuration: ModelConfiguration(url: locations.storeURL))
+    }
+
+    static func make(configuration: ModelConfiguration) throws -> ModelContainer {
+        try ModelContainer(
+            for: Schema(versionedSchema: IronsmithSchemaV1.self),
+            migrationPlan: IronsmithSchemaMigrationPlan.self,
+            configurations: configuration
+        )
     }
 }

--- a/Ironsmith/Core/Persistence/Bootstrap/IronsmithPersistentStorePreparer.swift
+++ b/Ironsmith/Core/Persistence/Bootstrap/IronsmithPersistentStorePreparer.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+struct IronsmithPersistentStorePreparer {
+    private static let retainedBackupCount = 3
+    private static let storeComponentSuffixes = ["", "-wal", "-shm", "-journal"]
+    private static let importMoveOrder = ["-wal", "-shm", "-journal", ""]
+
+    let locations: IronsmithPersistentStoreLocations
+    let fileManager: FileManager
+
+    init(
+        locations: IronsmithPersistentStoreLocations,
+        fileManager: FileManager = .default
+    ) {
+        self.locations = locations
+        self.fileManager = fileManager
+    }
+
+    func prepare(startupDate: Date = .now) throws {
+        try fileManager.createDirectory(
+            at: locations.databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try fileManager.createDirectory(
+            at: locations.backupsDirectoryURL,
+            withIntermediateDirectories: true
+        )
+
+        if !regularFileExists(at: locations.storeURL) {
+            try importLegacyStoreIfPresent()
+        }
+
+        if regularFileExists(at: locations.storeURL) {
+            try createStartupBackup(at: startupDate)
+            try pruneOldBackups()
+        }
+    }
+
+    private func importLegacyStoreIfPresent() throws {
+        guard regularFileExists(at: locations.legacyStoreURL) else { return }
+
+        for suffix in Self.storeComponentSuffixes.dropFirst() {
+            let destinationURL = storeComponentURL(baseURL: locations.storeURL, suffix: suffix)
+            if fileManager.fileExists(atPath: destinationURL.path) {
+                try fileManager.removeItem(at: destinationURL)
+            }
+        }
+
+        let stagingDirectoryURL = locations.databaseDirectoryURL
+            .appendingPathComponent(".legacy-import-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: stagingDirectoryURL, withIntermediateDirectories: false)
+
+        var movedDestinationURLs: [URL] = []
+        do {
+            for suffix in Self.storeComponentSuffixes {
+                let sourceURL = storeComponentURL(baseURL: locations.legacyStoreURL, suffix: suffix)
+                guard regularFileExists(at: sourceURL) else { continue }
+
+                let stagedURL = stagingDirectoryURL
+                    .appendingPathComponent(locations.storeURL.lastPathComponent + suffix)
+                try fileManager.copyItem(at: sourceURL, to: stagedURL)
+            }
+
+            for suffix in Self.importMoveOrder {
+                let stagedURL = stagingDirectoryURL
+                    .appendingPathComponent(locations.storeURL.lastPathComponent + suffix)
+                guard regularFileExists(at: stagedURL) else { continue }
+
+                let destinationURL = storeComponentURL(baseURL: locations.storeURL, suffix: suffix)
+                try fileManager.moveItem(at: stagedURL, to: destinationURL)
+                movedDestinationURLs.append(destinationURL)
+            }
+
+            try fileManager.removeItem(at: stagingDirectoryURL)
+        } catch {
+            for destinationURL in movedDestinationURLs {
+                try? fileManager.removeItem(at: destinationURL)
+            }
+            try? fileManager.removeItem(at: stagingDirectoryURL)
+            throw error
+        }
+    }
+
+    private func createStartupBackup(at startupDate: Date) throws {
+        let backupDirectoryURL = uniqueBackupDirectoryURL(for: startupDate)
+        let stagingDirectoryURL = locations.backupsDirectoryURL
+            .appendingPathComponent(".backup-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: stagingDirectoryURL, withIntermediateDirectories: false)
+
+        do {
+            for suffix in Self.storeComponentSuffixes {
+                let sourceURL = storeComponentURL(baseURL: locations.storeURL, suffix: suffix)
+                guard regularFileExists(at: sourceURL) else { continue }
+
+                let destinationURL = stagingDirectoryURL
+                    .appendingPathComponent(locations.storeURL.lastPathComponent + suffix)
+                try fileManager.copyItem(at: sourceURL, to: destinationURL)
+            }
+            try fileManager.moveItem(at: stagingDirectoryURL, to: backupDirectoryURL)
+        } catch {
+            try? fileManager.removeItem(at: stagingDirectoryURL)
+            throw error
+        }
+    }
+
+    private func uniqueBackupDirectoryURL(for date: Date) -> URL {
+        let baseName = backupDateFormatter.string(from: date)
+        var candidateURL = locations.backupsDirectoryURL
+            .appendingPathComponent(baseName, isDirectory: true)
+        var suffix = 2
+        while fileManager.fileExists(atPath: candidateURL.path) {
+            candidateURL = locations.backupsDirectoryURL
+                .appendingPathComponent("\(baseName)-\(suffix)", isDirectory: true)
+            suffix += 1
+        }
+        return candidateURL
+    }
+
+    private func pruneOldBackups() throws {
+        let backupDirectoryURLs = try fileManager.contentsOfDirectory(
+            at: locations.backupsDirectoryURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        .filter { isCompletedBackupDirectory($0) }
+        .sorted { $0.lastPathComponent > $1.lastPathComponent }
+
+        for backupDirectoryURL in backupDirectoryURLs.dropFirst(Self.retainedBackupCount) {
+            try fileManager.removeItem(at: backupDirectoryURL)
+        }
+    }
+
+    private func isCompletedBackupDirectory(_ url: URL) -> Bool {
+        guard (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true else {
+            return false
+        }
+
+        let name = url.lastPathComponent
+        guard name.count >= 19 else { return false }
+
+        let timestampEndIndex = name.index(name.startIndex, offsetBy: 19)
+        let timestamp = String(name[..<timestampEndIndex])
+        guard backupDateFormatter.date(from: timestamp) != nil else { return false }
+
+        let suffix = name[timestampEndIndex...]
+        return suffix.isEmpty
+            || (suffix.first == "-" && suffix.dropFirst().allSatisfy(\.isNumber))
+    }
+
+    private var backupDateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
+        return formatter
+    }
+
+    private func storeComponentURL(baseURL: URL, suffix: String) -> URL {
+        URL(fileURLWithPath: baseURL.path + suffix)
+    }
+
+    private func regularFileExists(at url: URL) -> Bool {
+        var isDirectory = ObjCBool(false)
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && !isDirectory.boolValue
+    }
+}

--- a/Ironsmith/Core/Persistence/Configuration/IronsmithPaths.swift
+++ b/Ironsmith/Core/Persistence/Configuration/IronsmithPaths.swift
@@ -1,9 +1,23 @@
 import Foundation
 
 enum IronsmithPaths {
+    static let databaseFileName = "ironsmith.sqlite"
+
     static var rootDirectory: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".ironsmith", isDirectory: true)
+    }
+
+    static var databaseDirectory: URL {
+        rootDirectory.appendingPathComponent("db", isDirectory: true)
+    }
+
+    static var databaseURL: URL {
+        databaseDirectory.appendingPathComponent(databaseFileName)
+    }
+
+    static var databaseBackupsDirectory: URL {
+        databaseDirectory.appendingPathComponent("backups", isDirectory: true)
     }
 
     static var modelsDirectory: URL {
@@ -19,7 +33,12 @@ enum IronsmithPaths {
     }
 
     static func ensureDirectoriesExist() throws {
-        for directory in [modelsDirectory, toolsDirectory] {
+        for directory in [
+            databaseDirectory,
+            databaseBackupsDirectory,
+            modelsDirectory,
+            toolsDirectory,
+        ] {
             try FileManager.default.createDirectory(
                 at: directory,
                 withIntermediateDirectories: true

--- a/Ironsmith/Core/Persistence/Configuration/IronsmithPersistentStoreLocations.swift
+++ b/Ironsmith/Core/Persistence/Configuration/IronsmithPersistentStoreLocations.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct IronsmithPersistentStoreLocations {
+    let databaseDirectoryURL: URL
+    let storeURL: URL
+    let backupsDirectoryURL: URL
+    let legacyStoreURL: URL
+
+    init(databaseDirectoryURL: URL, legacyStoreURL: URL) {
+        self.databaseDirectoryURL = databaseDirectoryURL
+        storeURL = databaseDirectoryURL.appendingPathComponent(IronsmithPaths.databaseFileName)
+        backupsDirectoryURL = databaseDirectoryURL.appendingPathComponent("backups", isDirectory: true)
+        self.legacyStoreURL = legacyStoreURL
+    }
+
+    static func live(fileManager: FileManager = .default) throws -> Self {
+        let applicationSupportURL = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+        return Self(
+            databaseDirectoryURL: IronsmithPaths.databaseDirectory,
+            legacyStoreURL: applicationSupportURL.appendingPathComponent("default.store")
+        )
+    }
+}

--- a/Ironsmith/Core/Persistence/Migrations/IronsmithSchemaMigrationPlan.swift
+++ b/Ironsmith/Core/Persistence/Migrations/IronsmithSchemaMigrationPlan.swift
@@ -1,0 +1,13 @@
+import SwiftData
+
+enum IronsmithSchemaMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] {
+        [
+            IronsmithSchemaV1.self,
+        ]
+    }
+
+    static var stages: [MigrationStage] {
+        []
+    }
+}

--- a/Ironsmith/Core/Persistence/Migrations/IronsmithSchemaV1.swift
+++ b/Ironsmith/Core/Persistence/Migrations/IronsmithSchemaV1.swift
@@ -1,0 +1,143 @@
+import Foundation
+import SwiftData
+
+enum IronsmithSchemaV1: VersionedSchema {
+    static var versionIdentifier: Schema.Version {
+        Schema.Version(1, 0, 0)
+    }
+
+    static var models: [any PersistentModel.Type] {
+        [
+            Tool.self,
+            ModelConfig.self,
+            ProviderConfig.self,
+        ]
+    }
+
+    @Model
+    final class Tool {
+        @Attribute(.unique) var id: UUID
+        var name: String
+        var executableName: String
+        var bundleIdentifier: String
+        var sandboxEnabled: Bool
+        var appKindRawValue: String = ToolAppKind.window.rawValue
+        var menuBarSystemImage: String = ToolMenuBarSymbol.fallback
+        var sandboxPermissionRawValues: String?
+        var resourcePermissionRawValues: String?
+        var packageRootPath: String
+        var generationStateRawValue: String = ToolGenerationState.ready.rawValue
+        var generationPhaseRawValue: String? = ToolGenerationPhase.completed.rawValue
+        var generationModeRawValue: String?
+        var pendingPrompt: String?
+        var generationErrorSummary: String?
+        var generationRepairErrorCount: Int? = nil
+        var createdAt: Date
+        var updatedAt: Date
+
+        init(
+            id: UUID = UUID(),
+            name: String,
+            executableName: String? = nil,
+            bundleIdentifier: String? = nil,
+            sandboxEnabled: Bool = true,
+            appKind: ToolAppKind = .window,
+            menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
+            sandboxPermissions: GeneratedAppSandboxPermissions? = nil,
+            resourcePermissions: GeneratedAppResourcePermissions? = nil,
+            packageRootPath: String,
+            generationState: ToolGenerationState = .ready,
+            generationPhase: ToolGenerationPhase? = .completed,
+            generationMode: ToolGenerationMode? = nil,
+            pendingPrompt: String? = nil,
+            generationErrorSummary: String? = nil,
+            generationRepairErrorCount: Int? = nil,
+            createdAt: Date = .now,
+            updatedAt: Date = .now
+        ) {
+            self.id = id
+            self.name = name
+            let resolvedExecutableName = executableName ?? ToolNameSanitizer.executableName(from: name)
+            self.executableName = resolvedExecutableName
+            self.bundleIdentifier = bundleIdentifier ?? ToolBundleIdentifier.make(executableName: resolvedExecutableName)
+            self.sandboxEnabled = sandboxEnabled
+            self.appKindRawValue = appKind.rawValue
+            self.menuBarSystemImage = ToolMenuBarSymbol.validated(menuBarSystemImage)
+            self.sandboxPermissionRawValues = sandboxPermissions?.rawValueList
+            self.resourcePermissionRawValues = resourcePermissions?.rawValueList
+            self.packageRootPath = packageRootPath
+            self.generationStateRawValue = generationState.rawValue
+            self.generationPhaseRawValue = generationPhase?.rawValue
+            self.generationModeRawValue = generationMode?.rawValue
+            self.pendingPrompt = pendingPrompt
+            self.generationErrorSummary = generationErrorSummary
+            self.generationRepairErrorCount = generationRepairErrorCount
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+        }
+    }
+
+    @Model
+    final class ModelConfig {
+        @Attribute(.unique) var id: UUID
+        var identifier: String
+        var displayName: String
+        var providerIdentifier: String
+        var source: ModelSource
+        var localDirectoryPath: String?
+        var downloadProgress: Double?
+        var installStateRaw: String
+        var estimatedToolCredits: Int?
+
+        init(
+            id: UUID = UUID(),
+            identifier: String,
+            displayName: String,
+            providerIdentifier: String,
+            source: ModelSource,
+            installState: ModelInstallState = .downloadable,
+            localDirectoryPath: String? = nil,
+            downloadProgress: Double? = nil,
+            estimatedToolCredits: Int? = nil
+        ) {
+            self.id = id
+            self.identifier = identifier
+            self.displayName = displayName
+            self.providerIdentifier = providerIdentifier
+            self.source = source
+            self.installStateRaw = installState.rawValue
+            self.localDirectoryPath = localDirectoryPath
+            self.downloadProgress = downloadProgress
+            self.estimatedToolCredits = estimatedToolCredits
+        }
+    }
+
+    @Model
+    final class ProviderConfig {
+        @Attribute(.unique) var id: UUID
+        var identifier: String
+        var displayName: String
+        @Attribute(originalName: "baseURLTemplate") var baseURLString: String
+        var authMode: ProviderAuthMode
+        var origin: ProviderOrigin
+        var isEnabled: Bool
+
+        init(
+            id: UUID = UUID(),
+            identifier: String,
+            displayName: String,
+            baseURLString: String,
+            authMode: ProviderAuthMode,
+            origin: ProviderOrigin,
+            isEnabled: Bool = true
+        ) {
+            self.id = id
+            self.identifier = identifier
+            self.displayName = displayName
+            self.baseURLString = baseURLString
+            self.authMode = authMode
+            self.origin = origin
+            self.isEnabled = isEnabled
+        }
+    }
+}

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -11,6 +11,17 @@ enum ToolLibraryPresentedErrorAction: Equatable {
     case buyIronsmithCredits
 }
 
+private enum ToolLibraryGenerationError: LocalizedError {
+    case missingPreparedTool
+
+    var errorDescription: String? {
+        switch self {
+        case .missingPreparedTool:
+            return "Ironsmith could not finish this app because generation did not prepare a library record."
+        }
+    }
+}
+
 private final class BindingBox<Value> {
     var value: Value
 
@@ -308,38 +319,22 @@ final class ToolLibraryStore {
             }
 
             let result = try await dependencies.generationClient.generateTool(
-                trimmedPrompt,
-                selectedTool,
-                submittedSettings,
-                languageModelContext,
-                lifecycle: lifecycle
-            ) { _ in }
+                ToolGenerationRequest(
+                    prompt: trimmedPrompt,
+                    existingTool: selectedTool,
+                    settings: submittedSettings,
+                    languageModelContext: languageModelContext,
+                    lifecycle: lifecycle
+                )
+            )
 
-            if let completedTool = selectedTool ?? activeTool {
-                applyCompletedGenerationResult(
-                    result,
-                    to: completedTool,
-                    prompt: trimmedPrompt
-                )
-                try modelContext.save()
-            } else {
-                let tool = Tool(
-                    name: result.toolName,
-                    executableName: result.executableName,
-                    bundleIdentifier: result.bundleIdentifier,
-                    sandboxEnabled: result.settings.sandboxEnabled,
-                    appKind: result.settings.appKind,
-                    menuBarSystemImage: result.settings.menuBarSystemImage,
-                    sandboxPermissions: result.settings.sandboxPermissions,
-                    resourcePermissions: result.settings.resourcePermissions,
-                    packageRootPath: result.packageRootURL.path,
-                    generationState: .ready,
-                    generationPhase: .completed
-                )
-                let repository = ToolRepository(modelContext: modelContext)
-                repository.insert(tool)
-                try repository.save()
-            }
+            let completedTool = try requirePreparedTool(selectedTool ?? activeTool)
+            applyCompletedGenerationResult(
+                result,
+                to: completedTool,
+                prompt: trimmedPrompt
+            )
+            try modelContext.save()
             prompt = Self.defaultPrompt
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
         } catch {
@@ -576,12 +571,14 @@ final class ToolLibraryStore {
             try modelContext.save()
 
             let result = try await dependencies.generationClient.generateTool(
-                resumePrompt,
-                tool,
-                settings,
-                languageModelContext,
-                lifecycle: lifecycle
-            ) { _ in }
+                ToolGenerationRequest(
+                    prompt: resumePrompt,
+                    existingTool: tool,
+                    settings: settings,
+                    languageModelContext: languageModelContext,
+                    lifecycle: lifecycle
+                )
+            )
             applyCompletedGenerationResult(result, to: tool, prompt: resumePrompt)
             try modelContext.save()
             await refreshIronsmithCreditsIfNeeded(inferenceStore)
@@ -743,6 +740,13 @@ final class ToolLibraryStore {
         tool.generationRepairErrorCount = nil
         removePendingDraft(for: tool)
         tool.updatedAt = .now
+    }
+
+    private func requirePreparedTool(_ tool: Tool?) throws -> Tool {
+        guard let tool else {
+            throw ToolLibraryGenerationError.missingPreparedTool
+        }
+        return tool
     }
 
     private func canContinueGeneration(_ tool: Tool) -> Bool {

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -248,12 +248,8 @@ final class ToolLibraryStore {
         }
 
         do {
-            let manifest = try Self.manifest(for: tool)
-            let layout = ToolPackageLayout(
-                packageRootURL: tool.packageRootURL,
-                executableName: manifest.executableName
-            )
-            let contentViewPath = manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
+            let layout = tool.packageLayout
+            let contentViewPath = tool.contentViewSourcePath
             let restoredSettings = try dependencies.versionBackupClient.restorePreviousVersion(
                 tool.packageRootURL,
                 contentViewPath,
@@ -262,7 +258,7 @@ final class ToolLibraryStore {
             tool.applyGenerationSettings(restoredSettings)
             try Self.writeAppEntry(
                 layout: layout,
-                displayName: manifest.displayName,
+                displayName: tool.name,
                 settings: restoredSettings
             )
             try await dependencies.buildClient.buildTool(tool)
@@ -771,23 +767,8 @@ final class ToolLibraryStore {
         return String(singleLine.prefix(240))
     }
 
-    private static func contentViewPath(for tool: Tool) throws -> String {
-        let manifest = try manifest(for: tool)
-        let layout = ToolPackageLayout(
-            packageRootURL: tool.packageRootURL,
-            executableName: manifest.executableName
-        )
-        return manifest.files.first?.path ?? layout.sourcePath(for: layout.defaultContentViewFileName)
-    }
-
-    private static func manifest(for tool: Tool) throws -> ToolManifest {
-        let data = try Data(contentsOf: tool.agentManifestURL)
-        return try JSONDecoder().decode(ToolManifest.self, from: data)
-    }
-
     private static func contentViewURL(for tool: Tool) throws -> URL {
-        let contentViewPath = try contentViewPath(for: tool)
-        return try ToolPackageLayout.packageFileURL(for: contentViewPath, packageRootURL: tool.packageRootURL)
+        try ToolPackageLayout.packageFileURL(for: tool.contentViewSourcePath, packageRootURL: tool.packageRootURL)
     }
 
     private static func writeAppEntry(

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
@@ -34,7 +34,7 @@ extension AgentPipelineTests {
         )
 
         let task = Task {
-            try await runtime.generateTool(for: "Build a cancellable tool", status: { _ in })
+            try await runtime.generateTool(for: "Build a cancellable tool", settings: .default)
         }
         await Self.eventually {
             await probe.didStart
@@ -73,13 +73,13 @@ extension AgentPipelineTests {
                 return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             }
         )
-        let generationClient = ToolGenerationClient.live(
+        let generationClient = ToolGenerationClient.live(dependencies: .live(
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: .noOp(),
             iconClient: .noOp,
             metadataClient: .fallback()
-        )
+        ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
                 generationClient: generationClient,
@@ -153,7 +153,7 @@ extension AgentPipelineTests {
         )
         let iconPrompt = "Notebook and compass"
         let refinedPrompt = "Build a polished focus notes helper with tags, search, pinned notes, and a calm compact layout."
-        let generationClient = ToolGenerationClient.live(
+        let generationClient = ToolGenerationClient.live(dependencies: .live(
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: appBundleClient,
@@ -168,7 +168,7 @@ extension AgentPipelineTests {
             promptRefinementClient: ToolPromptRefinementClient { _ in
                 refinedPrompt
             }
-        )
+        ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
                 generationClient: generationClient,
@@ -246,13 +246,13 @@ extension AgentPipelineTests {
             }
             """
         ])
-        let generationClient = ToolGenerationClient.live(
+        let generationClient = ToolGenerationClient.live(dependencies: .live(
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: .noOp(),
             iconClient: .noOp,
             metadataClient: .fallback()
-        )
+        ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
                 generationClient: generationClient,
@@ -312,13 +312,13 @@ extension AgentPipelineTests {
             }
             """
         )
-        let generationClient = ToolGenerationClient.live(
+        let generationClient = ToolGenerationClient.live(dependencies: .live(
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: .noOp(),
             iconClient: .noOp,
             metadataClient: .fallback()
-        )
+        ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
                 generationClient: generationClient,

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
@@ -108,7 +108,7 @@ extension AgentPipelineTests {
         let tool = try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
         #expect(tool.name == "Build A Hello Command")
         #expect(FileManager.default.fileExists(atPath: tool.packageManifestURL.path))
-        #expect(FileManager.default.fileExists(atPath: tool.agentManifestURL.path))
+        #expect(!FileManager.default.fileExists(atPath: tool.packageRootURL.appendingPathComponent("ironsmith-manifest.json").path))
         #expect(FileManager.default.fileExists(atPath: tool.packageRootURL.appendingPathComponent("Sources/BuildAHelloCommand/BuildAHelloCommand.swift").path))
         #expect(FileManager.default.fileExists(atPath: tool.packageRootURL.appendingPathComponent("Sources/BuildAHelloCommand/ContentView.swift").path))
 
@@ -271,10 +271,9 @@ extension AgentPipelineTests {
         await store.submitPrompt(modelContext: context, inferenceStore: inferenceStore)
 
         let tool = try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
-        let manifestData = try Data(contentsOf: tool.agentManifestURL)
-        let manifest = try JSONDecoder().decode(ToolManifest.self, from: manifestData)
+        let layout = ToolPackageLayout(packageRootURL: tool.packageRootURL, executableName: tool.executableName)
         let contentView = try String(
-            contentsOf: tool.packageRootURL.appendingPathComponent("Sources/\(manifest.executableName)/ContentView.swift"),
+            contentsOf: tool.packageRootURL.appendingPathComponent(layout.contentViewSourcePath),
             encoding: .utf8
         )
         #expect(contentView.contains(#"Text("real regenerated tool")"#))
@@ -337,10 +336,9 @@ extension AgentPipelineTests {
         await store.submitPrompt(modelContext: context, inferenceStore: inferenceStore)
 
         let tool = try #require(try context.fetch(FetchDescriptor<StoredTool>()).first)
-        let manifestData = try Data(contentsOf: tool.agentManifestURL)
-        let manifest = try JSONDecoder().decode(ToolManifest.self, from: manifestData)
+        let layout = ToolPackageLayout(packageRootURL: tool.packageRootURL, executableName: tool.executableName)
         let contentView = try String(
-            contentsOf: tool.packageRootURL.appendingPathComponent("Sources/\(manifest.executableName)/ContentView.swift"),
+            contentsOf: tool.packageRootURL.appendingPathComponent(layout.contentViewSourcePath),
             encoding: .utf8
         )
         #expect(contentView.contains(#"Text("retried after context window")"#))

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
@@ -16,27 +16,12 @@ extension AgentPipelineTests {
         try context.save()
 
         let capture = GenerationCapture()
-        let generationClient = ToolGenerationClient {
-            prompt,
-            existingTool,
-            sandboxEnabled,
-            sandboxPermissions,
-            resourcePermissions,
-            context,
-            status in
-            await capture.record(
-                prompt: prompt,
-                existingToolID: existingTool?.id,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                repairStrategy: context.repairStrategy
-            )
-            status("Fake edit")
+        let generationClient = ToolGenerationClient { request in
+            await capture.record(request)
             return ToolGenerationResult(
                 toolName: "Calculator",
                 executableName: "Calculator",
-                sandboxEnabled: sandboxEnabled,
+                settings: request.settings,
                 packageRootURL: URL(fileURLWithPath: "/tmp/calculator", isDirectory: true),
                 manifest: ToolManifest(
                     displayName: "Calculator",
@@ -78,9 +63,9 @@ extension AgentPipelineTests {
         #expect(tools.first?.pendingPrompt == nil)
         #expect(!(tools.first?.sandboxEnabled ?? false))
         #expect(await capture.existingToolID == existingTool.id)
-        #expect(!((await capture.sandboxEnabled) ?? false))
-        #expect(await capture.sandboxPermissions?.enabled == [.internet, .userSelectedFiles])
-        #expect(await capture.resourcePermissions?.enabled == [.location, .calendar])
+        #expect(await capture.settings?.sandboxEnabled == false)
+        #expect(await capture.settings?.sandboxPermissions.enabled == [.internet, .userSelectedFiles])
+        #expect(await capture.settings?.resourcePermissions.enabled == [.location, .calendar])
         #expect(await capture.repairStrategy == .deterministicOnly)
         #expect(await runCapture.ranToolIDs.isEmpty)
         #expect(!(store.isSelected(existingTool)))
@@ -110,12 +95,10 @@ extension AgentPipelineTests {
             processClient: Self.successfulProcessClient(),
             metadataClient: .fallback()
         )
-        var statuses: [String] = []
-
         let result = try await runtime.generateTool(
             for: "Change old to new",
             existingTool: tool,
-            status: { statuses.append($0) }
+            settings: .default
         )
 
         let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
@@ -126,8 +109,6 @@ extension AgentPipelineTests {
         #expect(contentView.contains(#"Text("new")"#))
         #expect(!(contentView.contains(#"Text("old")"#)))
         #expect(previousSource.contains(#"Text("old")"#))
-        #expect(statuses.contains("Editing Calculator"))
-        #expect(!(statuses.contains { $0.hasPrefix("Generating Calculator") }))
         #expect(await responses.count == 1)
     }
 
@@ -162,7 +143,7 @@ extension AgentPipelineTests {
         let result = try await runtime.generateTool(
             for: "Change old to new",
             existingTool: tool,
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
@@ -215,7 +196,7 @@ extension AgentPipelineTests {
         let result = try await runtime.generateTool(
             for: "Use full file fallback",
             existingTool: tool,
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
@@ -253,7 +234,7 @@ extension AgentPipelineTests {
 
         let result = try await runtime.generateTool(
             for: "Build a create mode tool",
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
@@ -311,12 +292,12 @@ extension AgentPipelineTests {
         _ = try await localRuntime.generateTool(
             for: "Change old to new",
             existingTool: localTool,
-            status: { _ in }
+            settings: .default
         )
         _ = try await remoteRuntime.generateTool(
             for: "Change old to new",
             existingTool: remoteTool,
-            status: { _ in }
+            settings: .default
         )
 
         let prompts = await promptCapture.prompts
@@ -376,7 +357,7 @@ extension AgentPipelineTests {
             _ = try await runtime.generateTool(
                 for: "Make it broken",
                 existingTool: tool,
-                status: { _ in }
+                settings: .default
             )
             Issue.record("Expected deterministic-only edit to fail after exhausting candidates.")
         } catch let error as ToolGenerationError {

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
@@ -22,17 +22,7 @@ extension AgentPipelineTests {
                 toolName: "Calculator",
                 executableName: "Calculator",
                 settings: request.settings,
-                packageRootURL: URL(fileURLWithPath: "/tmp/calculator", isDirectory: true),
-                manifest: ToolManifest(
-                    displayName: "Calculator",
-                    executableName: "Calculator",
-                    files: [
-                        ToolManifestFile(
-                            path: "Sources/Calculator/ContentView.swift",
-                            description: "Primary SwiftUI screen and supporting app logic."
-                        )
-                    ]
-                )
+                packageRootURL: URL(fileURLWithPath: "/tmp/calculator", isDirectory: true)
             )
         }
         let runCapture = ToolRunCapture()

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationRepairLoopTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationRepairLoopTests.swift
@@ -59,7 +59,7 @@ extension AgentPipelineTests {
 
         let result = try await runtime.generateTool(
             for: "Build a broken modifier tool",
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(
@@ -137,7 +137,7 @@ extension AgentPipelineTests {
 
         let result = try await runtime.generateTool(
             for: "Build a spacing tool",
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(
@@ -205,7 +205,7 @@ extension AgentPipelineTests {
 
         let result = try await runtime.generateTool(
             for: "Build a repeated spacing tool",
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(
@@ -275,11 +275,9 @@ extension AgentPipelineTests {
                 await invocationCapture.record()
             }
         )
-        var statuses: [String] = []
-
         let result = try await runtime.generateTool(
             for: "Build a model repair tool",
-            status: { statuses.append($0) }
+            settings: .default
         )
 
         let contentView = try String(
@@ -287,9 +285,6 @@ extension AgentPipelineTests {
             encoding: .utf8
         )
         #expect(contentView.contains(#"Text("fixed by model repair")"#))
-        #expect(statuses.contains("Generating Build A Model Repair Tool"))
-        #expect(statuses.contains("Building Build A Model Repair Tool"))
-        #expect(statuses.contains("Repairing 1 error"))
         #expect(await responses.count == 2)
         #expect(await invocationCapture.count == 2)
         #expect(await builds.count == 2)
@@ -365,7 +360,7 @@ extension AgentPipelineTests {
 
         let result = try await runtime.generateTool(
             for: "Build a large model repair tool",
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(
@@ -445,7 +440,7 @@ extension AgentPipelineTests {
 
         let result = try await runtime.generateTool(
             for: "Build budget exhaustion tool",
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(
@@ -500,7 +495,7 @@ extension AgentPipelineTests {
         let result = try await runtime.generateTool(
             for: "Change old to new",
             existingTool: tool,
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
@@ -173,8 +173,7 @@ extension AgentPipelineTests {
 
         _ = try await runtime.generateTool(
             for: "Make a timer",
-            settings: ToolGenerationSettings(appKind: .menuBar),
-            status: { _ in }
+            settings: ToolGenerationSettings(appKind: .menuBar)
         )
 
         let prompts = await promptCapture.prompts
@@ -216,7 +215,7 @@ extension AgentPipelineTests {
             promptRefinementEnabled: false
         )
 
-        _ = try await runtime.generateTool(for: "Make a habit tracker", status: { _ in })
+        _ = try await runtime.generateTool(for: "Make a habit tracker", settings: .default)
 
         let prompts = await promptCapture.prompts
         #expect(prompts.first?.contains("User request: Make a habit tracker") == true)
@@ -263,7 +262,7 @@ extension AgentPipelineTests {
         _ = try await runtime.generateTool(
             for: "Change old to new",
             existingTool: tool,
-            status: { _ in }
+            settings: .default
         )
 
         let prompts = await promptCapture.prompts

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -143,15 +143,21 @@ extension AgentPipelineTests {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let context = ToolGenerationRuntimeContext(
+        let languageModelContext = AgentLanguageModelContext(
             languageModel: EmptyLanguageModel(),
-            generationOptions: GenerationOptions(),
-            repairStrategy: .modelDiff(maxHunksPerTurn: 1),
+            options: GenerationOptions(),
+            repairStrategy: .modelDiff(maxHunksPerTurn: 1)
+        )
+        let dependencies = ToolGenerationRuntimeDependencies(
             toolsDirectoryURL: root,
             fileClient: .live,
             processClient: .live,
             appBundleClient: .noOp(),
             versionBackupClient: .live
+        )
+        let context = ToolGenerationRuntimeContext(
+            languageModelContext: languageModelContext,
+            dependencies: dependencies
         )
         let resolved = try context.packageFileURL(
             for: "Sources/Demo/main.swift",
@@ -293,8 +299,9 @@ extension AgentPipelineTests {
             executableName: "SandboxedTool",
             bundleIdentifier: "com.ironsmith.tests.sandboxed-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: true,
-            resourcePermissions: GeneratedAppResourcePermissions(GeneratedAppResourcePermission.allCases)
+            settings: ToolGenerationSettings(
+                resourcePermissions: GeneratedAppResourcePermissions(GeneratedAppResourcePermission.allCases)
+            )
         )
 
         let appURL = try await client.buildInternalApp(request)
@@ -383,8 +390,7 @@ extension AgentPipelineTests {
             executableName: "ExistingWindowTool",
             bundleIdentifier: "com.ironsmith.tests.existing-window-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: false,
-            settings: ToolGenerationSettings(appKind: .menuBar)
+            settings: ToolGenerationSettings(appKind: .menuBar, sandboxEnabled: false)
         )
 
         _ = try await client.buildInternalApp(request)
@@ -431,8 +437,7 @@ extension AgentPipelineTests {
                 executableName: executableName,
                 bundleIdentifier: "com.ironsmith.tests.\(executableName.lowercased())",
                 packageRootURL: packageRoot,
-                sandboxEnabled: true,
-                sandboxPermissions: sandboxPermissions
+                settings: ToolGenerationSettings(sandboxPermissions: sandboxPermissions)
             )
             let client = ToolAppBundleClient.live(
                 processClient: processClient,
@@ -589,8 +594,10 @@ extension AgentPipelineTests {
             executableName: "ExportedTool",
             bundleIdentifier: "com.ironsmith.tests.exported-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: false,
-            resourcePermissions: GeneratedAppResourcePermissions([.contacts, .photoLibrary, .appleEvents])
+            settings: ToolGenerationSettings(
+                sandboxEnabled: false,
+                resourcePermissions: GeneratedAppResourcePermissions([.contacts, .photoLibrary, .appleEvents])
+            )
         )
 
         let appURL = try await client.exportApp(request, applicationsDirectory)
@@ -652,7 +659,6 @@ extension AgentPipelineTests {
             executableName: "MenuBarTool",
             bundleIdentifier: "com.ironsmith.tests.menu-bar-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: true,
             settings: ToolGenerationSettings(appKind: .menuBar)
         )
 
@@ -722,7 +728,7 @@ extension AgentPipelineTests {
             executableName: "RestoredTool",
             bundleIdentifier: "com.ironsmith.tests.restored-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: false
+            settings: ToolGenerationSettings(sandboxEnabled: false)
         )
 
         do {
@@ -783,7 +789,7 @@ extension AgentPipelineTests {
             executableName: "NoIconTool",
             bundleIdentifier: "com.ironsmith.tests.no-icon-tool",
             packageRootURL: packageRoot,
-            sandboxEnabled: true
+            settings: .default
         )
 
         let appURL = try await client.buildInternalApp(request)

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -8,13 +8,12 @@ import Testing
 extension AgentPipelineTests {
     @MainActor
     @Test
-    func toolPathHelpersSeparatePackageAndAgentManifests() {
+    func toolPathHelpersExposePackageLayout() {
         let tool = StoredTool(name: "Demo", packageRootPath: "/tmp/DemoTool")
 
         #expect(tool.packageRootURL.path == "/tmp/DemoTool")
         #expect(tool.packageManifestURL.path == "/tmp/DemoTool/Package.swift")
-        #expect(tool.agentManifestURL.path == "/tmp/DemoTool/ironsmith-manifest.json")
-        #expect(tool.manifestURL == tool.agentManifestURL)
+        #expect(tool.contentViewSourcePath == "Sources/Demo/ContentView.swift")
 
         let layout = ToolPackageLayout(
             packageRootURL: URL(fileURLWithPath: "/tmp/DemoTool", isDirectory: true),
@@ -22,6 +21,7 @@ extension AgentPipelineTests {
         )
         #expect(layout.appEntrySourcePath == "Sources/DemoTool/DemoTool.swift")
         #expect(layout.sourcePath(for: "ContentView.swift") == "Sources/DemoTool/ContentView.swift")
+        #expect(layout.contentViewSourcePath == "Sources/DemoTool/ContentView.swift")
         #expect(layout.packageManifestContent().contains("swiftLanguageModes: [.v6]"))
         #expect(layout.fixedAppEntrySource().contains("ContentView()"))
     }
@@ -115,26 +115,6 @@ extension AgentPipelineTests {
         #expect(source.contains("WindowGroup"))
         #expect(source.contains("ContentView()"))
         #expect(!(source.contains("MenuBarExtra")))
-    }
-
-    @MainActor
-    @Test
-    func agentArtifactsRoundTripThroughJSON() throws {
-        let manifest = ToolManifest(
-            displayName: "Clipboard Cleaner",
-            executableName: "ClipboardCleaner",
-            files: [
-                ToolManifestFile(
-                    path: "Sources/ClipboardCleaner/main.swift",
-                    description: "Entry point."
-                )
-            ]
-        )
-
-        let encoder = JSONEncoder()
-        let decoder = JSONDecoder()
-
-        #expect(try decoder.decode(ToolManifest.self, from: encoder.encode(manifest)) == manifest)
     }
 
     @MainActor

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
@@ -18,7 +18,7 @@ extension AgentPipelineTests {
             }
         }
 
-        let generationClient = ToolGenerationClient.live(
+        let generationClient = ToolGenerationClient.live(dependencies: .live(
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
@@ -28,7 +28,7 @@ extension AgentPipelineTests {
                 return ToolMetadataSuggestion(displayName: "Named Later", iconPrompt: "")
             },
             promptRefinementClient: .disabled()
-        )
+        ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
                 generationClient: generationClient,
@@ -80,7 +80,7 @@ extension AgentPipelineTests {
         struct ContentView: View {
         """
         let probe = StreamingResponseProbe()
-        let generationClient = ToolGenerationClient.live(
+        let generationClient = ToolGenerationClient.live(dependencies: .live(
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
@@ -89,7 +89,7 @@ extension AgentPipelineTests {
                 ToolMetadataSuggestion(displayName: "Paused Tool", iconPrompt: "")
             },
             promptRefinementClient: .disabled()
-        )
+        ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
                 generationClient: generationClient,
@@ -183,7 +183,7 @@ extension AgentPipelineTests {
         let result = try await runtime.generateTool(
             for: "ignored because pending prompt is stored",
             existingTool: tool,
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
@@ -249,7 +249,7 @@ extension AgentPipelineTests {
         let result = try await runtime.generateTool(
             for: "ignored because pending prompt is stored",
             existingTool: tool,
-            status: { _ in }
+            settings: .default
         )
 
         let contentView = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
@@ -76,9 +76,10 @@ extension AgentPipelineTests {
             .appendingPathComponent("Sources/\(result.executableName)/ContentView.swift")
         let appEntryURL = result.packageRootURL
             .appendingPathComponent("Sources/\(result.executableName)/\(result.executableName).swift")
+        let layout = ToolPackageLayout(packageRootURL: result.packageRootURL, executableName: result.executableName)
         #expect(FileManager.default.fileExists(atPath: contentViewURL.path))
         #expect(FileManager.default.fileExists(atPath: appEntryURL.path))
-        #expect(result.manifest.files.map(\.path) == ["Sources/\(result.executableName)/ContentView.swift"])
+        #expect(layout.contentViewSourcePath == "Sources/\(result.executableName)/ContentView.swift")
         #expect(result.settings.appKind == .menuBar)
         #expect(result.settings.menuBarSystemImage == "timer")
         let appEntrySource = try String(contentsOf: appEntryURL, encoding: .utf8)

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
@@ -69,8 +69,7 @@ extension AgentPipelineTests {
         )
         let result = try await runtime.generateTool(
             for: "Build a tiny tool",
-            settings: settings,
-            status: { _ in }
+            settings: settings
         )
 
         let contentViewURL = result.packageRootURL

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
@@ -18,26 +18,34 @@ extension AgentPipelineTests {
         fileClient: AgentFileClient = .live,
         processClient: SwiftPackageProcessClient = .live,
         appBundleClient: ToolAppBundleClient = .noOp(),
+        iconClient: ToolIconClient = .noOp,
         metadataClient: ToolMetadataClient = .fallback(),
         promptRefinementClient: ToolPromptRefinementClient = .disabled(),
         promptRefinementEnabled: Bool = true,
         versionBackupClient: ToolVersionBackupClient = .live,
         afterLanguageModelInvocation: @escaping @MainActor @Sendable () async -> Void = {}
     ) -> SingleFileToolGenerationRuntime {
-        SingleFileToolGenerationRuntime(
+        let languageModelContext = AgentLanguageModelContext(
+            languageModel: languageModel,
+            options: generationOptions,
+            repairStrategy: repairStrategy,
+            promptRefinementEnabled: promptRefinementEnabled,
+            afterLanguageModelInvocation: afterLanguageModelInvocation
+        )
+        let dependencies = ToolGenerationRuntimeDependencies(
+            toolsDirectoryURL: toolsDirectoryURL,
+            fileClient: fileClient,
+            processClient: processClient,
+            appBundleClient: appBundleClient,
+            iconClient: iconClient,
+            metadataClient: metadataClient,
+            promptRefinementClient: promptRefinementClient,
+            versionBackupClient: versionBackupClient
+        )
+        return SingleFileToolGenerationRuntime(
             context: ToolGenerationRuntimeContext(
-                languageModel: languageModel,
-                generationOptions: generationOptions,
-                repairStrategy: repairStrategy,
-                toolsDirectoryURL: toolsDirectoryURL,
-                fileClient: fileClient,
-                processClient: processClient,
-                appBundleClient: appBundleClient,
-                metadataClient: metadataClient,
-                promptRefinementClient: promptRefinementClient,
-                promptRefinementEnabled: promptRefinementEnabled,
-                versionBackupClient: versionBackupClient,
-                afterLanguageModelInvocation: afterLanguageModelInvocation
+                languageModelContext: languageModelContext,
+                dependencies: dependencies
             )
         )
     }
@@ -295,25 +303,14 @@ actor FormatCapture {
 actor GenerationCapture {
     private(set) var prompt: String?
     private(set) var existingToolID: UUID?
-    private(set) var sandboxEnabled: Bool?
-    private(set) var sandboxPermissions: GeneratedAppSandboxPermissions?
-    private(set) var resourcePermissions: GeneratedAppResourcePermissions?
+    private(set) var settings: ToolGenerationSettings?
     private(set) var repairStrategy: ToolRepairStrategy?
 
-    func record(
-        prompt: String,
-        existingToolID: UUID?,
-        sandboxEnabled: Bool,
-        sandboxPermissions: GeneratedAppSandboxPermissions,
-        resourcePermissions: GeneratedAppResourcePermissions,
-        repairStrategy: ToolRepairStrategy
-    ) {
-        self.prompt = prompt
-        self.existingToolID = existingToolID
-        self.sandboxEnabled = sandboxEnabled
-        self.sandboxPermissions = sandboxPermissions
-        self.resourcePermissions = resourcePermissions
-        self.repairStrategy = repairStrategy
+    func record(_ request: ToolGenerationRequest) {
+        prompt = request.prompt
+        existingToolID = request.existingTool?.id
+        settings = request.settings
+        repairStrategy = request.languageModelContext.repairStrategy
     }
 }
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
@@ -161,16 +161,6 @@ extension AgentPipelineTests {
     ) throws -> StoredTool {
         let packageRoot = toolsDirectory.appendingPathComponent(executableName, isDirectory: true)
         let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: executableName)
-        let manifest = ToolManifest(
-            displayName: executableName,
-            executableName: executableName,
-            files: [
-                ToolManifestFile(
-                    path: layout.sourcePath(for: layout.defaultContentViewFileName),
-                    description: "Primary SwiftUI screen and supporting app logic."
-                )
-            ]
-        )
 
         try FileManager.default.createDirectory(at: layout.sourceDirectoryURL, withIntermediateDirectories: true)
         try layout.packageManifestContent().write(to: layout.packageManifestURL, atomically: true, encoding: .utf8)
@@ -179,14 +169,12 @@ extension AgentPipelineTests {
             atomically: true,
             encoding: .utf8
         )
-        let manifestData = try JSONEncoder().encode(manifest)
-        try manifestData.write(to: layout.agentManifestURL)
         try source.write(
-            to: packageRoot.appendingPathComponent(layout.sourcePath(for: layout.defaultContentViewFileName)),
+            to: packageRoot.appendingPathComponent(layout.contentViewSourcePath),
             atomically: true,
             encoding: .utf8
         )
-        return StoredTool(name: executableName, packageRootPath: packageRoot.path)
+        return StoredTool(name: executableName, executableName: executableName, packageRootPath: packageRoot.path)
     }
 
     static func successfulProcessClient() -> SwiftPackageProcessClient {

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineToolLibraryStoreTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineToolLibraryStoreTests.swift
@@ -13,28 +13,26 @@ extension AgentPipelineTests {
         let context = ModelContext(container)
         let packageRoot = URL(fileURLWithPath: "/tmp/fake-tool", isDirectory: true)
         let generationCapture = GenerationCapture()
-        let generationClient = ToolGenerationClient {
-            prompt,
-            existingTool,
-            sandboxEnabled,
-            sandboxPermissions,
-            resourcePermissions,
-            languageModelContext,
-            status in
-            await generationCapture.record(
-                prompt: prompt,
-                existingToolID: existingTool?.id,
-                sandboxEnabled: sandboxEnabled,
-                sandboxPermissions: sandboxPermissions,
-                resourcePermissions: resourcePermissions,
-                repairStrategy: languageModelContext.repairStrategy
+        let manifest = ToolManifest(displayName: "Fake Tool", executableName: "FakeTool", files: [])
+        let generationClient = ToolGenerationClient { request in
+            await generationCapture.record(request)
+            try await request.lifecycle.prepareCreatedTool(
+                ToolGenerationPreparedTool(
+                    name: "Fake Tool",
+                    executableName: "FakeTool",
+                    bundleIdentifier: ToolBundleIdentifier.make(executableName: "FakeTool"),
+                    settings: request.settings,
+                    packageRootURL: packageRoot,
+                    manifest: manifest
+                ),
+                request.prompt
             )
-            status("Fake build")
             return ToolGenerationResult(
                 toolName: "Fake Tool",
                 executableName: "FakeTool",
+                settings: request.settings,
                 packageRootURL: packageRoot,
-                manifest: ToolManifest(displayName: "Fake Tool", executableName: "FakeTool", files: [])
+                manifest: manifest
             )
         }
         let runCapture = ToolRunCapture()
@@ -59,14 +57,14 @@ extension AgentPipelineTests {
         #expect(tools.first?.packageRootPath == packageRoot.path)
         #expect(store.prompt == "Make a mortgage calculator")
         #expect(!(store.isGenerating))
-        #expect(await generationCapture.sandboxPermissions?.enabled == [.internet, .userSelectedFiles])
-        #expect(await generationCapture.resourcePermissions?.enabled == [.microphone, .camera])
+        #expect(await generationCapture.settings?.sandboxPermissions.enabled == [.internet, .userSelectedFiles])
+        #expect(await generationCapture.settings?.resourcePermissions.enabled == [.microphone, .camera])
         #expect(await runCapture.ranToolIDs.isEmpty)
 
         let failingRunCapture = ToolRunCapture()
         let failingStore = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { _ in
                     throw FakeAgentError.expected
                 },
                 runnerClient: ToolRunnerClient { tool in

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineToolLibraryStoreTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineToolLibraryStoreTests.swift
@@ -13,7 +13,6 @@ extension AgentPipelineTests {
         let context = ModelContext(container)
         let packageRoot = URL(fileURLWithPath: "/tmp/fake-tool", isDirectory: true)
         let generationCapture = GenerationCapture()
-        let manifest = ToolManifest(displayName: "Fake Tool", executableName: "FakeTool", files: [])
         let generationClient = ToolGenerationClient { request in
             await generationCapture.record(request)
             try await request.lifecycle.prepareCreatedTool(
@@ -22,8 +21,7 @@ extension AgentPipelineTests {
                     executableName: "FakeTool",
                     bundleIdentifier: ToolBundleIdentifier.make(executableName: "FakeTool"),
                     settings: request.settings,
-                    packageRootURL: packageRoot,
-                    manifest: manifest
+                    packageRootURL: packageRoot
                 ),
                 request.prompt
             )
@@ -31,8 +29,7 @@ extension AgentPipelineTests {
                 toolName: "Fake Tool",
                 executableName: "FakeTool",
                 settings: request.settings,
-                packageRootURL: packageRoot,
-                manifest: manifest
+                packageRootURL: packageRoot
             )
         }
         let runCapture = ToolRunCapture()

--- a/IronsmithTests/Core/Persistence/PersistenceTests.swift
+++ b/IronsmithTests/Core/Persistence/PersistenceTests.swift
@@ -45,10 +45,8 @@ struct PersistenceTests {
     @MainActor
     @Test
     func diskBackedModelContainerReopensCurrentToolSchema() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("ironsmith-persistence-tests-\(UUID().uuidString)", isDirectory: true)
+        let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         let storeURL = root.appendingPathComponent("ironsmith.sqlite")
         let config = ModelConfiguration(url: storeURL)
 
@@ -74,19 +72,163 @@ struct PersistenceTests {
         }
 
         do {
+            let container = try IronsmithModelContainerFactory.make(configuration: config)
+            let context = ModelContext(container)
+            let tool = try #require(try context.fetch(FetchDescriptor<Tool>()).first)
+            #expect(tool.generationState == ToolGenerationState.stopped)
+            #expect(tool.generationPhase == ToolGenerationPhase.generatingSource)
+            #expect(tool.generationMode == ToolGenerationMode.create)
+            #expect(tool.pendingPrompt == "Build a resumable app")
+            #expect(container.schema.version == IronsmithSchemaV1.versionIdentifier)
+            #expect(container.migrationPlan != nil)
+        }
+    }
+
+    @MainActor
+    @Test
+    func legacyStoreIsCopiedBackedUpAndReopenedWithoutDeletingSource() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let legacyDirectoryURL = root.appendingPathComponent("legacy", isDirectory: true)
+        try FileManager.default.createDirectory(at: legacyDirectoryURL, withIntermediateDirectories: true)
+        let legacyStoreURL = legacyDirectoryURL.appendingPathComponent("default.store")
+
+        do {
             let container = try ModelContainer(
                 for: Tool.self,
                 ModelConfig.self,
                 ProviderConfig.self,
-                configurations: config
+                configurations: ModelConfiguration(url: legacyStoreURL)
+            )
+            let context = ModelContext(container)
+            context.insert(Tool(name: "Legacy Tool", packageRootPath: "/tmp/legacy-tool"))
+            try context.save()
+        }
+
+        let locations = IronsmithPersistentStoreLocations(
+            databaseDirectoryURL: root
+                .appendingPathComponent(".ironsmith", isDirectory: true)
+                .appendingPathComponent("db", isDirectory: true),
+            legacyStoreURL: legacyStoreURL
+        )
+        try IronsmithPersistentStorePreparer(locations: locations)
+            .prepare(startupDate: Date(timeIntervalSince1970: 1_750_000_000))
+
+        #expect(FileManager.default.fileExists(atPath: legacyStoreURL.path))
+        #expect(FileManager.default.fileExists(atPath: locations.storeURL.path))
+
+        let backupDirectoryURL = try #require(
+            try Self.startupBackupDirectories(in: locations).first
+        )
+        let backupStoreURL = backupDirectoryURL.appendingPathComponent(IronsmithPaths.databaseFileName)
+        #expect(FileManager.default.fileExists(atPath: backupStoreURL.path))
+
+        do {
+            let container = try IronsmithModelContainerFactory.make(
+                configuration: ModelConfiguration(url: locations.storeURL)
             )
             let context = ModelContext(container)
             let tool = try #require(try context.fetch(FetchDescriptor<Tool>()).first)
-            #expect(tool.generationState == .stopped)
-            #expect(tool.generationPhase == .generatingSource)
-            #expect(tool.generationMode == .create)
-            #expect(tool.pendingPrompt == "Build a resumable app")
+            #expect(tool.name == "Legacy Tool")
         }
+
+        do {
+            let container = try IronsmithModelContainerFactory.make(
+                configuration: ModelConfiguration(url: backupStoreURL)
+            )
+            let context = ModelContext(container)
+            let tool = try #require(try context.fetch(FetchDescriptor<Tool>()).first)
+            #expect(tool.name == "Legacy Tool")
+        }
+    }
+
+    @Test
+    func existingStoreIsBackedUpInsteadOfBeingReplacedByLegacyStore() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let legacyStoreURL = root.appendingPathComponent("legacy/default.store")
+        try FileManager.default.createDirectory(
+            at: legacyStoreURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("legacy".utf8).write(to: legacyStoreURL)
+
+        let locations = IronsmithPersistentStoreLocations(
+            databaseDirectoryURL: root
+                .appendingPathComponent(".ironsmith", isDirectory: true)
+                .appendingPathComponent("db", isDirectory: true),
+            legacyStoreURL: legacyStoreURL
+        )
+        try FileManager.default.createDirectory(
+            at: locations.databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try Data("current".utf8).write(to: locations.storeURL)
+
+        try IronsmithPersistentStorePreparer(locations: locations)
+            .prepare(startupDate: Date(timeIntervalSince1970: 1_750_000_000))
+
+        #expect(try Data(contentsOf: locations.storeURL) == Data("current".utf8))
+        #expect(try Data(contentsOf: legacyStoreURL) == Data("legacy".utf8))
+
+        let backupDirectoryURL = try #require(
+            try Self.startupBackupDirectories(in: locations).first
+        )
+        let backupStoreURL = backupDirectoryURL.appendingPathComponent(IronsmithPaths.databaseFileName)
+        #expect(try Data(contentsOf: backupStoreURL) == Data("current".utf8))
+    }
+
+    @Test
+    func startupBackupsRetainOnlyTheThreeNewestSnapshots() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let locations = IronsmithPersistentStoreLocations(
+            databaseDirectoryURL: root
+                .appendingPathComponent(".ironsmith", isDirectory: true)
+                .appendingPathComponent("db", isDirectory: true),
+            legacyStoreURL: root.appendingPathComponent("legacy/default.store")
+        )
+        try FileManager.default.createDirectory(
+            at: locations.databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try Data("current".utf8).write(to: locations.storeURL)
+
+        let preparer = IronsmithPersistentStorePreparer(locations: locations)
+        for offset in 0..<5 {
+            try preparer.prepare(
+                startupDate: Date(timeIntervalSince1970: 1_750_000_000 + Double(offset))
+            )
+        }
+
+        let backupNames = try Self.startupBackupDirectories(in: locations)
+            .map(\.lastPathComponent)
+            .sorted()
+
+        #expect(backupNames == [
+            "20250615-150642-000",
+            "20250615-150643-000",
+            "20250615-150644-000",
+        ])
+    }
+
+    @Test
+    func persistentStorePathUsesIronsmithDatabaseDirectory() {
+        let expectedDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".ironsmith/db", isDirectory: true)
+
+        #expect(IronsmithPaths.databaseDirectory == expectedDirectory)
+        #expect(
+            IronsmithPaths.databaseURL
+                == expectedDirectory.appendingPathComponent(IronsmithPaths.databaseFileName)
+        )
+        #expect(
+            IronsmithPaths.databaseBackupsDirectory
+                == expectedDirectory.appendingPathComponent("backups", isDirectory: true)
+        )
     }
 
     @Test
@@ -124,5 +266,22 @@ struct PersistenceTests {
         let userDefaults = UserDefaults(suiteName: suiteName)!
         userDefaults.removePersistentDomain(forName: suiteName)
         return WelcomeOnboardingStore(userDefaults: userDefaults)
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ironsmith-persistence-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private static func startupBackupDirectories(
+        in locations: IronsmithPersistentStoreLocations
+    ) throws -> [URL] {
+        try FileManager.default.contentsOfDirectory(
+            at: locations.backupsDirectoryURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
     }
 }

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
@@ -70,7 +70,6 @@ extension ToolLibraryTests {
         await inferenceStore.loadIfNeeded(modelContext: context)
 
         let packageRoot = root.appendingPathComponent("LateCreate", isDirectory: true)
-        let manifest = ToolManifest(displayName: "Late Create", executableName: "LateCreate", files: [])
         let gate = LateGenerationCompletionGate()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
@@ -81,8 +80,7 @@ extension ToolLibraryTests {
                             executableName: "LateCreate",
                             bundleIdentifier: ToolBundleIdentifier.make(executableName: "LateCreate"),
                             settings: request.settings,
-                            packageRootURL: packageRoot,
-                            manifest: manifest
+                            packageRootURL: packageRoot
                         ),
                         request.prompt
                     )
@@ -91,8 +89,7 @@ extension ToolLibraryTests {
                         toolName: "Late Create",
                         executableName: "LateCreate",
                         settings: request.settings,
-                        packageRootURL: packageRoot,
-                        manifest: manifest
+                        packageRootURL: packageRoot
                     )
                 },
                 runnerClient: ToolRunnerClient { _ in }
@@ -126,7 +123,6 @@ extension ToolLibraryTests {
         await inferenceStore.loadIfNeeded(modelContext: context)
 
         let packageRoot = root.appendingPathComponent("LateResume", isDirectory: true)
-        let manifest = ToolManifest(displayName: "Late Resume", executableName: "LateResume", files: [])
         let tool = StoredTool(
             name: "Late Resume",
             executableName: "LateResume",
@@ -148,8 +144,7 @@ extension ToolLibraryTests {
                         toolName: "Late Resume",
                         executableName: "LateResume",
                         settings: request.settings,
-                        packageRootURL: packageRoot,
-                        manifest: manifest
+                        packageRootURL: packageRoot
                     )
                 },
                 runnerClient: ToolRunnerClient { _ in }
@@ -297,8 +292,7 @@ extension ToolLibraryTests {
                             executableName: "CreditTool",
                             bundleIdentifier: ToolBundleIdentifier.make(executableName: "CreditTool"),
                             settings: request.settings,
-                            packageRootURL: packageRoot,
-                            manifest: ToolManifest(displayName: "Credit Tool", executableName: "CreditTool", files: [])
+                            packageRootURL: packageRoot
                         ),
                         request.prompt
                     )
@@ -308,8 +302,7 @@ extension ToolLibraryTests {
                         toolName: "Credit Tool",
                         executableName: "CreditTool",
                         settings: request.settings,
-                        packageRootURL: packageRoot,
-                        manifest: ToolManifest(displayName: "Credit Tool", executableName: "CreditTool", files: [])
+                        packageRootURL: packageRoot
                     )
                 },
                 runnerClient: ToolRunnerClient { _ in }

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
@@ -16,7 +16,7 @@ extension ToolLibraryTests {
 
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { _ in
                     throw CancellationError()
                 },
                 runnerClient: ToolRunnerClient { _ in }
@@ -40,7 +40,7 @@ extension ToolLibraryTests {
 
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { _ in
                     throw NSError(
                         domain: NSURLErrorDomain,
                         code: NSURLErrorCancelled,
@@ -74,26 +74,27 @@ extension ToolLibraryTests {
         let gate = LateGenerationCompletionGate()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient(withLifecycle: { prompt, _, sandboxEnabled, _, _, _, lifecycle, _ in
-                    try await lifecycle.prepareCreatedTool(
+                generationClient: ToolGenerationClient { request in
+                    try await request.lifecycle.prepareCreatedTool(
                         ToolGenerationPreparedTool(
                             name: "Late Create",
                             executableName: "LateCreate",
                             bundleIdentifier: ToolBundleIdentifier.make(executableName: "LateCreate"),
-                            sandboxEnabled: sandboxEnabled,
+                            settings: request.settings,
                             packageRootURL: packageRoot,
                             manifest: manifest
                         ),
-                        prompt
+                        request.prompt
                     )
                     await gate.startAndWaitForRelease()
                     return ToolGenerationResult(
                         toolName: "Late Create",
                         executableName: "LateCreate",
+                        settings: request.settings,
                         packageRootURL: packageRoot,
                         manifest: manifest
                     )
-                }),
+                },
                 runnerClient: ToolRunnerClient { _ in }
             )
         )
@@ -141,15 +142,16 @@ extension ToolLibraryTests {
         let gate = LateGenerationCompletionGate()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient(withLifecycle: { _, _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { request in
                     await gate.startAndWaitForRelease()
                     return ToolGenerationResult(
                         toolName: "Late Resume",
                         executableName: "LateResume",
+                        settings: request.settings,
                         packageRootURL: packageRoot,
                         manifest: manifest
                     )
-                }),
+                },
                 runnerClient: ToolRunnerClient { _ in }
             )
         )
@@ -207,7 +209,7 @@ extension ToolLibraryTests {
 
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { _ in
                     Issue.record("Generation should not start without credits.")
                     throw CancellationError()
                 },
@@ -219,7 +221,7 @@ extension ToolLibraryTests {
         await store.submitPrompt(modelContext: context, inferenceStore: inferenceStore)
 
         #expect(store.presentedErrorMessage == InferenceStoreError.insufficientIronsmithCredits.localizedDescription)
-        #expect(store.presentedErrorAction == .buyIronsmithCredits)
+        #expect(store.presentedErrorAction == ToolLibraryPresentedErrorAction.buyIronsmithCredits)
         #expect(!(store.isGenerating))
     }
 
@@ -247,7 +249,7 @@ extension ToolLibraryTests {
 
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { _ in
                     throw NSError(domain: "AnyLanguageModel.AnyLanguageModelError", code: 0)
                 },
                 runnerClient: ToolRunnerClient { _ in }
@@ -288,12 +290,24 @@ extension ToolLibraryTests {
         let packageRoot = URL(fileURLWithPath: "/tmp/ironsmith-credit-refresh", isDirectory: true)
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, languageModelContext, _ in
-                    await languageModelContext.afterLanguageModelInvocation()
-                    await languageModelContext.afterLanguageModelInvocation()
+                generationClient: ToolGenerationClient { request in
+                    try await request.lifecycle.prepareCreatedTool(
+                        ToolGenerationPreparedTool(
+                            name: "Credit Tool",
+                            executableName: "CreditTool",
+                            bundleIdentifier: ToolBundleIdentifier.make(executableName: "CreditTool"),
+                            settings: request.settings,
+                            packageRootURL: packageRoot,
+                            manifest: ToolManifest(displayName: "Credit Tool", executableName: "CreditTool", files: [])
+                        ),
+                        request.prompt
+                    )
+                    await request.languageModelContext.afterLanguageModelInvocation()
+                    await request.languageModelContext.afterLanguageModelInvocation()
                     return ToolGenerationResult(
                         toolName: "Credit Tool",
                         executableName: "CreditTool",
+                        settings: request.settings,
                         packageRootURL: packageRoot,
                         manifest: ToolManifest(displayName: "Credit Tool", executableName: "CreditTool", files: [])
                     )

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -343,8 +343,7 @@ extension ToolLibraryTests {
                         toolName: "Runner",
                         executableName: "Runner",
                         settings: request.settings,
-                        packageRootURL: tool.packageRootURL,
-                        manifest: ToolManifest(displayName: "Runner", executableName: "Runner", files: [])
+                        packageRootURL: tool.packageRootURL
                     )
                 },
                 runnerClient: ToolRunnerClient { tool in
@@ -382,19 +381,11 @@ extension ToolLibraryTests {
         let executableName = "VersionedTool"
         let packageRoot = root.appendingPathComponent(executableName, isDirectory: true)
         let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: executableName)
-        let contentViewPath = layout.sourcePath(for: layout.defaultContentViewFileName)
+        let contentViewPath = layout.contentViewSourcePath
         let contentViewURL = packageRoot.appendingPathComponent(contentViewPath)
         let appEntryURL = packageRoot.appendingPathComponent(layout.appEntrySourcePath)
         let previousURL = layout.previousContentViewVersionURL
-        let manifest = ToolManifest(
-            displayName: executableName,
-            executableName: executableName,
-            files: [
-                ToolManifestFile(path: contentViewPath, description: "Primary SwiftUI screen.")
-            ]
-        )
         try FileManager.default.createDirectory(at: contentViewURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try JSONEncoder().encode(manifest).write(to: layout.agentManifestURL)
         let previousSettings = ToolGenerationSettings(
             appKind: .window,
             sandboxEnabled: true,
@@ -441,8 +432,7 @@ extension ToolLibraryTests {
                         toolName: executableName,
                         executableName: executableName,
                         settings: request.settings,
-                        packageRootURL: packageRoot,
-                        manifest: manifest
+                        packageRootURL: packageRoot
                     )
                 },
                 runnerClient: ToolRunnerClient { _ in },
@@ -490,8 +480,7 @@ extension ToolLibraryTests {
                         toolName: "Exporter",
                         executableName: "Exporter",
                         settings: request.settings,
-                        packageRootURL: URL(fileURLWithPath: "/tmp/exporter", isDirectory: true),
-                        manifest: ToolManifest(displayName: "Exporter", executableName: "Exporter", files: [])
+                        packageRootURL: URL(fileURLWithPath: "/tmp/exporter", isDirectory: true)
                     )
                 },
                 runnerClient: ToolRunnerClient { _ in },
@@ -528,8 +517,7 @@ extension ToolLibraryTests {
                         toolName: "Finder Tool",
                         executableName: "FinderTool",
                         settings: request.settings,
-                        packageRootURL: tool.packageRootURL,
-                        manifest: ToolManifest(displayName: "Finder Tool", executableName: "FinderTool", files: [])
+                        packageRootURL: tool.packageRootURL
                     )
                 },
                 runnerClient: ToolRunnerClient { _ in },
@@ -557,20 +545,12 @@ extension ToolLibraryTests {
         let executableName = "SourceViewer"
         let packageRoot = root.appendingPathComponent(executableName, isDirectory: true)
         let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: executableName)
-        let contentViewPath = layout.sourcePath(for: layout.defaultContentViewFileName)
+        let contentViewPath = layout.contentViewSourcePath
         let contentViewURL = packageRoot.appendingPathComponent(contentViewPath)
-        let manifest = ToolManifest(
-            displayName: executableName,
-            executableName: executableName,
-            files: [
-                ToolManifestFile(path: contentViewPath, description: "Primary SwiftUI screen.")
-            ]
-        )
         try FileManager.default.createDirectory(at: contentViewURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try JSONEncoder().encode(manifest).write(to: layout.agentManifestURL)
         try "import SwiftUI\n".write(to: contentViewURL, atomically: true, encoding: .utf8)
 
-        let tool = Tool(name: executableName, packageRootPath: packageRoot.path)
+        let tool = Tool(name: executableName, executableName: executableName, packageRootPath: packageRoot.path)
         let capture = ToolFinderCapture()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
@@ -579,8 +559,7 @@ extension ToolLibraryTests {
                         toolName: executableName,
                         executableName: executableName,
                         settings: request.settings,
-                        packageRootURL: packageRoot,
-                        manifest: manifest
+                        packageRootURL: packageRoot
                     )
                 },
                 runnerClient: ToolRunnerClient { _ in },
@@ -598,55 +577,6 @@ extension ToolLibraryTests {
 
         #expect(await capture.openedURL == contentViewURL.standardizedFileURL)
         #expect(store.presentedErrorMessage == nil)
-    }
-
-    @MainActor
-    @Test
-    func toolLibraryStoreRejectsSourcePathsOutsidePackage() async throws {
-        let root = try Self.makeTemporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        let executableName = "BadSourceViewer"
-        let packageRoot = root.appendingPathComponent(executableName, isDirectory: true)
-        let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: executableName)
-        let manifest = ToolManifest(
-            displayName: executableName,
-            executableName: executableName,
-            files: [
-                ToolManifestFile(path: "../outside.swift", description: "Escaping source.")
-            ]
-        )
-        try FileManager.default.createDirectory(at: packageRoot, withIntermediateDirectories: true)
-        try JSONEncoder().encode(manifest).write(to: layout.agentManifestURL)
-
-        let tool = Tool(name: executableName, packageRootPath: packageRoot.path)
-        let capture = ToolFinderCapture()
-        let store = ToolLibraryStore(
-            dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { request in
-                    ToolGenerationResult(
-                        toolName: executableName,
-                        executableName: executableName,
-                        settings: request.settings,
-                        packageRootURL: packageRoot,
-                        manifest: manifest
-                    )
-                },
-                runnerClient: ToolRunnerClient { _ in },
-                finderClient: ToolFinderClient(
-                    showToolDirectory: { _ in },
-                    revealURL: { _ in },
-                    openURL: { url in
-                        await capture.record(url)
-                    }
-                )
-            )
-        )
-
-        await store.viewSource(tool)
-
-        #expect(await capture.openedURL == nil)
-        #expect(store.presentedErrorMessage?.contains("outside the generated package") == true)
     }
 
     @MainActor

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -338,10 +338,11 @@ extension ToolLibraryTests {
         let runCapture = ToolRunCapture()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { request in
                     ToolGenerationResult(
                         toolName: "Runner",
                         executableName: "Runner",
+                        settings: request.settings,
                         packageRootURL: tool.packageRootURL,
                         manifest: ToolManifest(displayName: "Runner", executableName: "Runner", files: [])
                     )
@@ -435,10 +436,11 @@ extension ToolLibraryTests {
         let buildCapture = ToolBuildCapture()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { request in
                     ToolGenerationResult(
                         toolName: executableName,
                         executableName: executableName,
+                        settings: request.settings,
                         packageRootURL: packageRoot,
                         manifest: manifest
                     )
@@ -483,10 +485,11 @@ extension ToolLibraryTests {
         let finderCapture = ToolFinderCapture()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { request in
                     ToolGenerationResult(
                         toolName: "Exporter",
                         executableName: "Exporter",
+                        settings: request.settings,
                         packageRootURL: URL(fileURLWithPath: "/tmp/exporter", isDirectory: true),
                         manifest: ToolManifest(displayName: "Exporter", executableName: "Exporter", files: [])
                     )
@@ -520,10 +523,11 @@ extension ToolLibraryTests {
         let capture = ToolFinderCapture()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { request in
                     ToolGenerationResult(
                         toolName: "Finder Tool",
                         executableName: "FinderTool",
+                        settings: request.settings,
                         packageRootURL: tool.packageRootURL,
                         manifest: ToolManifest(displayName: "Finder Tool", executableName: "FinderTool", files: [])
                     )
@@ -570,10 +574,11 @@ extension ToolLibraryTests {
         let capture = ToolFinderCapture()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { request in
                     ToolGenerationResult(
                         toolName: executableName,
                         executableName: executableName,
+                        settings: request.settings,
                         packageRootURL: packageRoot,
                         manifest: manifest
                     )
@@ -618,10 +623,11 @@ extension ToolLibraryTests {
         let capture = ToolFinderCapture()
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
-                generationClient: ToolGenerationClient { _, _, _, _, _, _, _ in
+                generationClient: ToolGenerationClient { request in
                     ToolGenerationResult(
                         toolName: executableName,
                         executableName: executableName,
+                        settings: request.settings,
                         packageRootURL: packageRoot,
                         manifest: manifest
                     )


### PR DESCRIPTION
## Summary
- Refactor the single-file agent pipeline into clearer runtime, repair-loop, and artifact boundaries
- Simplify tool app bundle request and generation context plumbing
- Clean up model, provider, and tool persistence/path helpers while keeping migration behavior intact
- Expand generation, runtime, repair-loop, and Tool Library coverage for create, edit, resume, and persistence flows

## Testing
- Added and updated focused unit tests across the agent pipeline, Tool Library, and persistence layers
- Validated generation, repair-loop, and resumable workflow behavior through targeted test coverage
- Not run (not requested)