### PR TITLE
Add OpenAI Codex chat login and provider support

### DIFF
--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
@@ -83,7 +83,10 @@ struct ToolGenerationRuntimeContext {
     ) {
         self.languageModel = languageModelContext.languageModel
         self.metadataLanguageModel = languageModelContext.metadataLanguageModel
-        self.generationOptions = languageModelContext.options
+        self.generationOptions = OpenAICodexGenerationOptions.sanitized(
+            languageModelContext.options,
+            for: languageModelContext.languageModel
+        )
         self.pipelineConfiguration = languageModelContext.pipelineConfiguration
         self.repairStrategy = languageModelContext.repairStrategy
         self.toolsDirectoryURL = dependencies.toolsDirectoryURL

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -22,10 +22,15 @@ struct GeneratedToolMetadata {
     @Guide(description: "A snappy one or two word macOS playful and fun app name in Title Case")
     let displayName: String
 
-    @Guide(description: "A tiny app icon concept phrase for an image generator, two to five words. Do not write a sentence.")
+    @Guide(
+        description:
+            "A tiny app icon concept phrase for an image generator, two to five words. Do not write a sentence."
+    )
     let iconPrompt: String
 
-    @Guide(description: "One SF Symbol name chosen exactly from Ironsmith's allowed menuBarSystemImage list.")
+    @Guide(
+        description:
+            "One SF Symbol name chosen exactly from Ironsmith's allowed menuBarSystemImage list.")
     let menuBarSystemImage: String
 }
 
@@ -46,9 +51,13 @@ struct ToolMetadataRequest: Sendable {
 }
 
 struct ToolMetadataClient: Sendable {
-    private var suggestMetadataForRequest: @Sendable (_ request: ToolMetadataRequest) async -> ToolMetadataSuggestion
+    private var suggestMetadataForRequest:
+        @Sendable (_ request: ToolMetadataRequest) async -> ToolMetadataSuggestion
 
-    init(_ suggestMetadata: @escaping @Sendable (_ userPrompt: String) async -> ToolMetadataSuggestion) {
+    init(
+        _ suggestMetadata:
+            @escaping @Sendable (_ userPrompt: String) async -> ToolMetadataSuggestion
+    ) {
         self.suggestMetadataForRequest = { request in
             await suggestMetadata(request.userPrompt)
         }
@@ -56,7 +65,8 @@ struct ToolMetadataClient: Sendable {
 
     private init(
         requestBased: Void,
-        suggestMetadataForRequest: @escaping @Sendable (_ request: ToolMetadataRequest) async -> ToolMetadataSuggestion
+        suggestMetadataForRequest:
+            @escaping @Sendable (_ request: ToolMetadataRequest) async -> ToolMetadataSuggestion
     ) {
         self.suggestMetadataForRequest = suggestMetadataForRequest
     }
@@ -82,29 +92,31 @@ struct ToolMetadataClient: Sendable {
     }
 
     static func live() -> Self {
-        Self(requestBased: (), suggestMetadataForRequest: { request in
-            let userPrompt = request.userPrompt
-            let fallback = ToolMetadataSuggestion.fallback(for: userPrompt)
+        Self(
+            requestBased: (),
+            suggestMetadataForRequest: { request in
+                let userPrompt = request.userPrompt
+                let fallback = ToolMetadataSuggestion.fallback(for: userPrompt)
 
-            do {
-                return try await Self.generateMetadata(
-                    userPrompt: userPrompt,
-                    languageModel: request.languageModel,
-                    generationOptions: request.generationOptions,
-                    fallback: fallback
-                )
-            } catch {
-                AgentDiagnosticsLog.append(
-                    """
-                    Tool metadata generation failed; using fallback tool metadata.
-                    prompt: \(AgentDiagnosticsLog.compact(userPrompt, limit: 240))
-                    error:
-                    \(AgentDiagnosticsLog.renderError(error, limit: 500))
-                    """
-                )
-                return fallback
-            }
-        })
+                do {
+                    return try await Self.generateMetadata(
+                        userPrompt: userPrompt,
+                        languageModel: request.languageModel,
+                        generationOptions: request.generationOptions,
+                        fallback: fallback
+                    )
+                } catch {
+                    AgentDiagnosticsLog.append(
+                        """
+                        Tool metadata generation failed; using fallback tool metadata.
+                        prompt: \(AgentDiagnosticsLog.compact(userPrompt, limit: 240))
+                        error:
+                        \(AgentDiagnosticsLog.renderError(error, limit: 500))
+                        """
+                    )
+                    return fallback
+                }
+            })
     }
 
     private static func generateMetadata(
@@ -120,7 +132,10 @@ struct ToolMetadataClient: Sendable {
         let response = try await session.respond(
             to: Self.metadataPrompt(for: userPrompt),
             generating: GeneratedToolMetadata.self,
-            options: generationOptions
+            options: OpenAICodexGenerationOptions.sanitized(
+                generationOptions,
+                for: languageModel
+            )
         )
         return Self.metadataSuggestion(response.content, fallback: fallback)
     }
@@ -183,7 +198,8 @@ struct ToolPromptRefinementRequest: Sendable {
 struct ToolPromptRefinementClient: Sendable {
     nonisolated private static let maximumResponseTokens = 1000
 
-    private var refinePromptForRequest: @Sendable (_ request: ToolPromptRefinementRequest) async -> String?
+    private var refinePromptForRequest:
+        @Sendable (_ request: ToolPromptRefinementRequest) async -> String?
 
     init(_ refinePrompt: @escaping @Sendable (_ userPrompt: String) async -> String?) {
         self.refinePromptForRequest = { request in
@@ -193,7 +209,8 @@ struct ToolPromptRefinementClient: Sendable {
 
     private init(
         requestBased: Void,
-        refinePromptForRequest: @escaping @Sendable (_ request: ToolPromptRefinementRequest) async -> String?
+        refinePromptForRequest:
+            @escaping @Sendable (_ request: ToolPromptRefinementRequest) async -> String?
     ) {
         self.refinePromptForRequest = refinePromptForRequest
     }
@@ -221,52 +238,74 @@ struct ToolPromptRefinementClient: Sendable {
     }
 
     static func live() -> Self {
-        Self(requestBased: (), refinePromptForRequest: { request in
-            do {
-                let session = LanguageModelSession(
-                    model: request.languageModel,
-                    instructions: promptRefinementInstructions
-                )
-                let response: LanguageModelSession.Response<String> = try await session.respond(
-                    to: Self.promptRefinementPrompt(
-                        for: request.userPrompt,
-                        appKind: request.appKind,
-                        sandboxEnabled: request.sandboxEnabled
-                    ),
-                    options: Self.promptRefinementOptions(from: request.generationOptions)
-                )
-                let prompt = cleanedRefinedPrompt(response.content)
-                if prompt.isEmpty {
+        Self(
+            requestBased: (),
+            refinePromptForRequest: { request in
+                do {
+                    let session = LanguageModelSession(
+                        model: request.languageModel,
+                        instructions: promptRefinementInstructions
+                    )
+                    let response = try await Self.streamPromptRefinement(
+                        in: session,
+                        prompt: Self.promptRefinementPrompt(
+                            for: request.userPrompt,
+                            appKind: request.appKind,
+                            sandboxEnabled: request.sandboxEnabled
+                        ),
+                        options: Self.promptRefinementOptions(
+                            from: request.generationOptions,
+                            for: request.languageModel
+                        )
+                    )
+                    let prompt = cleanedRefinedPrompt(response)
+                    if prompt.isEmpty {
+                        AgentDiagnosticsLog.append(
+                            """
+                            Tool prompt refinement returned empty prompt; using original prompt.
+                            prompt: \(AgentDiagnosticsLog.compact(request.userPrompt, limit: 240))
+                            rawCharacters: \(response.count)
+                            """
+                        )
+                        return nil
+                    }
+
                     AgentDiagnosticsLog.append(
                         """
-                        Tool prompt refinement returned empty prompt; using original prompt.
+                        Tool prompt refinement generated.
                         prompt: \(AgentDiagnosticsLog.compact(request.userPrompt, limit: 240))
-                        rawCharacters: \(response.content.count)
+                        refinedPrompt: \(AgentDiagnosticsLog.compact(prompt, limit: 1_500))
+                        """
+                    )
+                    return prompt
+                } catch {
+                    AgentDiagnosticsLog.append(
+                        """
+                        Tool prompt refinement failed; using original prompt.
+                        prompt: \(AgentDiagnosticsLog.compact(request.userPrompt, limit: 240))
+                        error:
+                        \(AgentDiagnosticsLog.renderError(error, limit: 500))
                         """
                     )
                     return nil
                 }
+            })
+    }
 
-                AgentDiagnosticsLog.append(
-                    """
-                    Tool prompt refinement generated.
-                    prompt: \(AgentDiagnosticsLog.compact(request.userPrompt, limit: 240))
-                    refinedPrompt: \(AgentDiagnosticsLog.compact(prompt, limit: 1_500))
-                    """
-                )
-                return prompt
-            } catch {
-                AgentDiagnosticsLog.append(
-                    """
-                    Tool prompt refinement failed; using original prompt.
-                    prompt: \(AgentDiagnosticsLog.compact(request.userPrompt, limit: 240))
-                    error:
-                    \(AgentDiagnosticsLog.renderError(error, limit: 500))
-                    """
-                )
-                return nil
-            }
-        })
+    private static func streamPromptRefinement(
+        in session: LanguageModelSession,
+        prompt: String,
+        options: GenerationOptions
+    ) async throws -> String {
+        var latest = ""
+        let stream = session.streamResponse(
+            to: prompt,
+            options: options
+        )
+        for try await snapshot in stream {
+            latest = snapshot.content
+        }
+        return latest
     }
 
     nonisolated private static func promptRefinementPrompt(
@@ -286,10 +325,13 @@ struct ToolPromptRefinementClient: Sendable {
         """
     }
 
-    nonisolated private static func promptRefinementOptions(from generationOptions: GenerationOptions) -> GenerationOptions {
+    nonisolated private static func promptRefinementOptions(
+        from generationOptions: GenerationOptions,
+        for languageModel: any LanguageModel
+    ) -> GenerationOptions {
         var options = generationOptions
         options.maximumResponseTokens = maximumResponseTokens
-        return options
+        return OpenAICodexGenerationOptions.sanitized(options, for: languageModel)
     }
 
     nonisolated private static let promptRefinementInstructions = """

--- a/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
@@ -53,6 +53,7 @@ final class InferenceStore {
     var startingOllamaProviderIDs: Set<String> = []
     var selectedModelFallbackMessage: String?
     var ironsmithSession: Session?
+    var openAICodexCredential: OpenAICodexCredential?
     var ironsmithAccountSummary: IronsmithAccountSummary?
     var ironsmithCreditPacks: [IronsmithCreditPack] = []
     var isRefreshingIronsmithAccount = false
@@ -111,6 +112,7 @@ final class InferenceStore {
         }
 
         ironsmithSession = dependencies.accountClient.currentSession()
+        refreshOpenAICodexCredential()
         let selectedRemoteProvider = providers.first { provider in
             provider.kind != .local
                 && selectedModelID?.hasPrefix("\(provider.identifier)::") == true

--- a/Ironsmith/Core/Inference/InferenceStore/IronsmithAccount.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/IronsmithAccount.swift
@@ -94,7 +94,7 @@ extension InferenceStore {
             ironsmithAccountSummary = nil
             ironsmithCreditPacks = []
             pendingIronsmithAccountRefreshAfterCheckout = false
-            removeProvider(provider)
+            await removeProvider(provider)
             return true
         } catch {
             presentError(error)
@@ -110,7 +110,7 @@ extension InferenceStore {
             ironsmithAccountSummary = nil
             ironsmithCreditPacks = []
             pendingIronsmithAccountRefreshAfterCheckout = false
-            removeProvider(provider)
+            await removeProvider(provider)
             return true
         } catch {
             presentError(error)

--- a/Ironsmith/Core/Inference/InferenceStore/OpenAICodexAccount.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/OpenAICodexAccount.swift
@@ -14,11 +14,9 @@ extension InferenceStore {
         }
     }
 
-    func signInToOpenAIChatGPT(
-        launchFlow: @escaping OpenAICodexOAuthLaunchFlow
-    ) async -> Bool {
+    func signInToOpenAIChatGPT() async -> Bool {
         do {
-            openAICodexCredential = try await dependencies.openAICodexAuthClient.signIn(launchFlow)
+            openAICodexCredential = try await dependencies.openAICodexAuthClient.signIn()
             if let provider = providers.first(where: { $0.kind == .openAI }) {
                 await refreshDiscoveredModels(for: provider)
                 reconcileSelectedModel()
@@ -33,9 +31,9 @@ extension InferenceStore {
         }
     }
 
-    func signOutOpenAIChatGPT(provider: ProviderConfig? = nil) -> Bool {
+    func signOutOpenAIChatGPT(provider: ProviderConfig? = nil) async -> Bool {
         do {
-            try dependencies.openAICodexAuthClient.signOut()
+            try await dependencies.openAICodexAuthClient.signOut()
             openAICodexCredential = nil
             if let provider {
                 remoteModels.removeAll {
@@ -50,4 +48,3 @@ extension InferenceStore {
         }
     }
 }
-

--- a/Ironsmith/Core/Inference/InferenceStore/OpenAICodexAccount.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/OpenAICodexAccount.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+extension InferenceStore {
+    var hasOpenAICodexCredential: Bool {
+        openAICodexCredential != nil
+    }
+
+    func refreshOpenAICodexCredential() {
+        do {
+            openAICodexCredential = try dependencies.openAICodexAuthClient.credential()
+        } catch {
+            openAICodexCredential = nil
+            presentError(error)
+        }
+    }
+
+    func signInToOpenAIChatGPT(
+        launchFlow: @escaping OpenAICodexOAuthLaunchFlow
+    ) async -> Bool {
+        do {
+            openAICodexCredential = try await dependencies.openAICodexAuthClient.signIn(launchFlow)
+            if let provider = providers.first(where: { $0.kind == .openAI }) {
+                await refreshDiscoveredModels(for: provider)
+                reconcileSelectedModel()
+            }
+            return true
+        } catch {
+            guard !IronsmithErrorPresentation.isCancellation(error) else {
+                return false
+            }
+            presentError(error)
+            return false
+        }
+    }
+
+    func signOutOpenAIChatGPT(provider: ProviderConfig? = nil) -> Bool {
+        do {
+            try dependencies.openAICodexAuthClient.signOut()
+            openAICodexCredential = nil
+            if let provider {
+                remoteModels.removeAll {
+                    $0.providerIdentifier == provider.identifier && $0.isOpenAICodexModel
+                }
+                reconcileSelectedModel()
+            }
+            return true
+        } catch {
+            presentError(error)
+            return false
+        }
+    }
+}
+

--- a/Ironsmith/Core/Inference/InferenceStore/Providers.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/Providers.swift
@@ -140,7 +140,7 @@ extension InferenceStore {
         }
     }
 
-    func removeProvider(_ provider: ProviderConfig) {
+    func removeProvider(_ provider: ProviderConfig) async {
         guard let repository else { return }
         guard provider.isRemovable else { return }
 
@@ -155,7 +155,7 @@ extension InferenceStore {
         }
         if provider.kind == .openAI {
             do {
-                try dependencies.openAICodexAuthClient.signOut()
+                try await dependencies.openAICodexAuthClient.signOut()
                 openAICodexCredential = nil
             } catch {
                 presentError(error)

--- a/Ironsmith/Core/Inference/InferenceStore/Providers.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/Providers.swift
@@ -153,6 +153,15 @@ extension InferenceStore {
                 return
             }
         }
+        if provider.kind == .openAI {
+            do {
+                try dependencies.openAICodexAuthClient.signOut()
+                openAICodexCredential = nil
+            } catch {
+                presentError(error)
+                return
+            }
+        }
 
         remoteModels.removeAll { $0.providerIdentifier == identifier }
         providerConnectionIssues.removeValue(forKey: identifier)
@@ -281,7 +290,8 @@ extension InferenceStore {
         }
 
         if provider.authMode == .apiKey,
-            apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            !(provider.kind == .openAI && hasOpenAICodexCredential)
         {
             throw ProviderCreationError.missingAPIKey
         }

--- a/Ironsmith/Core/Inference/InferenceStore/Providers.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/Providers.swift
@@ -144,19 +144,23 @@ extension InferenceStore {
         guard let repository else { return }
         guard provider.isRemovable else { return }
 
-        let identifier = provider.identifier
-        if let reference = provider.apiKeyReference {
+        if provider.kind == .openAI {
             do {
-                try dependencies.credentialClient.deleteAPIKey(reference)
+                let codexCredential = try dependencies.openAICodexAuthClient.credential()
+                if codexCredential != nil {
+                    try await dependencies.openAICodexAuthClient.signOut()
+                }
+                openAICodexCredential = nil
             } catch {
                 presentError(error)
                 return
             }
         }
-        if provider.kind == .openAI {
+
+        let identifier = provider.identifier
+        if let reference = provider.apiKeyReference {
             do {
-                try await dependencies.openAICodexAuthClient.signOut()
-                openAICodexCredential = nil
+                try dependencies.credentialClient.deleteAPIKey(reference)
             } catch {
                 presentError(error)
                 return

--- a/Ironsmith/Core/Inference/ModelSelection/LanguageModelClient.swift
+++ b/Ironsmith/Core/Inference/ModelSelection/LanguageModelClient.swift
@@ -12,7 +12,8 @@ extension LanguageModelClient {
     static func live(
         credentialClient: CredentialClient,
         localModelClient: LocalModelClient,
-        accountClient: IronsmithAccountClient = .unconfigured
+        accountClient: IronsmithAccountClient = .unconfigured,
+        openAICodexAuthClient: OpenAICodexAuthClient = .unconfigured
     ) -> Self {
         Self(
             makeLanguageModel: { model, provider in
@@ -21,7 +22,8 @@ extension LanguageModelClient {
                     provider: provider,
                     credentialClient: credentialClient,
                     localModelClient: localModelClient,
-                    accountClient: accountClient
+                    accountClient: accountClient,
+                    openAICodexAuthClient: openAICodexAuthClient
                 )
             }
         )
@@ -32,7 +34,8 @@ extension LanguageModelClient {
         provider: ProviderConfig?,
         credentialClient: CredentialClient,
         localModelClient: LocalModelClient,
-        accountClient: IronsmithAccountClient
+        accountClient: IronsmithAccountClient,
+        openAICodexAuthClient: OpenAICodexAuthClient
     ) async throws -> any LanguageModel {
         switch model.source {
         case .appleFoundation:
@@ -69,6 +72,24 @@ extension LanguageModelClient {
                 )
 
             case .openAI:
+                if let codexModelIdentifier = model.openAICodexRawIdentifier {
+                    let credential = try await openAICodexAuthClient.validCredential()
+                    var headers: [String: String] = [:]
+                    if let accountID = credential.accountID, !accountID.isEmpty {
+                        headers["ChatGPT-Account-Id"] = accountID
+                    }
+                    return OpenAILanguageModel(
+                        baseURL: OpenAICodexBackend.backendBaseURL,
+                        apiKey: credential.accessToken,
+                        model: codexModelIdentifier,
+                        apiVariant: .responses,
+                        session: remoteGenerationSession(
+                            for: OpenAICodexBackend.backendBaseURL,
+                            headers: headers
+                        )
+                    )
+                }
+
                 let token = try apiKey(for: provider, credentialClient: credentialClient)
                 let baseURL = try providerBaseURL(provider)
                 return OpenAILanguageModel(

--- a/Ironsmith/Core/Inference/ModelSelection/ModelGenerationDefaults.swift
+++ b/Ironsmith/Core/Inference/ModelSelection/ModelGenerationDefaults.swift
@@ -59,6 +59,11 @@ struct ModelGenerationDefaults: Equatable {
         case .mlx:
             return MLXModelCatalog.generationDefaultsByIdentifier[model.identifier] ?? .qwenDefaults
         case .remote:
+            if model.isOpenAICodexModel {
+                var defaults = Self.remote
+                defaults.maximumResponseTokens = nil
+                return defaults
+            }
             if model.providerIdentifier == ProviderKind.ollama.rawValue {
                 return OllamaModelCatalog.generationDefaultsByIdentifier[model.identifier] ?? .ollamaDefaults
             }
@@ -114,6 +119,12 @@ extension ModelConfig {
             options[custom: OllamaLanguageModel.self] = ollamaOptions
         }
 
+        if source == .remote, isOpenAICodexModel {
+            options[custom: OpenAILanguageModel.self] = OpenAILanguageModel.CustomGenerationOptions(
+                store: false
+            )
+        }
+
         return options
     }
 
@@ -122,6 +133,9 @@ extension ModelConfig {
         for defaults: ModelGenerationDefaults,
         preferences: GenerationPreferencesStore
     ) -> Int? {
+        if isOpenAICodexModel {
+            return nil
+        }
         if preferences.customOptionsEnabled {
             return preferences.maximumResponseTokens
         }

--- a/Ironsmith/Core/Inference/Providers/CodexAuthFileClient.swift
+++ b/Ironsmith/Core/Inference/Providers/CodexAuthFileClient.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+nonisolated struct CodexAuthFileClient: Sendable {
+    var credential: @Sendable () throws -> OpenAICodexCredential?
+    var saveCredential: @Sendable (OpenAICodexCredential) throws -> Void
+}
+
+extension CodexAuthFileClient {
+    nonisolated static func live(authFileURL: URL = IronsmithPaths.codexAuthFileURL) -> Self {
+        Self(
+            credential: {
+                try credential(from: authFileURL)
+            },
+            saveCredential: { credential in
+                try save(credential, to: authFileURL)
+            }
+        )
+    }
+
+    nonisolated static var unconfigured: Self {
+        Self(
+            credential: { nil },
+            saveCredential: { _ in }
+        )
+    }
+
+    nonisolated static func credential(from authFileURL: URL) throws -> OpenAICodexCredential? {
+        guard FileManager.default.fileExists(atPath: authFileURL.path) else {
+            return nil
+        }
+        let data = try Data(contentsOf: authFileURL)
+        return try credential(from: data)
+    }
+
+    nonisolated static func credential(from data: Data) throws -> OpenAICodexCredential? {
+        let object = try JSONObject(data: data)
+        if let authMode = object.dictionary["auth_mode"] as? String,
+           authMode != "chatgpt" {
+            return nil
+        }
+        guard let tokens = object.dictionary["tokens"] as? [String: Any] else {
+            throw OpenAICodexAuthClientError.invalidAuthFile
+        }
+        guard let accessToken = nonEmptyString(tokens["access_token"]) else {
+            throw OpenAICodexAuthClientError.invalidAuthFile
+        }
+
+        let idToken = nonEmptyString(tokens["id_token"])
+        let claims = OpenAICodexJWTClaims.bestClaims(
+            idToken: idToken,
+            accessToken: accessToken
+        )
+        return OpenAICodexCredential(
+            accessToken: accessToken,
+            refreshToken: nonEmptyString(tokens["refresh_token"]),
+            expiresAt: claims.expiresAt,
+            idToken: idToken,
+            accountID: nonEmptyString(tokens["account_id"]) ?? claims.accountID,
+            email: claims.email
+        )
+    }
+
+    nonisolated static func save(_ credential: OpenAICodexCredential, to authFileURL: URL) throws {
+        let existingData = try? Data(contentsOf: authFileURL)
+        let data = try updatedAuthData(
+            existingData: existingData,
+            credential: credential,
+            refreshDate: Date()
+        )
+        try FileManager.default.createDirectory(
+            at: authFileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: authFileURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o600))],
+            ofItemAtPath: authFileURL.path
+        )
+    }
+
+    nonisolated static func updatedAuthData(
+        existingData: Data?,
+        credential: OpenAICodexCredential,
+        refreshDate: Date
+    ) throws -> Data {
+        let object: JSONObject
+        if let existingData {
+            object = try JSONObject(data: existingData)
+        } else {
+            object = JSONObject(dictionary: [:])
+        }
+        var root = object.dictionary
+        var tokens = root["tokens"] as? [String: Any] ?? [:]
+
+        root["auth_mode"] = root["auth_mode"] ?? "chatgpt"
+        root["OPENAI_API_KEY"] = root["OPENAI_API_KEY"] ?? NSNull()
+        tokens["access_token"] = credential.accessToken
+        tokens["refresh_token"] = credential.refreshToken ?? NSNull()
+        tokens["id_token"] = credential.idToken ?? NSNull()
+        tokens["account_id"] = credential.accountID ?? NSNull()
+        root["tokens"] = tokens
+        root["last_refresh"] = Self.timestampString(from: refreshDate)
+
+        return try JSONSerialization.data(
+            withJSONObject: root,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+    }
+
+    nonisolated private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    nonisolated private static func timestampString(from date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+nonisolated private struct JSONObject {
+    var dictionary: [String: Any]
+
+    init(dictionary: [String: Any]) {
+        self.dictionary = dictionary
+    }
+
+    init(data: Data) throws {
+        guard let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAICodexAuthClientError.invalidAuthFile
+        }
+        self.dictionary = dictionary
+    }
+}

--- a/Ironsmith/Core/Inference/Providers/CodexCLIClient.swift
+++ b/Ironsmith/Core/Inference/Providers/CodexCLIClient.swift
@@ -1,0 +1,218 @@
+import Foundation
+
+nonisolated struct CodexCLIProcessRequest: Equatable, Sendable {
+    var executableURL: URL
+    var arguments: [String]
+    var environment: [String: String]
+    var currentDirectoryURL: URL
+}
+
+nonisolated struct CodexCLIProcessResult: Equatable, Sendable {
+    var stdout: String
+    var stderr: String
+    var terminationStatus: Int32
+
+    var combinedOutput: String {
+        [stdout, stderr]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+}
+
+nonisolated struct CodexCLIClient: Sendable {
+    var signIn: @Sendable () async throws -> Void
+    var signOut: @Sendable () async throws -> Void
+    var loginStatus: @Sendable () async throws -> CodexCLIProcessResult
+}
+
+extension CodexCLIClient {
+    nonisolated static func live(
+        codexHomeDirectory: URL = IronsmithPaths.codexHomeDirectory,
+        executableURL: URL? = nil,
+        bundleResourceURL: URL? = Bundle.main.resourceURL,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        runProcess: @escaping @Sendable (CodexCLIProcessRequest) async throws -> CodexCLIProcessResult = { request in
+            try await Self.runProcess(request)
+        }
+    ) -> Self {
+        Self(
+            signIn: {
+                let request = try makeRequest(
+                    command: ["login"],
+                    codexHomeDirectory: codexHomeDirectory,
+                    executableURL: executableURL,
+                    bundleResourceURL: bundleResourceURL,
+                    environment: environment
+                )
+                let result = try await runProcess(request)
+                try validate(result)
+            },
+            signOut: {
+                let request = try makeRequest(
+                    command: ["logout"],
+                    codexHomeDirectory: codexHomeDirectory,
+                    executableURL: executableURL,
+                    bundleResourceURL: bundleResourceURL,
+                    environment: environment
+                )
+                let result = try await runProcess(request)
+                try validate(result)
+            },
+            loginStatus: {
+                let request = try makeRequest(
+                    command: ["login", "status"],
+                    codexHomeDirectory: codexHomeDirectory,
+                    executableURL: executableURL,
+                    bundleResourceURL: bundleResourceURL,
+                    environment: environment
+                )
+                return try await runProcess(request)
+            }
+        )
+    }
+
+    nonisolated static var unconfigured: Self {
+        Self(
+            signIn: { throw OpenAICodexAuthClientError.missingCodexBinary("Codex CLI is not configured.") },
+            signOut: {},
+            loginStatus: {
+                throw OpenAICodexAuthClientError.missingCodexBinary("Codex CLI is not configured.")
+            }
+        )
+    }
+
+    nonisolated static func makeRequest(
+        command: [String],
+        codexHomeDirectory: URL,
+        executableURL: URL?,
+        bundleResourceURL: URL?,
+        environment: [String: String]
+    ) throws -> CodexCLIProcessRequest {
+        try FileManager.default.createDirectory(
+            at: codexHomeDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let resolvedExecutableURL = try executableURL ?? bundledExecutableURL(resourceURL: bundleResourceURL)
+        var resolvedEnvironment = environment
+        resolvedEnvironment["CODEX_HOME"] = codexHomeDirectory.path
+
+        return CodexCLIProcessRequest(
+            executableURL: resolvedExecutableURL,
+            arguments: command,
+            environment: resolvedEnvironment,
+            currentDirectoryURL: codexHomeDirectory
+        )
+    }
+
+    nonisolated static func bundledExecutableURL(resourceURL: URL? = Bundle.main.resourceURL) throws -> URL {
+        guard let resourceURL else {
+            throw OpenAICodexAuthClientError.missingCodexBinary("Could not locate app resources.")
+        }
+        let vendorURL = resourceURL
+            .appendingPathComponent("Codex", isDirectory: true)
+            .appendingPathComponent("vendor", isDirectory: true)
+            .appendingPathComponent(currentTargetTriple, isDirectory: true)
+
+        let candidates = [
+            vendorURL.appendingPathComponent("codex"),
+            vendorURL
+                .appendingPathComponent("bin", isDirectory: true)
+                .appendingPathComponent("codex"),
+        ]
+        guard let executableURL = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) }) else {
+            throw OpenAICodexAuthClientError.missingCodexBinary("Missing Codex binary in \(vendorURL.path).")
+        }
+        return executableURL
+    }
+
+    nonisolated static func bundledVersion(resourceURL: URL? = Bundle.main.resourceURL) -> String? {
+        guard let resourceURL else { return nil }
+        let versionURL = resourceURL
+            .appendingPathComponent("Codex", isDirectory: true)
+            .appendingPathComponent("version.txt")
+        guard let version = try? String(contentsOf: versionURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !version.isEmpty
+        else {
+            return nil
+        }
+        return version
+    }
+
+    nonisolated private static var currentTargetTriple: String {
+        #if arch(arm64)
+        return "aarch64-apple-darwin"
+        #elseif arch(x86_64)
+        return "x86_64-apple-darwin"
+        #else
+        return "unsupported-apple-darwin"
+        #endif
+    }
+
+    nonisolated private static func validate(_ result: CodexCLIProcessResult) throws {
+        guard result.terminationStatus == 0 else {
+            throw OpenAICodexAuthClientError.codexCommandFailed(sanitizedOutput(result.combinedOutput))
+        }
+    }
+
+    nonisolated private static func sanitizedOutput(_ output: String) -> String {
+        var sanitized = output
+        for key in ["OPENAI_API_KEY", "access_token", "refresh_token", "id_token"] {
+            sanitized = sanitized.replacingOccurrences(
+                of: #""\#(key)"\s*:\s*"[^"]+""#,
+                with: #""\#(key)": "[redacted]""#,
+                options: .regularExpression
+            )
+        }
+        sanitized = sanitized.replacingOccurrences(
+            of: #"Bearer\s+[A-Za-z0-9._~+/=-]+"#,
+            with: "Bearer [redacted]",
+            options: .regularExpression
+        )
+        sanitized = sanitized.replacingOccurrences(
+            of: #"[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"#,
+            with: "[jwt-redacted]",
+            options: .regularExpression
+        )
+        sanitized = sanitized.replacingOccurrences(
+            of: #"rt\.[A-Za-z0-9._-]+"#,
+            with: "rt.[redacted]",
+            options: .regularExpression
+        )
+        return sanitized
+    }
+
+    nonisolated private static func runProcess(_ request: CodexCLIProcessRequest) async throws -> CodexCLIProcessResult {
+        try await withCheckedThrowingContinuation { continuation in
+            let process = Process()
+            process.executableURL = request.executableURL
+            process.arguments = request.arguments
+            process.environment = request.environment
+            process.currentDirectoryURL = request.currentDirectoryURL
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            process.terminationHandler = { process in
+                let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
+                continuation.resume(
+                    returning: CodexCLIProcessResult(
+                        stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+                        stderr: String(data: stderrData, encoding: .utf8) ?? "",
+                        terminationStatus: process.terminationStatus
+                    )
+                )
+            }
+
+            do {
+                try process.run()
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/Ironsmith/Core/Inference/Providers/CredentialClient.swift
+++ b/Ironsmith/Core/Inference/Providers/CredentialClient.swift
@@ -23,28 +23,34 @@ extension CredentialClient {
     }
 }
 
-extension CredentialClient {
-    nonisolated static let openAICodexCredentialReference = "provider.openai.codexOAuth"
+/*
+ Legacy Codex credential Keychain helpers, commented out for reference only. Codex auth
+ is now stored by Codex CLI in ~/.ironsmith/.codex/auth.json and accessed through
+ CodexAuthFileClient. Normal provider API-key Keychain behavior above remains live.
 
-    nonisolated func loadOpenAICodexCredential() throws -> OpenAICodexCredential? {
-        guard let dataString = try loadAPIKey(Self.openAICodexCredentialReference) else {
-            return nil
-        }
-        guard let data = dataString.data(using: .utf8) else {
-            throw CredentialStoreError.invalidData
-        }
-        return try JSONDecoder().decode(OpenAICodexCredential.self, from: data)
-    }
+ extension CredentialClient {
+     nonisolated static let openAICodexCredentialReference = "provider.openai.codexOAuth"
 
-    nonisolated func saveOpenAICodexCredential(_ credential: OpenAICodexCredential) throws {
-        let data = try JSONEncoder().encode(credential)
-        guard let dataString = String(data: data, encoding: .utf8) else {
-            throw CredentialStoreError.invalidData
-        }
-        try saveAPIKey(dataString, Self.openAICodexCredentialReference)
-    }
+     nonisolated func loadOpenAICodexCredential() throws -> OpenAICodexCredential? {
+         guard let dataString = try loadAPIKey(Self.openAICodexCredentialReference) else {
+             return nil
+         }
+         guard let data = dataString.data(using: .utf8) else {
+             throw CredentialStoreError.invalidData
+         }
+         return try JSONDecoder().decode(OpenAICodexCredential.self, from: data)
+     }
 
-    nonisolated func deleteOpenAICodexCredential() throws {
-        try deleteAPIKey(Self.openAICodexCredentialReference)
-    }
-}
+     nonisolated func saveOpenAICodexCredential(_ credential: OpenAICodexCredential) throws {
+         let data = try JSONEncoder().encode(credential)
+         guard let dataString = String(data: data, encoding: .utf8) else {
+             throw CredentialStoreError.invalidData
+         }
+         try saveAPIKey(dataString, Self.openAICodexCredentialReference)
+     }
+
+     nonisolated func deleteOpenAICodexCredential() throws {
+         try deleteAPIKey(Self.openAICodexCredentialReference)
+     }
+ }
+ */

--- a/Ironsmith/Core/Inference/Providers/CredentialClient.swift
+++ b/Ironsmith/Core/Inference/Providers/CredentialClient.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct CredentialClient {
+nonisolated struct CredentialClient {
     var loadAPIKey: (String) throws -> String?
     var saveAPIKey: (String, String) throws -> Void
     var deleteAPIKey: (String) throws -> Void
@@ -20,5 +20,31 @@ extension CredentialClient {
                 try store.deleteAPIKey(for: reference)
             }
         )
+    }
+}
+
+extension CredentialClient {
+    nonisolated static let openAICodexCredentialReference = "provider.openai.codexOAuth"
+
+    nonisolated func loadOpenAICodexCredential() throws -> OpenAICodexCredential? {
+        guard let dataString = try loadAPIKey(Self.openAICodexCredentialReference) else {
+            return nil
+        }
+        guard let data = dataString.data(using: .utf8) else {
+            throw CredentialStoreError.invalidData
+        }
+        return try JSONDecoder().decode(OpenAICodexCredential.self, from: data)
+    }
+
+    nonisolated func saveOpenAICodexCredential(_ credential: OpenAICodexCredential) throws {
+        let data = try JSONEncoder().encode(credential)
+        guard let dataString = String(data: data, encoding: .utf8) else {
+            throw CredentialStoreError.invalidData
+        }
+        try saveAPIKey(dataString, Self.openAICodexCredentialReference)
+    }
+
+    nonisolated func deleteOpenAICodexCredential() throws {
+        try deleteAPIKey(Self.openAICodexCredentialReference)
     }
 }

--- a/Ironsmith/Core/Inference/Providers/OpenAICodexAuthClient.swift
+++ b/Ironsmith/Core/Inference/Providers/OpenAICodexAuthClient.swift
@@ -1,0 +1,432 @@
+import CryptoKit
+import Foundation
+@preconcurrency import Network
+
+typealias OpenAICodexOAuthLaunchFlow = @MainActor @Sendable (_ url: URL) async throws -> Void
+
+nonisolated struct OpenAICodexAuthClient {
+    static let refreshWindow: TimeInterval = 5 * 60
+
+    var credential: @Sendable () throws -> OpenAICodexCredential?
+    var signIn: @Sendable (_ launchFlow: @escaping OpenAICodexOAuthLaunchFlow) async throws -> OpenAICodexCredential
+    var signOut: @Sendable () throws -> Void
+    var validCredential: @Sendable () async throws -> OpenAICodexCredential
+    var discoverModels: @Sendable () async throws -> [OpenAICodexModel]
+}
+
+extension OpenAICodexAuthClient {
+    static func live(credentialClient: CredentialClient) -> Self {
+        let tokenStore = OpenAICodexTokenStore(credentialClient: credentialClient)
+
+        return Self(
+            credential: {
+                try credentialClient.loadOpenAICodexCredential()
+            },
+            signIn: { launchFlow in
+                let credential = try await Self.performBrowserSignIn(launchFlow: launchFlow)
+                try credentialClient.saveOpenAICodexCredential(credential)
+                return credential
+            },
+            signOut: {
+                try credentialClient.deleteOpenAICodexCredential()
+            },
+            validCredential: {
+                try await tokenStore.validCredential()
+            },
+            discoverModels: {
+                let credential = try await tokenStore.validCredential()
+                return try await Self.fetchModels(credential: credential)
+            }
+        )
+    }
+
+    static var unconfigured: Self {
+        Self(
+            credential: { nil },
+            signIn: { _ in throw OpenAICodexAuthClientError.missingCredential },
+            signOut: {},
+            validCredential: { throw OpenAICodexAuthClientError.missingCredential },
+            discoverModels: { throw OpenAICodexAuthClientError.missingCredential }
+        )
+    }
+
+    private static func performBrowserSignIn(
+        launchFlow: @escaping OpenAICodexOAuthLaunchFlow
+    ) async throws -> OpenAICodexCredential {
+        let pkce = try OpenAICodexPKCE()
+        let state = OpenAICodexRandom.base64URLString(byteCount: 32)
+        let callbackReceiver = OpenAICodexLoopbackOAuthReceiver(
+            port: OpenAICodexBackend.redirectPort,
+            path: OpenAICodexBackend.redirectPath,
+            expectedState: state
+        )
+        let authorizeURL = try authorizationURL(pkce: pkce, state: state)
+
+        let code = try await callbackReceiver.receiveCode {
+            try await launchFlow(authorizeURL)
+        }
+        let tokenResponse = try await exchangeCodeForTokens(code: code, verifier: pkce.verifier)
+        return credential(from: tokenResponse)
+    }
+
+    private static func authorizationURL(pkce: OpenAICodexPKCE, state: String) throws -> URL {
+        var components = URLComponents(url: OpenAICodexBackend.authorizeURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: OpenAICodexBackend.clientID),
+            URLQueryItem(name: "redirect_uri", value: OpenAICodexBackend.redirectURI),
+            URLQueryItem(name: "scope", value: "openid profile email offline_access"),
+            URLQueryItem(name: "code_challenge", value: pkce.challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "id_token_add_organizations", value: "true"),
+            URLQueryItem(name: "codex_cli_simplified_flow", value: "true"),
+            URLQueryItem(name: "originator", value: "ironsmith"),
+        ]
+        guard let url = components?.url else {
+            throw OpenAICodexAuthClientError.invalidAuthorizationURL
+        }
+        return url
+    }
+
+    private static func exchangeCodeForTokens(
+        code: String,
+        verifier: String
+    ) async throws -> OpenAICodexTokenResponse {
+        try await tokenRequest(
+            form: [
+                "grant_type": "authorization_code",
+                "client_id": OpenAICodexBackend.clientID,
+                "code": code,
+                "code_verifier": verifier,
+                "redirect_uri": OpenAICodexBackend.redirectURI,
+            ]
+        )
+    }
+
+    static func refreshCredential(
+        _ credential: OpenAICodexCredential
+    ) async throws -> OpenAICodexCredential {
+        guard let refreshToken = credential.refreshToken, !refreshToken.isEmpty else {
+            throw OpenAICodexAuthClientError.missingRefreshToken
+        }
+
+        let response: OpenAICodexTokenResponse = try await tokenRequest(
+            form: [
+                "grant_type": "refresh_token",
+                "client_id": OpenAICodexBackend.clientID,
+                "refresh_token": refreshToken,
+            ]
+        )
+
+        var refreshed = Self.credential(from: response)
+        if refreshed.refreshToken == nil {
+            refreshed.refreshToken = refreshToken
+        }
+        if refreshed.idToken == nil {
+            refreshed.idToken = credential.idToken
+        }
+        if refreshed.accountID == nil {
+            refreshed.accountID = credential.accountID
+        }
+        if refreshed.email == nil {
+            refreshed.email = credential.email
+        }
+        return refreshed
+    }
+
+    private static func tokenRequest<T: Decodable>(
+        form: [String: String]
+    ) async throws -> T {
+        var request = URLRequest(url: OpenAICodexBackend.tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.httpBody = formURLEncodedBody(form)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OpenAICodexAuthClientError.invalidResponse
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw OpenAICodexAuthClientError.requestFailed(
+                statusCode: httpResponse.statusCode,
+                message: String(data: data, encoding: .utf8) ?? "Invalid response"
+            )
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private static func fetchModels(credential: OpenAICodexCredential) async throws -> [OpenAICodexModel] {
+        var components = URLComponents(url: OpenAICodexBackend.modelsURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "client_version", value: OpenAICodexBackend.modelCatalogClientVersion)
+        ]
+        guard let url = components?.url else {
+            throw OpenAICodexAuthClientError.invalidModelURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = RemoteModelClient.discoveryTimeout
+        request.setValue("Bearer \(credential.accessToken)", forHTTPHeaderField: "Authorization")
+        if let accountID = credential.accountID, !accountID.isEmpty {
+            request.setValue(accountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OpenAICodexAuthClientError.invalidResponse
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            throw OpenAICodexAuthClientError.requestFailed(
+                statusCode: httpResponse.statusCode,
+                message: String(data: data, encoding: .utf8) ?? "Invalid response"
+            )
+        }
+
+        return try decodeModels(data)
+    }
+
+    static func decodeModels(_ data: Data) throws -> [OpenAICodexModel] {
+        let root = try JSONSerialization.jsonObject(with: data)
+        let entries = modelEntries(from: root)
+        var seen = Set<String>()
+        return entries.compactMap { entry in
+            guard isSupportedCodexModel(entry.identifier) else {
+                return nil
+            }
+            guard seen.insert(entry.identifier).inserted else {
+                return nil
+            }
+            return entry
+        }
+        .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
+    }
+
+    private static func modelEntries(from value: Any) -> [OpenAICodexModel] {
+        if let array = value as? [Any] {
+            return array.flatMap(modelEntries(from:))
+        }
+
+        guard let object = value as? [String: Any] else {
+            return []
+        }
+
+        if let data = object["data"] {
+            return modelEntries(from: data)
+        }
+        if let models = object["models"] {
+            return modelEntries(from: models)
+        }
+
+        guard let identifier = stringValue(in: object, keys: ["id", "slug", "model", "name"]) else {
+            return []
+        }
+
+        let displayName =
+            stringValue(in: object, keys: ["display_name", "displayName", "title", "label"])
+            ?? identifier
+        return [OpenAICodexModel(identifier: identifier, displayName: displayName)]
+    }
+
+    private static func stringValue(in object: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            if let value = object[key] as? String,
+               !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func isSupportedCodexModel(_ identifier: String) -> Bool {
+        let excludedTerms = [
+            "audio",
+            "dall-e",
+            "embedding",
+            "image",
+            "moderation",
+            "realtime",
+            "speech",
+            "transcribe",
+            "tts",
+            "video",
+            "whisper",
+        ]
+        if excludedTerms.contains(where: { identifier.localizedCaseInsensitiveContains($0) }) {
+            return false
+        }
+
+        return identifier.hasPrefix("gpt-")
+            || identifier.hasPrefix("o")
+    }
+
+    private static func credential(from response: OpenAICodexTokenResponse) -> OpenAICodexCredential {
+        let claims = OpenAICodexJWTClaims.bestClaims(
+            idToken: response.idToken,
+            accessToken: response.accessToken
+        )
+        let expiresAt = response.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+        return OpenAICodexCredential(
+            accessToken: response.accessToken,
+            refreshToken: response.refreshToken,
+            expiresAt: expiresAt,
+            idToken: response.idToken,
+            accountID: claims.accountID,
+            email: claims.email
+        )
+    }
+
+    private static func formURLEncodedBody(_ values: [String: String]) -> Data {
+        var components = URLComponents()
+        components.queryItems = values.map { URLQueryItem(name: $0.key, value: $0.value) }
+            .sorted { $0.name < $1.name }
+        return Data((components.percentEncodedQuery ?? "").utf8)
+    }
+}
+
+private actor OpenAICodexTokenStore {
+    private let credentialClient: CredentialClient
+
+    init(credentialClient: CredentialClient) {
+        self.credentialClient = credentialClient
+    }
+
+    func validCredential() async throws -> OpenAICodexCredential {
+        guard let credential = try credentialClient.loadOpenAICodexCredential() else {
+            throw OpenAICodexAuthClientError.missingCredential
+        }
+
+        if let expiresAt = credential.expiresAt,
+           expiresAt.timeIntervalSinceNow > OpenAICodexAuthClient.refreshWindow {
+            return credential
+        }
+
+        let refreshed = try await OpenAICodexAuthClient.refreshCredential(credential)
+        try credentialClient.saveOpenAICodexCredential(refreshed)
+        return refreshed
+    }
+}
+
+nonisolated struct OpenAICodexTokenResponse: Decodable {
+    let accessToken: String
+    let refreshToken: String?
+    let idToken: String?
+    let expiresIn: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+        case idToken = "id_token"
+        case expiresIn = "expires_in"
+    }
+}
+
+private struct OpenAICodexPKCE {
+    let verifier: String
+    let challenge: String
+
+    init() throws {
+        verifier = OpenAICodexRandom.base64URLString(byteCount: 64)
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        challenge = Data(digest).openAICodexBase64URLEncodedString()
+    }
+}
+
+private enum OpenAICodexRandom {
+    static func base64URLString(byteCount: Int) -> String {
+        var data = Data(count: byteCount)
+        _ = data.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, byteCount, $0.baseAddress!)
+        }
+        return data.openAICodexBase64URLEncodedString()
+    }
+}
+
+private extension Data {
+    func openAICodexBase64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private struct OpenAICodexJWTClaims {
+    var accountID: String?
+    var email: String?
+
+    static func bestClaims(idToken: String?, accessToken: String) -> Self {
+        decode(token: idToken) ?? decode(token: accessToken) ?? Self()
+    }
+
+    private static func decode(token: String?) -> Self? {
+        guard let token else { return nil }
+        let parts = token.split(separator: ".")
+        guard parts.count >= 2 else { return nil }
+
+        var payload = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while payload.count % 4 != 0 {
+            payload.append("=")
+        }
+
+        guard let data = Data(base64Encoded: payload),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let authClaims = object["https://api.openai.com/auth"] as? [String: Any]
+        let accountID =
+            object["chatgpt_account_id"] as? String
+            ?? authClaims?["chatgpt_account_id"] as? String
+            ?? (object["organizations"] as? [[String: Any]])?.first?["id"] as? String
+        return Self(
+            accountID: accountID,
+            email: object["email"] as? String
+        )
+    }
+}
+
+nonisolated enum OpenAICodexAuthClientError: LocalizedError, Equatable {
+    case browserLaunchFailed
+    case callbackTimedOut
+    case invalidAuthorizationURL
+    case invalidCallback
+    case invalidModelURL
+    case invalidResponse
+    case missingCredential
+    case missingRefreshToken
+    case oauthFailed(String)
+    case requestFailed(statusCode: Int, message: String)
+    case stateMismatch
+
+    var errorDescription: String? {
+        switch self {
+        case .browserLaunchFailed:
+            return "Could not open the ChatGPT sign-in page."
+        case .callbackTimedOut:
+            return "ChatGPT sign-in timed out."
+        case .invalidAuthorizationURL:
+            return "Could not create the ChatGPT sign-in URL."
+        case .invalidCallback:
+            return "ChatGPT returned an invalid sign-in callback."
+        case .invalidModelURL:
+            return "Could not create the ChatGPT model list URL."
+        case .invalidResponse:
+            return "ChatGPT returned an invalid response."
+        case .missingCredential:
+            return "Sign in with ChatGPT before using Codex models."
+        case .missingRefreshToken:
+            return "Sign in with ChatGPT again before using Codex models."
+        case .oauthFailed(let message):
+            return "ChatGPT sign-in failed: \(message)"
+        case .requestFailed(let statusCode, let message):
+            return "ChatGPT returned HTTP \(statusCode): \(message)"
+        case .stateMismatch:
+            return "ChatGPT sign-in returned an unexpected state."
+        }
+    }
+}

--- a/Ironsmith/Core/Inference/Providers/OpenAICodexAuthClient.swift
+++ b/Ironsmith/Core/Inference/Providers/OpenAICodexAuthClient.swift
@@ -1,34 +1,51 @@
-import CryptoKit
 import Foundation
-@preconcurrency import Network
 
-typealias OpenAICodexOAuthLaunchFlow = @MainActor @Sendable (_ url: URL) async throws -> Void
+/*
+ Legacy PKCE OAuth dependencies, commented out for reference only. Codex CLI now owns
+ ChatGPT browser login and writes auth.json under Ironsmith's CODEX_HOME.
+
+ import CryptoKit
+ @preconcurrency import Network
+
+ private typealias OpenAICodexOAuthLaunchFlow = @MainActor @Sendable (_ url: URL) async throws -> Void
+ */
 
 nonisolated struct OpenAICodexAuthClient {
     static let refreshWindow: TimeInterval = 5 * 60
 
     var credential: @Sendable () throws -> OpenAICodexCredential?
-    var signIn: @Sendable (_ launchFlow: @escaping OpenAICodexOAuthLaunchFlow) async throws -> OpenAICodexCredential
-    var signOut: @Sendable () throws -> Void
+    var signIn: @Sendable () async throws -> OpenAICodexCredential
+    var signOut: @Sendable () async throws -> Void
     var validCredential: @Sendable () async throws -> OpenAICodexCredential
     var discoverModels: @Sendable () async throws -> [OpenAICodexModel]
 }
 
 extension OpenAICodexAuthClient {
-    static func live(credentialClient: CredentialClient) -> Self {
-        let tokenStore = OpenAICodexTokenStore(credentialClient: credentialClient)
+    nonisolated static func live(
+        codexCLIClient: CodexCLIClient = .live(),
+        authFileClient: CodexAuthFileClient = .live(),
+        refreshCredential: @escaping @Sendable (OpenAICodexCredential) async throws -> OpenAICodexCredential = { credential in
+            try await Self.refreshCredential(credential)
+        }
+    ) -> Self {
+        let tokenStore = OpenAICodexTokenStore(
+            authFileClient: authFileClient,
+            refreshCredential: refreshCredential
+        )
 
         return Self(
             credential: {
-                try credentialClient.loadOpenAICodexCredential()
+                try authFileClient.credential()
             },
-            signIn: { launchFlow in
-                let credential = try await Self.performBrowserSignIn(launchFlow: launchFlow)
-                try credentialClient.saveOpenAICodexCredential(credential)
+            signIn: {
+                try await codexCLIClient.signIn()
+                guard let credential = try authFileClient.credential() else {
+                    throw OpenAICodexAuthClientError.missingCredential
+                }
                 return credential
             },
             signOut: {
-                try credentialClient.deleteOpenAICodexCredential()
+                try await codexCLIClient.signOut()
             },
             validCredential: {
                 try await tokenStore.validCredential()
@@ -40,17 +57,21 @@ extension OpenAICodexAuthClient {
         )
     }
 
-    static var unconfigured: Self {
+    nonisolated static var unconfigured: Self {
         Self(
             credential: { nil },
-            signIn: { _ in throw OpenAICodexAuthClientError.missingCredential },
+            signIn: { throw OpenAICodexAuthClientError.missingCredential },
             signOut: {},
             validCredential: { throw OpenAICodexAuthClientError.missingCredential },
             discoverModels: { throw OpenAICodexAuthClientError.missingCredential }
         )
     }
 
-    private static func performBrowserSignIn(
+    /*
+    Legacy PKCE OAuth implementation, commented out for reference only. The live path
+    invokes Codex CLI login/logout and reads auth.json.
+
+    nonisolated private static func performBrowserSignIn(
         launchFlow: @escaping OpenAICodexOAuthLaunchFlow
     ) async throws -> OpenAICodexCredential {
         let pkce = try OpenAICodexPKCE()
@@ -69,7 +90,7 @@ extension OpenAICodexAuthClient {
         return credential(from: tokenResponse)
     }
 
-    private static func authorizationURL(pkce: OpenAICodexPKCE, state: String) throws -> URL {
+    nonisolated private static func authorizationURL(pkce: OpenAICodexPKCE, state: String) throws -> URL {
         var components = URLComponents(url: OpenAICodexBackend.authorizeURL, resolvingAgainstBaseURL: false)
         components?.queryItems = [
             URLQueryItem(name: "response_type", value: "code"),
@@ -89,7 +110,7 @@ extension OpenAICodexAuthClient {
         return url
     }
 
-    private static func exchangeCodeForTokens(
+    nonisolated private static func exchangeCodeForTokens(
         code: String,
         verifier: String
     ) async throws -> OpenAICodexTokenResponse {
@@ -103,8 +124,9 @@ extension OpenAICodexAuthClient {
             ]
         )
     }
+    */
 
-    static func refreshCredential(
+    nonisolated static func refreshCredential(
         _ credential: OpenAICodexCredential
     ) async throws -> OpenAICodexCredential {
         guard let refreshToken = credential.refreshToken, !refreshToken.isEmpty else {
@@ -135,7 +157,7 @@ extension OpenAICodexAuthClient {
         return refreshed
     }
 
-    private static func tokenRequest<T: Decodable>(
+    nonisolated private static func tokenRequest<T: Decodable>(
         form: [String: String]
     ) async throws -> T {
         var request = URLRequest(url: OpenAICodexBackend.tokenURL)
@@ -156,7 +178,7 @@ extension OpenAICodexAuthClient {
         return try JSONDecoder().decode(T.self, from: data)
     }
 
-    private static func fetchModels(credential: OpenAICodexCredential) async throws -> [OpenAICodexModel] {
+    nonisolated private static func fetchModels(credential: OpenAICodexCredential) async throws -> [OpenAICodexModel] {
         var components = URLComponents(url: OpenAICodexBackend.modelsURL, resolvingAgainstBaseURL: false)
         components?.queryItems = [
             URLQueryItem(name: "client_version", value: OpenAICodexBackend.modelCatalogClientVersion)
@@ -187,7 +209,7 @@ extension OpenAICodexAuthClient {
         return try decodeModels(data)
     }
 
-    static func decodeModels(_ data: Data) throws -> [OpenAICodexModel] {
+    nonisolated static func decodeModels(_ data: Data) throws -> [OpenAICodexModel] {
         let root = try JSONSerialization.jsonObject(with: data)
         let entries = modelEntries(from: root)
         var seen = Set<String>()
@@ -203,7 +225,7 @@ extension OpenAICodexAuthClient {
         .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
     }
 
-    private static func modelEntries(from value: Any) -> [OpenAICodexModel] {
+    nonisolated private static func modelEntries(from value: Any) -> [OpenAICodexModel] {
         if let array = value as? [Any] {
             return array.flatMap(modelEntries(from:))
         }
@@ -229,7 +251,7 @@ extension OpenAICodexAuthClient {
         return [OpenAICodexModel(identifier: identifier, displayName: displayName)]
     }
 
-    private static func stringValue(in object: [String: Any], keys: [String]) -> String? {
+    nonisolated private static func stringValue(in object: [String: Any], keys: [String]) -> String? {
         for key in keys {
             if let value = object[key] as? String,
                !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -239,7 +261,7 @@ extension OpenAICodexAuthClient {
         return nil
     }
 
-    private static func isSupportedCodexModel(_ identifier: String) -> Bool {
+    nonisolated private static func isSupportedCodexModel(_ identifier: String) -> Bool {
         let excludedTerms = [
             "audio",
             "dall-e",
@@ -261,12 +283,13 @@ extension OpenAICodexAuthClient {
             || identifier.hasPrefix("o")
     }
 
-    private static func credential(from response: OpenAICodexTokenResponse) -> OpenAICodexCredential {
+    nonisolated private static func credential(from response: OpenAICodexTokenResponse) -> OpenAICodexCredential {
         let claims = OpenAICodexJWTClaims.bestClaims(
             idToken: response.idToken,
             accessToken: response.accessToken
         )
         let expiresAt = response.expiresIn.map { Date().addingTimeInterval(TimeInterval($0)) }
+            ?? claims.expiresAt
         return OpenAICodexCredential(
             accessToken: response.accessToken,
             refreshToken: response.refreshToken,
@@ -277,7 +300,7 @@ extension OpenAICodexAuthClient {
         )
     }
 
-    private static func formURLEncodedBody(_ values: [String: String]) -> Data {
+    nonisolated private static func formURLEncodedBody(_ values: [String: String]) -> Data {
         var components = URLComponents()
         components.queryItems = values.map { URLQueryItem(name: $0.key, value: $0.value) }
             .sorted { $0.name < $1.name }
@@ -286,14 +309,19 @@ extension OpenAICodexAuthClient {
 }
 
 private actor OpenAICodexTokenStore {
-    private let credentialClient: CredentialClient
+    private let authFileClient: CodexAuthFileClient
+    private let refreshCredential: @Sendable (OpenAICodexCredential) async throws -> OpenAICodexCredential
 
-    init(credentialClient: CredentialClient) {
-        self.credentialClient = credentialClient
+    init(
+        authFileClient: CodexAuthFileClient,
+        refreshCredential: @escaping @Sendable (OpenAICodexCredential) async throws -> OpenAICodexCredential
+    ) {
+        self.authFileClient = authFileClient
+        self.refreshCredential = refreshCredential
     }
 
     func validCredential() async throws -> OpenAICodexCredential {
-        guard let credential = try credentialClient.loadOpenAICodexCredential() else {
+        guard let credential = try authFileClient.credential() else {
             throw OpenAICodexAuthClientError.missingCredential
         }
 
@@ -302,8 +330,8 @@ private actor OpenAICodexTokenStore {
             return credential
         }
 
-        let refreshed = try await OpenAICodexAuthClient.refreshCredential(credential)
-        try credentialClient.saveOpenAICodexCredential(refreshed)
+        let refreshed = try await refreshCredential(credential)
+        try authFileClient.saveCredential(refreshed)
         return refreshed
     }
 }
@@ -322,7 +350,10 @@ nonisolated struct OpenAICodexTokenResponse: Decodable {
     }
 }
 
-private struct OpenAICodexPKCE {
+/*
+Legacy PKCE OAuth helpers, commented out for reference only.
+
+nonisolated private struct OpenAICodexPKCE {
     let verifier: String
     let challenge: String
 
@@ -333,8 +364,8 @@ private struct OpenAICodexPKCE {
     }
 }
 
-private enum OpenAICodexRandom {
-    static func base64URLString(byteCount: Int) -> String {
+nonisolated private enum OpenAICodexRandom {
+    nonisolated static func base64URLString(byteCount: Int) -> String {
         var data = Data(count: byteCount)
         _ = data.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, byteCount, $0.baseAddress!)
@@ -344,20 +375,28 @@ private enum OpenAICodexRandom {
 }
 
 private extension Data {
-    func openAICodexBase64URLEncodedString() -> String {
+    nonisolated func openAICodexBase64URLEncodedString() -> String {
         base64EncodedString()
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
     }
 }
+*/
 
-private struct OpenAICodexJWTClaims {
+nonisolated struct OpenAICodexJWTClaims {
     var accountID: String?
     var email: String?
+    var expiresAt: Date?
 
     static func bestClaims(idToken: String?, accessToken: String) -> Self {
-        decode(token: idToken) ?? decode(token: accessToken) ?? Self()
+        let idClaims = decode(token: idToken)
+        let accessClaims = decode(token: accessToken)
+        return Self(
+            accountID: idClaims?.accountID ?? accessClaims?.accountID,
+            email: idClaims?.email ?? accessClaims?.email,
+            expiresAt: accessClaims?.expiresAt ?? idClaims?.expiresAt
+        )
     }
 
     private static func decode(token: String?) -> Self? {
@@ -385,48 +424,75 @@ private struct OpenAICodexJWTClaims {
             ?? (object["organizations"] as? [[String: Any]])?.first?["id"] as? String
         return Self(
             accountID: accountID,
-            email: object["email"] as? String
+            email: object["email"] as? String,
+            expiresAt: unixTimestamp(from: object["exp"])
         )
+    }
+
+    private static func unixTimestamp(from value: Any?) -> Date? {
+        guard let number = value as? NSNumber else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: number.doubleValue)
     }
 }
 
 nonisolated enum OpenAICodexAuthClientError: LocalizedError, Equatable {
-    case browserLaunchFailed
-    case callbackTimedOut
-    case invalidAuthorizationURL
-    case invalidCallback
+    case invalidAuthFile
     case invalidModelURL
     case invalidResponse
+    case missingCodexBinary(String)
     case missingCredential
     case missingRefreshToken
-    case oauthFailed(String)
+    case codexCommandFailed(String)
     case requestFailed(statusCode: Int, message: String)
-    case stateMismatch
+
+    /*
+     Legacy PKCE OAuth error cases, commented out for reference only.
+
+     case browserLaunchFailed
+     case callbackTimedOut
+     case invalidAuthorizationURL
+     case invalidCallback
+     case oauthFailed(String)
+     case stateMismatch
+     */
 
     var errorDescription: String? {
         switch self {
-        case .browserLaunchFailed:
-            return "Could not open the ChatGPT sign-in page."
-        case .callbackTimedOut:
-            return "ChatGPT sign-in timed out."
-        case .invalidAuthorizationURL:
-            return "Could not create the ChatGPT sign-in URL."
-        case .invalidCallback:
-            return "ChatGPT returned an invalid sign-in callback."
+        case .invalidAuthFile:
+            return "Codex sign-in data is invalid. Sign in with ChatGPT again."
         case .invalidModelURL:
             return "Could not create the ChatGPT model list URL."
         case .invalidResponse:
             return "ChatGPT returned an invalid response."
+        case .missingCodexBinary(let message):
+            return message
         case .missingCredential:
             return "Sign in with ChatGPT before using Codex models."
         case .missingRefreshToken:
             return "Sign in with ChatGPT again before using Codex models."
-        case .oauthFailed(let message):
-            return "ChatGPT sign-in failed: \(message)"
+        case .codexCommandFailed(let message):
+            return message.isEmpty ? "Codex command failed." : message
         case .requestFailed(let statusCode, let message):
             return "ChatGPT returned HTTP \(statusCode): \(message)"
-        case .stateMismatch:
-            return "ChatGPT sign-in returned an unexpected state."
         }
     }
+
+    /*
+     Legacy PKCE OAuth error descriptions, commented out for reference only.
+
+     case .browserLaunchFailed:
+         return "Could not open the ChatGPT sign-in page."
+     case .callbackTimedOut:
+         return "ChatGPT sign-in timed out."
+     case .invalidAuthorizationURL:
+         return "Could not create the ChatGPT sign-in URL."
+     case .invalidCallback:
+         return "ChatGPT returned an invalid sign-in callback."
+     case .oauthFailed(let message):
+         return "ChatGPT sign-in failed: \(message)"
+     case .stateMismatch:
+         return "ChatGPT sign-in returned an unexpected state."
+     */
 }

--- a/Ironsmith/Core/Inference/Providers/OpenAICodexGenerationOptions.swift
+++ b/Ironsmith/Core/Inference/Providers/OpenAICodexGenerationOptions.swift
@@ -1,0 +1,29 @@
+import AnyLanguageModel
+import Foundation
+
+nonisolated enum OpenAICodexGenerationOptions {
+    static func isCodexLanguageModel(_ languageModel: any LanguageModel) -> Bool {
+        guard let openAIModel = languageModel as? OpenAILanguageModel else {
+            return false
+        }
+        return openAIModel.baseURL == OpenAICodexBackend.backendBaseURL
+    }
+
+    static func sanitized(
+        _ options: GenerationOptions,
+        for languageModel: any LanguageModel
+    ) -> GenerationOptions {
+        guard isCodexLanguageModel(languageModel) else {
+            return options
+        }
+
+        var options = options
+        options.maximumResponseTokens = nil
+
+        var openAIOptions = options[custom: OpenAILanguageModel.self] ?? OpenAILanguageModel.CustomGenerationOptions()
+        openAIOptions.store = false
+        options[custom: OpenAILanguageModel.self] = openAIOptions
+
+        return options
+    }
+}

--- a/Ironsmith/Core/Inference/Providers/OpenAICodexLoopbackOAuthReceiver.swift
+++ b/Ironsmith/Core/Inference/Providers/OpenAICodexLoopbackOAuthReceiver.swift
@@ -1,6 +1,14 @@
+/*
+ Legacy PKCE loopback OAuth receiver, commented out for reference only. The live
+ ChatGPT/Codex sign-in path invokes Codex CLI and reads auth.json from
+ Ironsmith's CODEX_HOME.
+
 import Foundation
 @preconcurrency import Network
 
+// Commented-out legacy implementation: Codex CLI now owns ChatGPT browser login and
+// writes auth.json under Ironsmith's CODEX_HOME. This receiver is not used by
+// the live OpenAICodexAuthClient path.
 nonisolated final class OpenAICodexLoopbackOAuthReceiver {
     private let port: UInt16
     private let path: String
@@ -257,3 +265,4 @@ private actor OpenAICodexListenerReadiness {
         continuation = nil
     }
 }
+*/

--- a/Ironsmith/Core/Inference/Providers/OpenAICodexLoopbackOAuthReceiver.swift
+++ b/Ironsmith/Core/Inference/Providers/OpenAICodexLoopbackOAuthReceiver.swift
@@ -1,0 +1,259 @@
+import Foundation
+@preconcurrency import Network
+
+nonisolated final class OpenAICodexLoopbackOAuthReceiver {
+    private let port: UInt16
+    private let path: String
+    private let expectedState: String
+    private let timeout: TimeInterval
+
+    init(
+        port: UInt16,
+        path: String,
+        expectedState: String,
+        timeout: TimeInterval = 5 * 60
+    ) {
+        self.port = port
+        self.path = path
+        self.expectedState = expectedState
+        self.timeout = timeout
+    }
+
+    func receiveCode(
+        launchAuthorizationURL: @escaping @Sendable () async throws -> Void
+    ) async throws -> String {
+        let listener = try makeListener()
+        let callback = OpenAICodexCallbackContinuation()
+        let readiness = OpenAICodexListenerReadiness()
+        listener.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                readiness.resume()
+            case .failed(let error), .waiting(let error):
+                readiness.resume(throwing: error)
+            default:
+                break
+            }
+        }
+        listener.newConnectionHandler = { [path, expectedState] connection in
+            connection.start(queue: .global(qos: .userInitiated))
+            Self.receiveCallback(
+                connection: connection,
+                expectedPath: path,
+                expectedState: expectedState,
+                callback: callback
+            )
+        }
+        listener.start(queue: .global(qos: .userInitiated))
+
+        do {
+            try await readiness.wait()
+            try await launchAuthorizationURL()
+            return try await waitForCallback(callback, listener: listener)
+        } catch {
+            listener.cancel()
+            throw error
+        }
+    }
+
+    private func makeListener() throws -> NWListener {
+        guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+            throw OpenAICodexAuthClientError.invalidCallback
+        }
+        let parameters = NWParameters.tcp
+        parameters.allowLocalEndpointReuse = true
+        return try NWListener(using: parameters, on: nwPort)
+    }
+
+    private func waitForCallback(
+        _ callback: OpenAICodexCallbackContinuation,
+        listener: NWListener
+    ) async throws -> String {
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                try await callback.value()
+            }
+            group.addTask { [timeout] in
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw OpenAICodexAuthClientError.callbackTimedOut
+            }
+
+            guard let result = try await group.next() else {
+                throw OpenAICodexAuthClientError.invalidCallback
+            }
+            group.cancelAll()
+            listener.cancel()
+            return result
+        }
+    }
+
+    private static func receiveCallback(
+        connection: NWConnection,
+        expectedPath: String,
+        expectedState: String,
+        callback: OpenAICodexCallbackContinuation
+    ) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, _, error in
+            if let error {
+                callback.resume(throwing: error)
+                connection.cancel()
+                return
+            }
+
+            guard let data,
+                  let request = String(data: data, encoding: .utf8),
+                  let result = parseCallback(
+                    request: request,
+                    expectedPath: expectedPath,
+                    expectedState: expectedState
+                  )
+            else {
+                sendResponse("Invalid ChatGPT sign-in callback.", status: 400, connection: connection)
+                callback.resume(throwing: OpenAICodexAuthClientError.invalidCallback)
+                return
+            }
+
+            switch result {
+            case .success(let code):
+                sendResponse("ChatGPT sign-in complete. You can close this window.", status: 200, connection: connection)
+                callback.resume(returning: code)
+            case .failure(let error):
+                sendResponse("ChatGPT sign-in failed.", status: 400, connection: connection)
+                callback.resume(throwing: error)
+            }
+        }
+    }
+
+    private static func parseCallback(
+        request: String,
+        expectedPath: String,
+        expectedState: String
+    ) -> Result<String, Error>? {
+        guard let requestLine = request.components(separatedBy: "\r\n").first else {
+            return nil
+        }
+        let pieces = requestLine.split(separator: " ")
+        guard pieces.count >= 2 else {
+            return nil
+        }
+
+        let rawPath = String(pieces[1])
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = "localhost"
+        components.percentEncodedPath = rawPath.components(separatedBy: "?").first ?? rawPath
+        if let queryStart = rawPath.firstIndex(of: "?") {
+            components.percentEncodedQuery = String(rawPath[rawPath.index(after: queryStart)...])
+        }
+
+        guard components.path == expectedPath else {
+            return .failure(OpenAICodexAuthClientError.invalidCallback)
+        }
+
+        let queryItems = components.queryItems ?? []
+        let state = queryItems.first { $0.name == "state" }?.value
+        guard state == expectedState else {
+            return .failure(OpenAICodexAuthClientError.stateMismatch)
+        }
+
+        if let error = queryItems.first(where: { $0.name == "error" })?.value {
+            let description = queryItems.first(where: { $0.name == "error_description" })?.value
+            return .failure(OpenAICodexAuthClientError.oauthFailed(description ?? error))
+        }
+
+        guard let code = queryItems.first(where: { $0.name == "code" })?.value,
+              !code.isEmpty
+        else {
+            return .failure(OpenAICodexAuthClientError.invalidCallback)
+        }
+        return .success(code)
+    }
+
+    private static func sendResponse(_ message: String, status: Int, connection: NWConnection) {
+        let statusText = status == 200 ? "OK" : "Bad Request"
+        let body = """
+        <!doctype html>
+        <html>
+        <head><meta charset="utf-8"><title>Ironsmith</title></head>
+        <body><p>\(message)</p><script>setTimeout(() => window.close(), 1200)</script></body>
+        </html>
+        """
+        let response = """
+        HTTP/1.1 \(status) \(statusText)\r
+        Content-Type: text/html; charset=utf-8\r
+        Content-Length: \(Data(body.utf8).count)\r
+        Connection: close\r
+        \r
+        \(body)
+        """
+        connection.send(content: Data(response.utf8), completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+}
+
+private actor OpenAICodexCallbackContinuation {
+    private var continuation: CheckedContinuation<String, Error>?
+    private var result: Result<String, Error>?
+
+    func value() async throws -> String {
+        if let result {
+            return try result.get()
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    nonisolated func resume(returning value: String) {
+        Task {
+            await complete(.success(value))
+        }
+    }
+
+    nonisolated func resume(throwing error: Error) {
+        Task {
+            await complete(.failure(error))
+        }
+    }
+
+    private func complete(_ result: Result<String, Error>) {
+        guard self.result == nil else { return }
+        self.result = result
+        continuation?.resume(with: result)
+        continuation = nil
+    }
+}
+
+private actor OpenAICodexListenerReadiness {
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var result: Result<Void, Error>?
+
+    func wait() async throws {
+        if let result {
+            return try result.get()
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    nonisolated func resume() {
+        Task {
+            await complete(.success(()))
+        }
+    }
+
+    nonisolated func resume(throwing error: Error) {
+        Task {
+            await complete(.failure(error))
+        }
+    }
+
+    private func complete(_ result: Result<Void, Error>) {
+        guard self.result == nil else { return }
+        self.result = result
+        continuation?.resume(with: result)
+        continuation = nil
+    }
+}

--- a/Ironsmith/Core/Inference/Providers/OpenAICodexModels.swift
+++ b/Ironsmith/Core/Inference/Providers/OpenAICodexModels.swift
@@ -2,16 +2,24 @@ import Foundation
 
 nonisolated enum OpenAICodexBackend {
     static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
-    static let issuerURL = URL(string: "https://auth.openai.com")!
     static let tokenURL = URL(string: "https://auth.openai.com/oauth/token")!
-    static let authorizeURL = URL(string: "https://auth.openai.com/oauth/authorize")!
     static let backendBaseURL = URL(string: "https://chatgpt.com/backend-api/codex/")!
     static let modelsURL = URL(string: "https://chatgpt.com/backend-api/codex/models")!
-    static let modelCatalogClientVersion = "0.142.5"
-    static let redirectURI = "http://localhost:1455/auth/callback"
-    static let redirectPort: UInt16 = 1455
-    static let redirectPath = "/auth/callback"
+    static var modelCatalogClientVersion: String {
+        CodexCLIClient.bundledVersion() ?? "0.142.5"
+    }
     static let modelIdentifierPrefix = "codex:"
+
+    /*
+     Legacy PKCE OAuth constants, commented out for reference only. Codex CLI now owns
+     browser login and writes auth.json under Ironsmith's CODEX_HOME.
+
+     static let issuerURL = URL(string: "https://auth.openai.com")!
+     static let authorizeURL = URL(string: "https://auth.openai.com/oauth/authorize")!
+     static let redirectURI = "http://localhost:1455/auth/callback"
+     static let redirectPort: UInt16 = 1455
+     static let redirectPath = "/auth/callback"
+     */
 
     static func codexModelIdentifier(for rawIdentifier: String) -> String {
         "\(modelIdentifierPrefix)\(rawIdentifier)"

--- a/Ironsmith/Core/Inference/Providers/OpenAICodexModels.swift
+++ b/Ironsmith/Core/Inference/Providers/OpenAICodexModels.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+nonisolated enum OpenAICodexBackend {
+    static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+    static let issuerURL = URL(string: "https://auth.openai.com")!
+    static let tokenURL = URL(string: "https://auth.openai.com/oauth/token")!
+    static let authorizeURL = URL(string: "https://auth.openai.com/oauth/authorize")!
+    static let backendBaseURL = URL(string: "https://chatgpt.com/backend-api/codex/")!
+    static let modelsURL = URL(string: "https://chatgpt.com/backend-api/codex/models")!
+    static let modelCatalogClientVersion = "0.142.5"
+    static let redirectURI = "http://localhost:1455/auth/callback"
+    static let redirectPort: UInt16 = 1455
+    static let redirectPath = "/auth/callback"
+    static let modelIdentifierPrefix = "codex:"
+
+    static func codexModelIdentifier(for rawIdentifier: String) -> String {
+        "\(modelIdentifierPrefix)\(rawIdentifier)"
+    }
+
+    static func rawCodexModelIdentifier(from identifier: String) -> String? {
+        guard identifier.hasPrefix(modelIdentifierPrefix) else { return nil }
+        return String(identifier.dropFirst(modelIdentifierPrefix.count))
+    }
+}
+
+nonisolated struct OpenAICodexCredential: Codable, Equatable, Sendable {
+    var accessToken: String
+    var refreshToken: String?
+    var expiresAt: Date?
+    var idToken: String?
+    var accountID: String?
+    var email: String?
+
+    var statusText: String {
+        if let email, !email.isEmpty {
+            return email
+        }
+        if accountID != nil {
+            return "Signed in"
+        }
+        return "Connected"
+    }
+}
+
+nonisolated struct OpenAICodexModel: Equatable, Sendable {
+    var identifier: String
+    var displayName: String
+}
+
+extension ModelConfig {
+    var isOpenAICodexModel: Bool {
+        OpenAICodexBackend.rawCodexModelIdentifier(from: identifier) != nil
+    }
+
+    var openAICodexRawIdentifier: String? {
+        OpenAICodexBackend.rawCodexModelIdentifier(from: identifier)
+    }
+}

--- a/Ironsmith/Core/Inference/Providers/RemoteModelClient.swift
+++ b/Ironsmith/Core/Inference/Providers/RemoteModelClient.swift
@@ -7,11 +7,22 @@ struct RemoteModelClient {
 extension RemoteModelClient {
     static let discoveryTimeout: TimeInterval = 10
 
-    static func live(accountClient: IronsmithAccountClient = .unconfigured) -> Self {
+    static func live(
+        accountClient: IronsmithAccountClient = .unconfigured,
+        openAICodexAuthClient: OpenAICodexAuthClient = .unconfigured
+    ) -> Self {
         Self { provider, apiKey in
             if provider.kind == .ironsmith {
                 let data = try await accountClient.invokeAPIData("api/v1/models", .get)
                 return try Self.decodeModels(data, for: provider)
+            }
+
+            if provider.kind == .openAI {
+                return try await Self.discoverOpenAIModels(
+                    provider: provider,
+                    apiKey: apiKey,
+                    openAICodexAuthClient: openAICodexAuthClient
+                )
             }
 
             let request = try Self.makeModelListRequest(for: provider, apiKey: apiKey)
@@ -26,6 +37,48 @@ extension RemoteModelClient {
 
             return try Self.decodeModels(data, for: provider)
         }
+    }
+
+    private static func discoverOpenAIModels(
+        provider: ProviderConfig,
+        apiKey: String?,
+        openAICodexAuthClient: OpenAICodexAuthClient
+    ) async throws -> [ModelConfig] {
+        var models: [ModelConfig] = []
+        var firstError: Error?
+
+        if let apiKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !apiKey.isEmpty {
+            do {
+                let request = try makeModelListRequest(for: provider, apiKey: apiKey)
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw RemoteModelDiscoveryError.invalidResponse
+                }
+                guard (200...299).contains(httpResponse.statusCode) else {
+                    throw RemoteModelDiscoveryError.fetchFailed(statusCode: httpResponse.statusCode)
+                }
+                models.append(contentsOf: try decodeModels(data, for: provider))
+            } catch {
+                firstError = error
+            }
+        }
+
+        do {
+            let codexModels = try await openAICodexAuthClient.discoverModels()
+            models.append(contentsOf: makeCodexModelConfigs(codexModels, provider: provider))
+        } catch OpenAICodexAuthClientError.missingCredential {
+        } catch {
+            firstError = firstError ?? error
+        }
+
+        if models.isEmpty, let firstError {
+            throw firstError
+        }
+
+        return models
+            .removingDuplicateSelectionIdentifiers()
+            .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
     }
 
     static func makeModelListRequest(for provider: ProviderConfig, apiKey: String?) throws -> URLRequest {
@@ -134,6 +187,21 @@ extension RemoteModelClient {
             .sorted { $0.displayName.localizedStandardCompare($1.displayName) == .orderedAscending }
     }
 
+    static func makeCodexModelConfigs(
+        _ codexModels: [OpenAICodexModel],
+        provider: ProviderConfig
+    ) -> [ModelConfig] {
+        codexModels.map { model in
+            ModelConfig(
+                identifier: OpenAICodexBackend.codexModelIdentifier(for: model.identifier),
+                displayName: "\(model.displayName) (Codex)",
+                providerIdentifier: provider.identifier,
+                source: .remote,
+                installState: .installed
+            )
+        }
+    }
+
     private static func filterDiscoverableModels(
         _ entries: [(identifier: String, displayName: String)],
         for providerKind: ProviderKind
@@ -208,6 +276,15 @@ extension RemoteModelClient {
                 return true
             }
             return !identifiers.contains(stableAlias)
+        }
+    }
+}
+
+private extension Array where Element == ModelConfig {
+    func removingDuplicateSelectionIdentifiers() -> [ModelConfig] {
+        var seen = Set<String>()
+        return filter { model in
+            seen.insert(model.selectionIdentifier).inserted
         }
     }
 }

--- a/Ironsmith/Core/Inference/Providers/RemoteModelClient.swift
+++ b/Ironsmith/Core/Inference/Providers/RemoteModelClient.swift
@@ -5,7 +5,7 @@ struct RemoteModelClient {
 }
 
 extension RemoteModelClient {
-    static let discoveryTimeout: TimeInterval = 10
+    nonisolated static let discoveryTimeout: TimeInterval = 10
 
     static func live(
         accountClient: IronsmithAccountClient = .unconfigured,

--- a/Ironsmith/Core/Inference/Wiring/InferenceDependencies.swift
+++ b/Ironsmith/Core/Inference/Wiring/InferenceDependencies.swift
@@ -33,7 +33,7 @@ extension InferenceDependencies {
         let credentialClient = CredentialClient.live
         let localModelClient = LocalModelClient.live
         let accountClient = IronsmithAccountClient.live
-        let openAICodexAuthClient = OpenAICodexAuthClient.live(credentialClient: credentialClient)
+        let openAICodexAuthClient = OpenAICodexAuthClient.live()
         return Self(
             credentialClient: credentialClient,
             accountClient: accountClient,

--- a/Ironsmith/Core/Inference/Wiring/InferenceDependencies.swift
+++ b/Ironsmith/Core/Inference/Wiring/InferenceDependencies.swift
@@ -3,6 +3,7 @@ import Foundation
 struct InferenceDependencies {
     var credentialClient: CredentialClient
     var accountClient: IronsmithAccountClient
+    var openAICodexAuthClient: OpenAICodexAuthClient
     var remoteModelClient: RemoteModelClient
     var localModelClient: LocalModelClient
     var ollamaClient: OllamaClient
@@ -11,6 +12,7 @@ struct InferenceDependencies {
     init(
         credentialClient: CredentialClient,
         accountClient: IronsmithAccountClient = .unconfigured,
+        openAICodexAuthClient: OpenAICodexAuthClient = .unconfigured,
         remoteModelClient: RemoteModelClient,
         localModelClient: LocalModelClient,
         ollamaClient: OllamaClient,
@@ -18,6 +20,7 @@ struct InferenceDependencies {
     ) {
         self.credentialClient = credentialClient
         self.accountClient = accountClient
+        self.openAICodexAuthClient = openAICodexAuthClient
         self.remoteModelClient = remoteModelClient
         self.localModelClient = localModelClient
         self.ollamaClient = ollamaClient
@@ -30,16 +33,22 @@ extension InferenceDependencies {
         let credentialClient = CredentialClient.live
         let localModelClient = LocalModelClient.live
         let accountClient = IronsmithAccountClient.live
+        let openAICodexAuthClient = OpenAICodexAuthClient.live(credentialClient: credentialClient)
         return Self(
             credentialClient: credentialClient,
             accountClient: accountClient,
-            remoteModelClient: .live(accountClient: accountClient),
+            openAICodexAuthClient: openAICodexAuthClient,
+            remoteModelClient: .live(
+                accountClient: accountClient,
+                openAICodexAuthClient: openAICodexAuthClient
+            ),
             localModelClient: localModelClient,
             ollamaClient: .live,
             languageModelClient: .live(
                 credentialClient: credentialClient,
                 localModelClient: localModelClient,
-                accountClient: accountClient
+                accountClient: accountClient,
+                openAICodexAuthClient: openAICodexAuthClient
             )
         )
     }

--- a/Ironsmith/Core/Persistence/Configuration/IronsmithPaths.swift
+++ b/Ironsmith/Core/Persistence/Configuration/IronsmithPaths.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum IronsmithPaths {
+nonisolated enum IronsmithPaths {
     static let databaseFileName = "ironsmith.sqlite"
 
     static var rootDirectory: URL {
@@ -28,6 +28,14 @@ enum IronsmithPaths {
         rootDirectory.appendingPathComponent("tools", isDirectory: true)
     }
 
+    static var codexHomeDirectory: URL {
+        rootDirectory.appendingPathComponent(".codex", isDirectory: true)
+    }
+
+    static var codexAuthFileURL: URL {
+        codexHomeDirectory.appendingPathComponent("auth.json")
+    }
+
     static var agentDiagnosticsLogURL: URL {
         rootDirectory.appendingPathComponent("agent-diagnostics.log")
     }
@@ -38,6 +46,7 @@ enum IronsmithPaths {
             databaseBackupsDirectory,
             modelsDirectory,
             toolsDirectory,
+            codexHomeDirectory,
         ] {
             try FileManager.default.createDirectory(
                 at: directory,

--- a/Ironsmith/Features/Settings/Sheets/AddProvider/AddProviderSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/AddProvider/AddProviderSheetView.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import AppKit
 import SwiftUI
 
 struct AddProviderSheetView: View {
@@ -13,9 +14,14 @@ struct AddProviderSheetView: View {
     @State private var baseURLString = ""
     @State private var apiKey = ""
     @State private var isSaving = false
+    @State private var isSigningInToChatGPT = false
 
     private var isCustomOpenAICompatible: Bool {
         selectedChoice?.kind == .customOpenAICompatible
+    }
+
+    private var isOpenAI: Bool {
+        selectedChoice?.kind == .openAI
     }
 
     private var isIronsmith: Bool {
@@ -114,27 +120,53 @@ struct AddProviderSheetView: View {
                 }
             }
 
-            Section {
-                if isCustomOpenAICompatible {
-                    TextField("Display Name", text: $displayName, prompt: Text("LM Studio"))
+            if isOpenAI {
+                Section {
+                    SecureField("API Key", text: $apiKey, prompt: Text("Optional"))
+                } header: {
+                    Text("API Key")
                 }
 
-                if usesEditableConnection {
-                    TextField(
-                        isOllama ? "Server URL" : "Base URL",
-                        text: $baseURLString,
-                        prompt: Text(
-                            isOllama ? "http://localhost:11434" : "http://localhost:1234/v1")
+                Section {
+                    HStack {
+                        LabeledContent("ChatGPT") {
+                            Text(openAIChatGPTStatusText)
+                                .foregroundStyle(inferenceStore.hasOpenAICodexCredential ? .primary : .secondary)
+                        }
+
+                        Spacer()
+
+                        Button(openAIChatGPTButtonTitle) {
+                            signInWithOpenAIChatGPT()
+                        }
+                        .disabled(isSaving || isSigningInToChatGPT)
+                    }
+                } header: {
+                    Text("ChatGPT")
+                }
+            } else {
+                Section {
+                    if isCustomOpenAICompatible {
+                        TextField("Display Name", text: $displayName, prompt: Text("LM Studio"))
+                    }
+
+                    if usesEditableConnection {
+                        TextField(
+                            isOllama ? "Server URL" : "Base URL",
+                            text: $baseURLString,
+                            prompt: Text(
+                                isOllama ? "http://localhost:11434" : "http://localhost:1234/v1")
+                        )
+                    }
+
+                    SecureField(
+                        "API Key",
+                        text: $apiKey,
+                        prompt: Text(isCustomOpenAICompatible || isOllama ? "Optional" : "Required")
                     )
+                } header: {
+                    Text(usesEditableConnection ? "Connection" : "Authentication")
                 }
-
-                SecureField(
-                    "API Key",
-                    text: $apiKey,
-                    prompt: Text(isCustomOpenAICompatible || isOllama ? "Optional" : "Required")
-                )
-            } header: {
-                Text(usesEditableConnection ? "Connection" : "Authentication")
             }
         }
         .formStyle(.grouped)
@@ -158,6 +190,11 @@ struct AddProviderSheetView: View {
             return trimmedBaseURLString.isEmpty
                 || (ProviderBaseURLValidator.usesLoopbackHost(trimmedBaseURLString)
                     && inferenceStore.ollamaInstallationStatus != .installed)
+        }
+
+        if isOpenAI {
+            return apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !inferenceStore.hasOpenAICodexCredential
         }
 
         return apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -184,6 +221,14 @@ struct AddProviderSheetView: View {
             displayName = ""
             baseURLString = ""
         }
+    }
+
+    private var openAIChatGPTStatusText: String {
+        inferenceStore.openAICodexCredential?.statusText ?? "Not signed in"
+    }
+
+    private var openAIChatGPTButtonTitle: String {
+        isSigningInToChatGPT ? "Signing In..." : "Sign In"
     }
 
     private func signInWithAppleOAuth() {
@@ -226,6 +271,45 @@ struct AddProviderSheetView: View {
                     onProviderAdded(selectedChoice.kind)
                     dismiss()
                 }
+            }
+        }
+    }
+
+    private func signInWithOpenAIChatGPT() {
+        guard !isSaving, !isSigningInToChatGPT else { return }
+        guard let selectedChoice, selectedChoice.kind == .openAI else { return }
+        isSigningInToChatGPT = true
+
+        Task {
+            let didSignIn = await inferenceStore.signInToOpenAIChatGPT { @MainActor url in
+                guard NSWorkspace.shared.open(url) else {
+                    throw OpenAICodexAuthClientError.browserLaunchFailed
+                }
+            }
+
+            if didSignIn {
+                await MainActor.run {
+                    isSaving = true
+                }
+                let didAdd = await inferenceStore.addProvider(
+                    choice: selectedChoice,
+                    apiKey: apiKey,
+                    displayName: displayName,
+                    baseURLString: baseURLString
+                )
+                await MainActor.run {
+                    isSaving = false
+                    isSigningInToChatGPT = false
+                    if didAdd {
+                        onProviderAdded(.openAI)
+                        dismiss()
+                    }
+                }
+                return
+            }
+
+            await MainActor.run {
+                isSigningInToChatGPT = false
             }
         }
     }

--- a/Ironsmith/Features/Settings/Sheets/AddProvider/AddProviderSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/AddProvider/AddProviderSheetView.swift
@@ -1,5 +1,4 @@
 import AuthenticationServices
-import AppKit
 import SwiftUI
 
 struct AddProviderSheetView: View {
@@ -281,11 +280,7 @@ struct AddProviderSheetView: View {
         isSigningInToChatGPT = true
 
         Task {
-            let didSignIn = await inferenceStore.signInToOpenAIChatGPT { @MainActor url in
-                guard NSWorkspace.shared.open(url) else {
-                    throw OpenAICodexAuthClientError.browserLaunchFailed
-                }
-            }
+            let didSignIn = await inferenceStore.signInToOpenAIChatGPT()
 
             if didSignIn {
                 await MainActor.run {

--- a/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
@@ -1,4 +1,5 @@
 import Supabase
+import AppKit
 import SwiftUI
 
 struct ProviderEditorSheetView: View {
@@ -15,6 +16,8 @@ struct ProviderEditorSheetView: View {
     @State private var isConfirmingAccountDeletionWithCredits = false
     @State private var isShowingCreditPacks = false
     @State private var isSigningOut = false
+    @State private var isSigningInToChatGPT = false
+    @State private var isSigningOutOfChatGPT = false
     @State private var isDeletingAccount = false
 
     private var isCustomOpenAICompatible: Bool {
@@ -23,6 +26,10 @@ struct ProviderEditorSheetView: View {
 
     private var isIronsmith: Bool {
         provider.kind == .ironsmith
+    }
+
+    private var isOpenAI: Bool {
+        provider.kind == .openAI
     }
 
     private var isOllama: Bool {
@@ -71,6 +78,8 @@ struct ProviderEditorSheetView: View {
                     } header: {
                         Text("Billing")
                     }
+                } else if isOpenAI {
+                    openAIAuthenticationSections
                 } else {
                     if usesEditableConnection {
                         Section {
@@ -169,6 +178,9 @@ struct ProviderEditorSheetView: View {
             if isIronsmith {
                 inferenceStore.refreshIronsmithSession()
             }
+            if isOpenAI {
+                inferenceStore.refreshOpenAICodexCredential()
+            }
         }
         .task(id: provider.identifier) {
             if isIronsmith {
@@ -238,6 +250,40 @@ struct ProviderEditorSheetView: View {
     }
 
     @ViewBuilder
+    private var openAIAuthenticationSections: some View {
+        Section {
+            SecureField("API Key", text: $apiKey, prompt: Text("Optional"))
+        } header: {
+            Text("API Key")
+        }
+
+        Section {
+            HStack {
+                LabeledContent("ChatGPT") {
+                    Text(openAIChatGPTStatusText)
+                        .foregroundStyle(inferenceStore.hasOpenAICodexCredential ? .primary : .secondary)
+                }
+
+                Spacer()
+
+                if inferenceStore.hasOpenAICodexCredential {
+                    Button(openAIChatGPTSignOutTitle) {
+                        signOutOpenAIChatGPT()
+                    }
+                    .disabled(isSigningInToChatGPT || isSigningOutOfChatGPT)
+                } else {
+                    Button(openAIChatGPTSignInTitle) {
+                        signInWithOpenAIChatGPT()
+                    }
+                    .disabled(isSigningInToChatGPT || isSigningOutOfChatGPT)
+                }
+            }
+        } header: {
+            Text("ChatGPT")
+        }
+    }
+
+    @ViewBuilder
     private var ironsmithAccountRows: some View {
         if let summary = inferenceStore.ironsmithAccountSummary {
             LabeledContent("Email") {
@@ -267,6 +313,18 @@ struct ProviderEditorSheetView: View {
         inferenceStore.ironsmithAccountSummary?.credits.balanceCredits
     }
 
+    private var openAIChatGPTStatusText: String {
+        inferenceStore.openAICodexCredential?.statusText ?? "Not signed in"
+    }
+
+    private var openAIChatGPTSignInTitle: String {
+        isSigningInToChatGPT ? "Signing In..." : "Sign In"
+    }
+
+    private var openAIChatGPTSignOutTitle: String {
+        isSigningOutOfChatGPT ? "Signing Out..." : "Sign Out"
+    }
+
     private func signOut() {
         guard !isSigningOut else { return }
 
@@ -292,6 +350,43 @@ struct ProviderEditorSheetView: View {
                 isDeletingAccount = false
                 if didDelete {
                     dismiss()
+                }
+            }
+        }
+    }
+
+    private func signInWithOpenAIChatGPT() {
+        guard !isSigningInToChatGPT, !isSigningOutOfChatGPT else { return }
+
+        isSigningInToChatGPT = true
+        Task {
+            let didSignIn = await inferenceStore.signInToOpenAIChatGPT { @MainActor url in
+                guard NSWorkspace.shared.open(url) else {
+                    throw OpenAICodexAuthClientError.browserLaunchFailed
+                }
+            }
+
+            await MainActor.run {
+                isSigningInToChatGPT = false
+                if didSignIn {
+                    inferenceStore.refreshOpenAICodexCredential()
+                }
+            }
+        }
+    }
+
+    private func signOutOpenAIChatGPT() {
+        guard !isSigningInToChatGPT, !isSigningOutOfChatGPT else { return }
+
+        isSigningOutOfChatGPT = true
+        Task {
+            let didSignOut = await MainActor.run {
+                inferenceStore.signOutOpenAIChatGPT(provider: provider)
+            }
+            await MainActor.run {
+                isSigningOutOfChatGPT = false
+                if didSignOut {
+                    inferenceStore.refreshOpenAICodexCredential()
                 }
             }
         }

--- a/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
@@ -1,5 +1,4 @@
 import Supabase
-import AppKit
 import SwiftUI
 
 struct ProviderEditorSheetView: View {
@@ -207,8 +206,12 @@ struct ProviderEditorSheetView: View {
             isPresented: $isConfirmingDelete
         ) {
             Button("Delete Provider", role: .destructive) {
-                inferenceStore.removeProvider(provider)
-                dismiss()
+                Task {
+                    await inferenceStore.removeProvider(provider)
+                    await MainActor.run {
+                        dismiss()
+                    }
+                }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -360,11 +363,7 @@ struct ProviderEditorSheetView: View {
 
         isSigningInToChatGPT = true
         Task {
-            let didSignIn = await inferenceStore.signInToOpenAIChatGPT { @MainActor url in
-                guard NSWorkspace.shared.open(url) else {
-                    throw OpenAICodexAuthClientError.browserLaunchFailed
-                }
-            }
+            let didSignIn = await inferenceStore.signInToOpenAIChatGPT()
 
             await MainActor.run {
                 isSigningInToChatGPT = false
@@ -380,9 +379,7 @@ struct ProviderEditorSheetView: View {
 
         isSigningOutOfChatGPT = true
         Task {
-            let didSignOut = await MainActor.run {
-                inferenceStore.signOutOpenAIChatGPT(provider: provider)
-            }
+            let didSignOut = await inferenceStore.signOutOpenAIChatGPT(provider: provider)
             await MainActor.run {
                 isSigningOutOfChatGPT = false
                 if didSignOut {

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
@@ -108,6 +108,20 @@ extension AgentPipelineTests {
 
     @MainActor
     @Test
+    func livePromptRefinementClientStreamsPlainTextResponse() async throws {
+        let refinedPrompt = "Build a mortgage calculator with purchase price, down payment, interest, taxes, insurance, and a clear monthly payment summary."
+        let refined = await ToolPromptRefinementClient.live().refinePrompt(
+            userPrompt: "Make a mortgage calculator",
+            languageModel: StreamOnlyPromptRefinementLanguageModel(response: refinedPrompt),
+            generationOptions: GenerationOptions(maximumResponseTokens: 4096),
+            sandboxEnabled: true
+        )
+
+        #expect(refined == refinedPrompt)
+    }
+
+    @MainActor
+    @Test
     func livePromptRefinementClientIncludesMenuBarAppTypeContext() async throws {
         let promptCapture = PromptCapture()
         let refinedPrompt = "Build a compact menu bar timer with start, pause, reset, and a current-session summary."
@@ -270,5 +284,34 @@ extension AgentPipelineTests {
         #expect(!(prompts.first?.contains("Rewrite the whole app with unrelated features.") ?? false))
         #expect(await metadataCapture.count == 0)
         #expect(await promptRefinementCapture.count == 0)
+    }
+}
+
+private struct StreamOnlyPromptRefinementLanguageModel: LanguageModel {
+    typealias UnavailableReason = Never
+
+    let response: String
+
+    func respond<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) async throws -> LanguageModelSession.Response<Content> where Content: Generable {
+        throw FakeAgentError.expected
+    }
+
+    func streamResponse<Content>(
+        within session: LanguageModelSession,
+        to prompt: Prompt,
+        generating type: Content.Type,
+        includeSchemaInPrompt: Bool,
+        options: GenerationOptions
+    ) -> sending LanguageModelSession.ResponseStream<Content> where Content: Generable {
+        LanguageModelSession.ResponseStream(
+            content: response as! Content,
+            rawContent: GeneratedContent(response)
+        )
     }
 }

--- a/IronsmithTests/Core/Inference/CodexAuthFileClientTests.swift
+++ b/IronsmithTests/Core/Inference/CodexAuthFileClientTests.swift
@@ -1,0 +1,301 @@
+import Foundation
+import Testing
+@testable import Ironsmith
+
+extension InferenceTests {
+    @Test
+    func codexAuthFileClientParsesChatGPTAuthFileShape() throws {
+        let expiration = Date(timeIntervalSince1970: 1_900_000_000)
+        let accessToken = Self.testJWT(payload: [
+            "exp": expiration.timeIntervalSince1970,
+            "https://api.openai.com/auth": [
+                "chatgpt_account_id": "claim-account",
+            ],
+        ])
+        let idToken = Self.testJWT(payload: [
+            "email": "jade@example.com",
+            "chatgpt_account_id": "id-account",
+        ])
+        let data = """
+        {
+          "auth_mode": "chatgpt",
+          "OPENAI_API_KEY": null,
+          "tokens": {
+            "id_token": "\(idToken)",
+            "access_token": "\(accessToken)",
+            "refresh_token": "rt.test",
+            "account_id": "auth-file-account"
+          },
+          "last_refresh": "2026-07-05T05:40:41.597781Z"
+        }
+        """.data(using: .utf8)!
+
+        let parsedCredential = try CodexAuthFileClient.credential(from: data)
+        let credential = try #require(parsedCredential)
+
+        #expect(credential.accessToken == accessToken)
+        #expect(credential.refreshToken == "rt.test")
+        #expect(credential.idToken == idToken)
+        #expect(credential.accountID == "auth-file-account")
+        #expect(credential.email == "jade@example.com")
+        #expect(credential.expiresAt?.timeIntervalSince1970 == expiration.timeIntervalSince1970)
+    }
+
+    @Test
+    func codexAuthFileClientReturnsNilForMissingOrNonChatGPTAuth() throws {
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("IronsmithTests.\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("auth.json")
+        let missingCredential = try CodexAuthFileClient.credential(from: missingURL)
+        #expect(missingCredential == nil)
+
+        let apiKeyAuthData = """
+        {
+          "auth_mode": "api_key",
+          "tokens": {
+            "access_token": "ignored"
+          }
+        }
+        """.data(using: .utf8)!
+        let apiKeyCredential = try CodexAuthFileClient.credential(from: apiKeyAuthData)
+        #expect(apiKeyCredential == nil)
+    }
+
+    @Test
+    func codexAuthFileClientRejectsInvalidAuthFile() throws {
+        do {
+            _ = try CodexAuthFileClient.credential(from: #"{"auth_mode":"chatgpt"}"#.data(using: .utf8)!)
+            Issue.record("Expected missing tokens to be rejected.")
+        } catch let error as OpenAICodexAuthClientError {
+            #expect(error == .invalidAuthFile)
+        }
+
+        do {
+            _ = try CodexAuthFileClient.credential(from: #"{"auth_mode":"chatgpt","tokens":{}}"#.data(using: .utf8)!)
+            Issue.record("Expected missing access token to be rejected.")
+        } catch let error as OpenAICodexAuthClientError {
+            #expect(error == .invalidAuthFile)
+        }
+    }
+
+    @Test
+    func openAICodexValidCredentialRefreshesStaleJWTAndRewritesAuthFile() async throws {
+        let directory = try Self.temporaryDirectory()
+        let authFileURL = directory.appendingPathComponent("auth.json")
+        let staleAccessToken = Self.testJWT(payload: [
+            "exp": Date().addingTimeInterval(-60).timeIntervalSince1970,
+        ])
+        let existingData = """
+        {
+          "auth_mode": "chatgpt",
+          "preserved": {
+            "value": true
+          },
+          "tokens": {
+            "access_token": "\(staleAccessToken)",
+            "refresh_token": "old-refresh",
+            "id_token": "old-id",
+            "account_id": "old-account"
+          }
+        }
+        """.data(using: .utf8)!
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try existingData.write(to: authFileURL)
+
+        let refreshedExpiration = Date().addingTimeInterval(60 * 60)
+        let refreshedCredential = OpenAICodexCredential(
+            accessToken: Self.testJWT(payload: ["exp": refreshedExpiration.timeIntervalSince1970]),
+            refreshToken: "new-refresh",
+            expiresAt: refreshedExpiration,
+            idToken: "new-id",
+            accountID: "new-account",
+            email: "new@example.com"
+        )
+        let authClient = OpenAICodexAuthClient.live(
+            codexCLIClient: .unconfigured,
+            authFileClient: .live(authFileURL: authFileURL),
+            refreshCredential: { oldCredential in
+                #expect(oldCredential.accessToken == staleAccessToken)
+                #expect(oldCredential.refreshToken == "old-refresh")
+                return refreshedCredential
+            }
+        )
+
+        let credential = try await authClient.validCredential()
+        let rewrittenRoot = try Self.jsonObject(from: Data(contentsOf: authFileURL))
+        let rewrittenTokens = try #require(rewrittenRoot["tokens"] as? [String: Any])
+        let preserved = try #require(rewrittenRoot["preserved"] as? [String: Any])
+
+        #expect(credential == refreshedCredential)
+        #expect(rewrittenTokens["access_token"] as? String == refreshedCredential.accessToken)
+        #expect(rewrittenTokens["refresh_token"] as? String == "new-refresh")
+        #expect(rewrittenTokens["id_token"] as? String == "new-id")
+        #expect(rewrittenTokens["account_id"] as? String == "new-account")
+        #expect(preserved["value"] as? Bool == true)
+        #expect(rewrittenRoot["last_refresh"] as? String != nil)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: authFileURL.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+    }
+
+    @Test
+    func openAICodexValidCredentialRejectsStaleMalformedJWTWithoutRefreshToken() async throws {
+        let authClient = OpenAICodexAuthClient.live(
+            codexCLIClient: .unconfigured,
+            authFileClient: CodexAuthFileClient(
+                credential: {
+                    OpenAICodexCredential(accessToken: "not-a-jwt")
+                },
+                saveCredential: { _ in
+                    Issue.record("Missing refresh token should fail before saving.")
+                }
+            ),
+            refreshCredential: { credential in
+                try await OpenAICodexAuthClient.refreshCredential(credential)
+            }
+        )
+
+        do {
+            _ = try await authClient.validCredential()
+            Issue.record("Expected malformed JWT without refresh token to require sign-in.")
+        } catch let error as OpenAICodexAuthClientError {
+            #expect(error == .missingRefreshToken)
+        }
+    }
+
+    @Test
+    func codexCLIClientBuildsCommandsWithBundledExecutableAndCodexHome() async throws {
+        let directory = try Self.temporaryDirectory()
+        let codexHomeDirectory = directory.appendingPathComponent(".codex", isDirectory: true)
+        let executableURL = directory.appendingPathComponent("codex")
+        let recorder = CodexCLIRequestRecorder()
+        let client = CodexCLIClient.live(
+            codexHomeDirectory: codexHomeDirectory,
+            executableURL: executableURL,
+            bundleResourceURL: nil,
+            environment: ["PATH": "/usr/bin"],
+            runProcess: { request in
+                await recorder.record(request)
+                return CodexCLIProcessResult(stdout: "", stderr: "", terminationStatus: 0)
+            }
+        )
+
+        try await client.signIn()
+        _ = try await client.loginStatus()
+        try await client.signOut()
+
+        let requests = await recorder.requests
+        #expect(requests.map(\.executableURL) == [executableURL, executableURL, executableURL])
+        #expect(requests.map(\.arguments) == [
+            ["login"],
+            ["login", "status"],
+            ["logout"],
+        ])
+        #expect(requests.allSatisfy { $0.currentDirectoryURL == codexHomeDirectory })
+        #expect(requests.allSatisfy { $0.environment["CODEX_HOME"] == codexHomeDirectory.path })
+        #expect(FileManager.default.fileExists(atPath: codexHomeDirectory.path))
+    }
+
+    @Test
+    func codexCLIClientRedactsTokenShapedCommandFailures() async throws {
+        let directory = try Self.temporaryDirectory()
+        let client = CodexCLIClient.live(
+            codexHomeDirectory: directory.appendingPathComponent(".codex", isDirectory: true),
+            executableURL: directory.appendingPathComponent("codex"),
+            bundleResourceURL: nil,
+            environment: [:],
+            runProcess: { _ in
+                CodexCLIProcessResult(
+                    stdout: #""access_token": "eyJ.header.payload""#,
+                    stderr: #"Bearer eyJ.access.payload and refresh_token: rt.1.secret"#,
+                    terminationStatus: 1
+                )
+            }
+        )
+
+        do {
+            try await client.signIn()
+            Issue.record("Expected Codex command failure.")
+        } catch let error as OpenAICodexAuthClientError {
+            guard case .codexCommandFailed(let message) = error else {
+                Issue.record("Expected codexCommandFailed, got \(error).")
+                return
+            }
+            #expect(!message.contains("eyJ.header.payload"))
+            #expect(!message.contains("eyJ.access.payload"))
+            #expect(!message.contains("rt.1.secret"))
+            #expect(message.contains("[redacted]") || message.contains("[jwt-redacted]"))
+        }
+    }
+
+    @Test
+    func codexCLIClientLocatesBundledVendorBinaryForCurrentArchitecture() throws {
+        let resourcesURL = try Self.temporaryDirectory()
+        let codexResourceURL = resourcesURL.appendingPathComponent("Codex", isDirectory: true)
+        let vendorURL = resourcesURL
+            .appendingPathComponent("Codex", isDirectory: true)
+            .appendingPathComponent("vendor", isDirectory: true)
+            .appendingPathComponent(Self.testCodexTargetTriple, isDirectory: true)
+        let versionURL = codexResourceURL.appendingPathComponent("version.txt")
+        let executableURL = vendorURL.appendingPathComponent("codex")
+        try FileManager.default.createDirectory(at: vendorURL, withIntermediateDirectories: true)
+        try Data().write(to: executableURL)
+        try "0.200.0\n".write(to: versionURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o755))],
+            ofItemAtPath: executableURL.path
+        )
+
+        let resolvedURL = try CodexCLIClient.bundledExecutableURL(resourceURL: resourcesURL)
+
+        #expect(resolvedURL == executableURL)
+        #expect(CodexCLIClient.bundledVersion(resourceURL: resourcesURL) == "0.200.0")
+    }
+
+    private static func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("IronsmithTests.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func jsonObject(from data: Data) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try #require(object as? [String: Any])
+    }
+
+    private static func testJWT(payload: [String: Any]) -> String {
+        let header = [
+            "alg": "none",
+            "typ": "JWT",
+        ]
+        let headerData = try! JSONSerialization.data(withJSONObject: header, options: [.sortedKeys])
+        let payloadData = try! JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        return "\(Self.base64URL(headerData)).\(Self.base64URL(payloadData)).signature"
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private static var testCodexTargetTriple: String {
+        #if arch(arm64)
+        return "aarch64-apple-darwin"
+        #elseif arch(x86_64)
+        return "x86_64-apple-darwin"
+        #else
+        return "unsupported-apple-darwin"
+        #endif
+    }
+}
+
+private actor CodexCLIRequestRecorder {
+    private(set) var requests: [CodexCLIProcessRequest] = []
+
+    func record(_ request: CodexCLIProcessRequest) {
+        requests.append(request)
+    }
+}

--- a/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
@@ -134,6 +134,72 @@ extension InferenceTests {
 
     @MainActor
     @Test
+    func languageModelClientBuildsOpenAICodexLanguageModel() async throws {
+        let provider = ProviderCatalog.makeProvider(for: .openAI)!
+        let model = ModelConfig(
+            identifier: "codex:gpt-5.5",
+            displayName: "GPT-5.5 (Codex)",
+            providerIdentifier: provider.identifier,
+            source: .remote,
+            installState: .installed
+        )
+        let authClient = OpenAICodexAuthClient(
+            credential: {
+                OpenAICodexCredential(accessToken: "codex-token", accountID: "account-id")
+            },
+            signIn: { _ in
+                OpenAICodexCredential(accessToken: "codex-token", accountID: "account-id")
+            },
+            signOut: {},
+            validCredential: {
+                OpenAICodexCredential(accessToken: "codex-token", accountID: "account-id")
+            },
+            discoverModels: { [] }
+        )
+        let client = LanguageModelClient.live(
+            credentialClient: CredentialClient(
+                loadAPIKey: { _ in nil },
+                saveAPIKey: { _, _ in },
+                deleteAPIKey: { _ in }
+            ),
+            localModelClient: Self.fakeLocalModelClient(),
+            openAICodexAuthClient: authClient
+        )
+
+        let languageModel = try await client.makeLanguageModel(model, provider)
+        let openAIModel = try #require(languageModel as? OpenAILanguageModel)
+
+        #expect(openAIModel.model == "gpt-5.5")
+        #expect(openAIModel.baseURL == OpenAICodexBackend.backendBaseURL)
+    }
+
+    @MainActor
+    @Test
+    func openAICodexGenerationOptionsOmitMaxTokensAndDisableStorage() {
+        let model = ModelConfig(
+            identifier: "codex:gpt-5.5",
+            displayName: "GPT-5.5 (Codex)",
+            providerIdentifier: ProviderKind.openAI.rawValue,
+            source: .remote,
+            installState: .installed
+        )
+
+        let options = model.generationOptions(preferences: Self.generationPreferences())
+        let openAIOptions = options[custom: OpenAILanguageModel.self]
+
+        #expect(options.maximumResponseTokens == nil)
+        #expect(openAIOptions?.store == false)
+
+        let customPreferences = Self.generationPreferences()
+        customPreferences.customOptionsEnabled = true
+        customPreferences.maximumResponseTokens = 8192
+
+        let customOptions = model.generationOptions(preferences: customPreferences)
+        #expect(customOptions.maximumResponseTokens == nil)
+    }
+
+    @MainActor
+    @Test
     func selectionIdentifierWorksForPersistedAndTransientModels() {
         let localModel = ModelConfig(
             identifier: ModelConfig.appleFoundationIdentifier,

--- a/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
@@ -147,7 +147,7 @@ extension InferenceTests {
             credential: {
                 OpenAICodexCredential(accessToken: "codex-token", accountID: "account-id")
             },
-            signIn: { _ in
+            signIn: {
                 OpenAICodexCredential(accessToken: "codex-token", accountID: "account-id")
             },
             signOut: {},
@@ -196,6 +196,46 @@ extension InferenceTests {
 
         let customOptions = model.generationOptions(preferences: customPreferences)
         #expect(customOptions.maximumResponseTokens == nil)
+    }
+
+    @MainActor
+    @Test
+    func openAICodexGenerationOptionsSanitizerRemovesUnsupportedParameters() {
+        let languageModel = OpenAILanguageModel(
+            baseURL: OpenAICodexBackend.backendBaseURL,
+            apiKey: "token",
+            model: "gpt-5.5",
+            apiVariant: .responses
+        )
+        var options = GenerationOptions(maximumResponseTokens: 8192)
+        var openAIOptions = OpenAILanguageModel.CustomGenerationOptions()
+        openAIOptions.store = true
+        options[custom: OpenAILanguageModel.self] = openAIOptions
+
+        let sanitized = OpenAICodexGenerationOptions.sanitized(options, for: languageModel)
+
+        #expect(sanitized.maximumResponseTokens == nil)
+        #expect(sanitized[custom: OpenAILanguageModel.self]?.store == false)
+    }
+
+    @MainActor
+    @Test
+    func openAICodexGenerationOptionsSanitizerLeavesNormalOpenAIOptionsUnchanged() {
+        let languageModel = OpenAILanguageModel(
+            baseURL: OpenAILanguageModel.defaultBaseURL,
+            apiKey: "token",
+            model: "gpt-5.5",
+            apiVariant: .responses
+        )
+        var options = GenerationOptions(maximumResponseTokens: 8192)
+        var openAIOptions = OpenAILanguageModel.CustomGenerationOptions()
+        openAIOptions.store = true
+        options[custom: OpenAILanguageModel.self] = openAIOptions
+
+        let sanitized = OpenAICodexGenerationOptions.sanitized(options, for: languageModel)
+
+        #expect(sanitized.maximumResponseTokens == 8192)
+        #expect(sanitized[custom: OpenAILanguageModel.self]?.store == true)
     }
 
     @MainActor

--- a/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
@@ -394,6 +394,58 @@ extension InferenceTests {
 
     @MainActor
     @Test
+    func openAICodexModelDiscoveryLabelsModelsInsideOpenAIProvider() async throws {
+        let provider = ProviderCatalog.makeProvider(for: .openAI)!
+        let authClient = OpenAICodexAuthClient(
+            credential: {
+                OpenAICodexCredential(accessToken: "access-token")
+            },
+            signIn: { _ in
+                OpenAICodexCredential(accessToken: "access-token")
+            },
+            signOut: {},
+            validCredential: {
+                OpenAICodexCredential(accessToken: "access-token")
+            },
+            discoverModels: {
+                [
+                    OpenAICodexModel(identifier: "gpt-5.5", displayName: "GPT-5.5"),
+                    OpenAICodexModel(identifier: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
+                ]
+            }
+        )
+        let client = RemoteModelClient.live(openAICodexAuthClient: authClient)
+
+        let models = try await client.discoverModels(provider, nil)
+
+        #expect(models.map(\.identifier) == ["codex:gpt-5.4-mini", "codex:gpt-5.5"])
+        #expect(models.map(\.displayName) == ["GPT-5.4 Mini (Codex)", "GPT-5.5 (Codex)"])
+        #expect(models.allSatisfy { $0.providerIdentifier == provider.identifier })
+    }
+
+    @Test
+    func openAICodexModelDecoderHandlesCatalogShapes() throws {
+        let data = """
+        {
+          "models": [
+            {"id": "gpt-5.5", "display_name": "GPT-5.5"},
+            {"slug": "o4-mini", "title": "o4 mini"},
+            {"id": "codex-auto-review", "display_name": "Codex Auto Review"},
+            {"id": "gpt-image-1", "display_name": "GPT Image"},
+            {"id": "text-embedding-3-small", "display_name": "Embedding"},
+            {"id": "gpt-5.5", "display_name": "Duplicate"}
+          ]
+        }
+        """.data(using: .utf8)!
+
+        let models = try OpenAICodexAuthClient.decodeModels(data)
+
+        #expect(models.map(\.identifier) == ["gpt-5.5", "o4-mini"])
+        #expect(models.map(\.displayName) == ["GPT-5.5", "o4 mini"])
+    }
+
+    @MainActor
+    @Test
     func customOpenAICompatibleDiscoveryAllowsNonOpenAIPrefixes() throws {
         let customProvider = ProviderConfig(
             identifier: "custom.test",

--- a/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
@@ -400,7 +400,7 @@ extension InferenceTests {
             credential: {
                 OpenAICodexCredential(accessToken: "access-token")
             },
-            signIn: { _ in
+            signIn: {
                 OpenAICodexCredential(accessToken: "access-token")
             },
             signOut: {},

--- a/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
@@ -54,6 +54,83 @@ extension InferenceTests {
 
     @MainActor
     @Test
+    func removingAPIKeyOpenAIProviderDoesNotRequireCodexLogout() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let codexLogout = CodexLogoutRecorder()
+        let authClient = OpenAICodexAuthClient(
+            credential: { nil },
+            signIn: { throw OpenAICodexAuthClientError.missingCredential },
+            signOut: {
+                await codexLogout.record()
+                throw OpenAICodexAuthClientError.missingCodexBinary("Missing Codex")
+            },
+            validCredential: { throw OpenAICodexAuthClientError.missingCredential },
+            discoverModels: { throw OpenAICodexAuthClientError.missingCredential }
+        )
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteModelIDs: ["gpt-test"],
+                openAICodexAuthClient: authClient
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+        let didAdd = await inferenceStore.addProvider(
+            choice: .init(descriptor: ProviderCatalog.descriptor(for: .openAI)!),
+            apiKey: "test-key"
+        )
+        let provider = try #require(inferenceStore.providers.first { $0.kind == .openAI })
+
+        await inferenceStore.removeProvider(provider)
+
+        #expect(didAdd)
+        #expect(await codexLogout.callCount == 0)
+        #expect(!(inferenceStore.providers.contains { $0.kind == .openAI }))
+        #expect(inferenceStore.presentedErrorMessage == nil)
+    }
+
+    @MainActor
+    @Test
+    func removingOpenAIProviderPreservesAPIKeyWhenCodexLogoutFails() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let codexLogout = CodexLogoutRecorder()
+        let authClient = OpenAICodexAuthClient(
+            credential: { OpenAICodexCredential(accessToken: "codex-token") },
+            signIn: { OpenAICodexCredential(accessToken: "codex-token") },
+            signOut: {
+                await codexLogout.record()
+                throw OpenAICodexAuthClientError.missingCodexBinary("Missing Codex")
+            },
+            validCredential: { OpenAICodexCredential(accessToken: "codex-token") },
+            discoverModels: { [] }
+        )
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteModelIDs: ["gpt-test"],
+                openAICodexAuthClient: authClient
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+        let didAdd = await inferenceStore.addProvider(
+            choice: .init(descriptor: ProviderCatalog.descriptor(for: .openAI)!),
+            apiKey: "test-key"
+        )
+        let provider = try #require(inferenceStore.providers.first { $0.kind == .openAI })
+
+        await inferenceStore.removeProvider(provider)
+
+        #expect(didAdd)
+        #expect(await codexLogout.callCount == 1)
+        #expect(inferenceStore.providers.contains { $0.kind == .openAI })
+        #expect(inferenceStore.apiKey(for: provider) == "test-key")
+        #expect(inferenceStore.presentedErrorMessage == "Missing Codex")
+    }
+
+    @MainActor
+    @Test
     func addingProviderDoesNotWaitForRemoteModelDiscovery() async throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
@@ -543,5 +620,13 @@ extension InferenceTests {
         }
 
         #expect(inferenceStore.availableProviderChoices.map(\.kind) == [.customOpenAICompatible])
+    }
+}
+
+private actor CodexLogoutRecorder {
+    private(set) var callCount = 0
+
+    func record() {
+        callCount += 1
     }
 }

--- a/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
@@ -32,6 +32,28 @@ extension InferenceTests {
 
     @MainActor
     @Test
+    func openAIProviderCanBeAddedWithChatGPTCredentialOnly() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(remoteModelIDs: ["codex:gpt-5.5"])
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+        inferenceStore.openAICodexCredential = OpenAICodexCredential(accessToken: "access-token")
+
+        let didAdd = await inferenceStore.addProvider(
+            choice: .init(descriptor: ProviderCatalog.descriptor(for: .openAI)!),
+            apiKey: ""
+        )
+
+        #expect(didAdd)
+        #expect(inferenceStore.providers.contains { $0.kind == .openAI })
+        #expect(inferenceStore.apiKey(for: inferenceStore.providers.first { $0.kind == .openAI }!) == "")
+    }
+
+    @MainActor
+    @Test
     func addingProviderDoesNotWaitForRemoteModelDiscovery() async throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)

--- a/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
@@ -181,7 +181,7 @@ extension InferenceTests {
         #expect(didSave)
         #expect(savedProvider.identifier == provider.identifier)
 
-        inferenceStore.removeProvider(provider)
+        await inferenceStore.removeProvider(provider)
 
         #expect(!(inferenceStore.providers.contains { $0.kind == .anthropic }))
         #expect(inferenceStore.remoteModels.isEmpty)

--- a/IronsmithTests/Core/Inference/InferenceTestSupport.swift
+++ b/IronsmithTests/Core/Inference/InferenceTestSupport.swift
@@ -78,7 +78,8 @@ extension InferenceTests {
         ollamaPullProgresses: [OllamaPullProgress] = [],
         ollamaPullResult: Result<Void, Error> = .success(()),
         ollamaDeleteResult: Result<Void, Error> = .success(()),
-        accountClient: IronsmithAccountClient = .unconfigured
+        accountClient: IronsmithAccountClient = .unconfigured,
+        openAICodexAuthClient: OpenAICodexAuthClient = .unconfigured
     ) -> InferenceDependencies {
         let credentialBox = CredentialBox()
         return InferenceDependencies(
@@ -94,6 +95,7 @@ extension InferenceTests {
                 }
             ),
             accountClient: accountClient,
+            openAICodexAuthClient: openAICodexAuthClient,
             remoteModelClient: RemoteModelClient { provider, _ in
                 await remoteDiscoveryHook?()
                 if let remoteDiscoveryScript {

--- a/script/build.sh
+++ b/script/build.sh
@@ -22,6 +22,7 @@ Builds the SwiftPM executable and stages dist/debug/Ironsmith.app or dist/releas
 
 Environment:
   Build-time backend values are read from Config/.env by default.
+  IRONSMITH_CODEX_VERSION pins the bundled Codex version. Defaults to latest.
 
 Options:
   --release                     Build with SwiftPM release configuration and Developer ID signing
@@ -123,6 +124,10 @@ RESOURCES_URL="$CONTENTS_URL/Resources"
 INFO_PLIST_URL="$CONTENTS_URL/Info.plist"
 ASSET_INFO_PLIST_URL="$RESOURCES_URL/asset-info.plist"
 APP_RESOURCES_SOURCE_URL="$REPO_ROOT/Ironsmith/Resources"
+CODEX_CACHE_ROOT="$REPO_ROOT/.build/ironsmith-codex"
+CODEX_VENDOR_RESOURCE_URL="$RESOURCES_URL/Codex/vendor"
+CODEX_ARM64_TRIPLE="aarch64-apple-darwin"
+CODEX_X64_TRIPLE="x86_64-apple-darwin"
 
 source_env_file() {
   local file="$1"
@@ -138,6 +143,7 @@ HAS_ENV_IRONSMITH_SUPABASE_URL=false
 HAS_ENV_IRONSMITH_SUPABASE_PUBLISHABLE_KEY=false
 HAS_ENV_IRONSMITH_API_BASE_URL=false
 HAS_ENV_IRONSMITH_DEV_SIGN_IDENTITY=false
+HAS_ENV_IRONSMITH_CODEX_VERSION=false
 
 if [[ "${IRONSMITH_SUPABASE_URL+x}" == x ]]; then
   HAS_ENV_IRONSMITH_SUPABASE_URL=true
@@ -159,6 +165,11 @@ if [[ "${IRONSMITH_DEV_SIGN_IDENTITY+x}" == x ]]; then
   ENV_IRONSMITH_DEV_SIGN_IDENTITY="$IRONSMITH_DEV_SIGN_IDENTITY"
 fi
 
+if [[ "${IRONSMITH_CODEX_VERSION+x}" == x ]]; then
+  HAS_ENV_IRONSMITH_CODEX_VERSION=true
+  ENV_IRONSMITH_CODEX_VERSION="$IRONSMITH_CODEX_VERSION"
+fi
+
 source_env_file "$CONFIG_DIR/.env"
 
 if [[ "$HAS_ENV_IRONSMITH_SUPABASE_URL" == true ]]; then
@@ -177,10 +188,15 @@ if [[ "$HAS_ENV_IRONSMITH_DEV_SIGN_IDENTITY" == true ]]; then
   IRONSMITH_DEV_SIGN_IDENTITY="$ENV_IRONSMITH_DEV_SIGN_IDENTITY"
 fi
 
+if [[ "$HAS_ENV_IRONSMITH_CODEX_VERSION" == true ]]; then
+  IRONSMITH_CODEX_VERSION="$ENV_IRONSMITH_CODEX_VERSION"
+fi
+
 IRONSMITH_SUPABASE_URL="${IRONSMITH_SUPABASE_URL:-}"
 IRONSMITH_SUPABASE_PUBLISHABLE_KEY="${IRONSMITH_SUPABASE_PUBLISHABLE_KEY:-}"
 IRONSMITH_API_BASE_URL="${IRONSMITH_API_BASE_URL:-}"
 IRONSMITH_DEV_SIGN_IDENTITY="${IRONSMITH_DEV_SIGN_IDENTITY:--}"
+IRONSMITH_CODEX_VERSION="${IRONSMITH_CODEX_VERSION:-latest}"
 
 if [[ -n "$SUPABASE_URL_OVERRIDE" ]]; then
   IRONSMITH_SUPABASE_URL="$SUPABASE_URL_OVERRIDE"
@@ -236,6 +252,114 @@ require_executable() {
     echo "Missing executable at $executable_url" >&2
     exit 1
   fi
+}
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required command: $command_name" >&2
+    exit 1
+  fi
+}
+
+resolve_codex_version() {
+  require_command npm
+
+  local resolved_version
+  resolved_version="$(npm view "@openai/codex@$IRONSMITH_CODEX_VERSION" version --silent)"
+  if [[ -z "$resolved_version" ]]; then
+    echo "Could not resolve @openai/codex@$IRONSMITH_CODEX_VERSION." >&2
+    exit 1
+  fi
+
+  printf '%s' "$resolved_version"
+}
+
+codex_vendor_has_binary() {
+  local vendor_dir="$1"
+  [[ -x "$vendor_dir/codex" || -x "$vendor_dir/bin/codex" ]]
+}
+
+download_codex_vendor() {
+  local resolved_version="$1"
+  local platform_suffix="$2"
+  local triple="$3"
+  local cache_dir="$CODEX_CACHE_ROOT/$resolved_version/$triple"
+
+  if codex_vendor_has_binary "$cache_dir"; then
+    echo "Using cached Codex $resolved_version ($triple)"
+    return 0
+  fi
+
+  local package_spec="@openai/codex@${resolved_version}-${platform_suffix}"
+  local tmp_dir="$CODEX_CACHE_ROOT/.tmp-$resolved_version-$platform_suffix-$$"
+  local tarball=""
+  local vendor_dir=""
+
+  echo "Downloading $package_spec"
+  rm -rf "$tmp_dir"
+  mkdir -p "$tmp_dir"
+  tarball="$(cd "$tmp_dir" && npm pack "$package_spec" --silent)"
+  tar -xzf "$tmp_dir/$tarball" -C "$tmp_dir"
+  vendor_dir="$(find "$tmp_dir/package" -type d -path "*/vendor/$triple" -print -quit)"
+
+  if [[ -z "$vendor_dir" || ! -d "$vendor_dir" ]]; then
+    echo "Package $package_spec did not contain vendor/$triple." >&2
+    exit 1
+  fi
+
+  if ! codex_vendor_has_binary "$vendor_dir"; then
+    echo "Package $package_spec did not contain an executable Codex binary." >&2
+    exit 1
+  fi
+
+  mkdir -p "$CODEX_CACHE_ROOT/$resolved_version"
+  rm -rf "$cache_dir"
+  cp -R "$vendor_dir" "$cache_dir"
+  rm -rf "$tmp_dir"
+}
+
+stage_codex_resources() {
+  local resolved_version
+  resolved_version="$(resolve_codex_version)"
+
+  echo "Bundling Codex $resolved_version"
+  download_codex_vendor "$resolved_version" "darwin-arm64" "$CODEX_ARM64_TRIPLE"
+  download_codex_vendor "$resolved_version" "darwin-x64" "$CODEX_X64_TRIPLE"
+
+  mkdir -p "$RESOURCES_URL/Codex"
+  printf '%s\n' "$resolved_version" > "$RESOURCES_URL/Codex/version.txt"
+  mkdir -p "$CODEX_VENDOR_RESOURCE_URL"
+  rm -rf "$CODEX_VENDOR_RESOURCE_URL/$CODEX_ARM64_TRIPLE"
+  rm -rf "$CODEX_VENDOR_RESOURCE_URL/$CODEX_X64_TRIPLE"
+  cp -R "$CODEX_CACHE_ROOT/$resolved_version/$CODEX_ARM64_TRIPLE" "$CODEX_VENDOR_RESOURCE_URL/$CODEX_ARM64_TRIPLE"
+  cp -R "$CODEX_CACHE_ROOT/$resolved_version/$CODEX_X64_TRIPLE" "$CODEX_VENDOR_RESOURCE_URL/$CODEX_X64_TRIPLE"
+}
+
+codesign_file() {
+  local file_url="$1"
+  if [[ "$RELEASE_BUILD" == true ]]; then
+    /usr/bin/codesign \
+      --force \
+      --sign "$SIGN_IDENTITY" \
+      --options runtime \
+      --timestamp \
+      "$file_url" >/dev/null
+  else
+    /usr/bin/codesign --force --sign "$SIGN_IDENTITY" "$file_url" >/dev/null
+  fi
+}
+
+sign_codex_vendor_executables() {
+  if [[ ! -d "$CODEX_VENDOR_RESOURCE_URL" ]]; then
+    return 0
+  fi
+
+  local executable_url
+  while IFS= read -r executable_url; do
+    echo "Signing Codex executable $executable_url"
+    codesign_file "$executable_url"
+  done < <(find "$CODEX_VENDOR_RESOURCE_URL" -type f -perm -u+x)
 }
 
 build_native_executable() {
@@ -338,6 +462,9 @@ find "$RESOURCE_BUNDLE_BIN_DIR" \
   -name "*.bundle" \
   ! -name "${APP_NAME}_${APP_NAME}.bundle" \
   -exec cp -R {} "$RESOURCES_URL" \;
+
+stage_codex_resources
+sign_codex_vendor_executables
 
 if [[ "$RELEASE_BUILD" == true ]]; then
   /usr/bin/codesign \


### PR DESCRIPTION
## Summary
- Add OpenAI Codex account handling, auth file integration, and loopback OAuth support for chat login
- Wire Codex provider metadata, model discovery, and generation option defaults into inference selection
- Update settings flows to add and edit the new provider path, plus runtime metadata handling for generated tools
- Extend tests to cover auth file behavior, provider catalog coverage, model selection, and agent pipeline metadata

## Testing
- Added and updated focused unit tests for Codex auth, provider store/catalog, model selection, and agent pipeline metadata
- Validation also covered build script integration changes at a high level