### PR TITLE
Fixes edge case bug that caused a crash on startup

### DIFF
--- a/Ironsmith/App/IronsmithApp.swift
+++ b/Ironsmith/App/IronsmithApp.swift
@@ -8,7 +8,11 @@ final class IronsmithAppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         IronsmithEditCommandMenu.installIfNeeded()
-        applicationController = IronsmithApplicationController()
+        let applicationController = IronsmithApplicationController()
+        self.applicationController = applicationController
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
+            applicationController.showToolLibraryPopover()
+        }
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
@@ -172,5 +176,9 @@ final class IronsmithApplicationController {
         Task {
             await inferenceStore.refreshIronsmithAccountSummaryIfNeededAfterCheckout()
         }
+    }
+
+    func showToolLibraryPopover() {
+        menuBarController?.show()
     }
 }

--- a/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
+++ b/Ironsmith/Core/AgentPipeline/BuildRepairLoop/ContentViewBuildRepairLoop.swift
@@ -281,6 +281,33 @@ struct ContentViewBuildRepairLoop {
                     case .regenerate(let reason, let stalledState):
                         repairState = stalledState
                         lastFailedState = stalledState
+                        guard let deterministicallyRecoveredState = try await applyDeterministicRepairsUntilStable(
+                            startingFrom: stalledState,
+                            phasePrefix: "model repair stall deterministic recovery"
+                        ) else {
+                            try await lifecycle.updateRepairErrorCount(nil)
+                            AgentDiagnosticsLog.append(
+                                """
+                                Model repair stall resolved by deterministic recovery.
+                                packageRoot: \(layout.packageRootURL.path)
+                                trigger: \(reason.description)
+                                """
+                            )
+                            return
+                        }
+                        repairState = deterministicallyRecoveredState
+                        lastFailedState = deterministicallyRecoveredState
+                        try await lifecycle.updateRepairErrorCount(
+                            deterministicallyRecoveredState.contentViewErrors.isEmpty
+                                ? nil
+                                : deterministicallyRecoveredState.contentViewErrors.count
+                        )
+                        recordBestCandidate(
+                            from: deterministicallyRecoveredState,
+                            phase: "model repair stall deterministic recovery",
+                            bestCandidate: &bestCandidate
+                        )
+
                         guard !attemptedDiagnosticWholeFileRewrite,
                               reason.allowsDiagnosticWholeFileRewrite,
                               let diagnosticRewrite
@@ -292,7 +319,7 @@ struct ContentViewBuildRepairLoop {
                         attemptedDiagnosticWholeFileRewrite = true
                         switch try await runDiagnosticWholeFileRewrite(
                             diagnosticRewrite,
-                            startingFrom: stalledState,
+                            startingFrom: deterministicallyRecoveredState,
                             trigger: reason
                         ) {
                         case .finished:

--- a/Ironsmith/Core/Persistence/Bootstrap/IronsmithPersistentStorePreparer.swift
+++ b/Ironsmith/Core/Persistence/Bootstrap/IronsmithPersistentStorePreparer.swift
@@ -1,9 +1,11 @@
+import CoreData
 import Foundation
 
 struct IronsmithPersistentStorePreparer {
     private static let retainedBackupCount = 3
     private static let storeComponentSuffixes = ["", "-wal", "-shm", "-journal"]
     private static let importMoveOrder = ["-wal", "-shm", "-journal", ""]
+    private static let ironsmithEntityNames = Set(["Tool", "ModelConfig", "ProviderConfig"])
 
     let locations: IronsmithPersistentStoreLocations
     let fileManager: FileManager
@@ -26,6 +28,8 @@ struct IronsmithPersistentStorePreparer {
             withIntermediateDirectories: true
         )
 
+        try quarantineRejectedLegacyImportIfNeeded(at: startupDate)
+
         if !regularFileExists(at: locations.storeURL) {
             try importLegacyStoreIfPresent()
         }
@@ -37,7 +41,11 @@ struct IronsmithPersistentStorePreparer {
     }
 
     private func importLegacyStoreIfPresent() throws {
-        guard regularFileExists(at: locations.legacyStoreURL) else { return }
+        guard regularFileExists(at: locations.legacyStoreURL),
+              storeIdentity(at: locations.legacyStoreURL)?.isIronsmith == true
+        else {
+            return
+        }
 
         for suffix in Self.storeComponentSuffixes.dropFirst() {
             let destinationURL = storeComponentURL(baseURL: locations.storeURL, suffix: suffix)
@@ -81,6 +89,62 @@ struct IronsmithPersistentStorePreparer {
         }
     }
 
+    private func quarantineRejectedLegacyImportIfNeeded(at startupDate: Date) throws {
+        guard regularFileExists(at: locations.storeURL),
+              regularFileExists(at: locations.legacyStoreURL),
+              let currentIdentity = storeIdentity(at: locations.storeURL),
+              let legacyIdentity = storeIdentity(at: locations.legacyStoreURL),
+              !currentIdentity.isIronsmith,
+              !legacyIdentity.isIronsmith,
+              currentIdentity.storeUUID == legacyIdentity.storeUUID
+        else {
+            return
+        }
+
+        let quarantineDirectoryURL = uniqueRejectedLegacyImportDirectoryURL(for: startupDate)
+        let stagingDirectoryURL = locations.backupsDirectoryURL
+            .appendingPathComponent(".rejected-legacy-import-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: stagingDirectoryURL, withIntermediateDirectories: false)
+
+        var movedComponents: [(source: URL, staged: URL)] = []
+        do {
+            for suffix in Self.importMoveOrder {
+                let sourceURL = storeComponentURL(baseURL: locations.storeURL, suffix: suffix)
+                guard regularFileExists(at: sourceURL) else { continue }
+
+                let stagedURL = stagingDirectoryURL
+                    .appendingPathComponent(locations.storeURL.lastPathComponent + suffix)
+                try fileManager.moveItem(at: sourceURL, to: stagedURL)
+                movedComponents.append((sourceURL, stagedURL))
+            }
+            try fileManager.moveItem(at: stagingDirectoryURL, to: quarantineDirectoryURL)
+        } catch {
+            for component in movedComponents.reversed()
+            where fileManager.fileExists(atPath: component.staged.path) {
+                try? fileManager.moveItem(at: component.staged, to: component.source)
+            }
+            try? fileManager.removeItem(at: stagingDirectoryURL)
+            throw error
+        }
+    }
+
+    private func storeIdentity(at url: URL) -> PersistentStoreIdentity? {
+        guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(
+            type: .sqlite,
+            at: url
+        ),
+            let versionHashes = metadata[NSStoreModelVersionHashesKey] as? [String: Any],
+            let storeUUID = metadata[NSStoreUUIDKey] as? String
+        else {
+            return nil
+        }
+
+        return PersistentStoreIdentity(
+            entityNames: Set(versionHashes.keys),
+            storeUUID: storeUUID
+        )
+    }
+
     private func createStartupBackup(at startupDate: Date) throws {
         let backupDirectoryURL = uniqueBackupDirectoryURL(for: startupDate)
         let stagingDirectoryURL = locations.backupsDirectoryURL
@@ -105,6 +169,19 @@ struct IronsmithPersistentStorePreparer {
 
     private func uniqueBackupDirectoryURL(for date: Date) -> URL {
         let baseName = backupDateFormatter.string(from: date)
+        var candidateURL = locations.backupsDirectoryURL
+            .appendingPathComponent(baseName, isDirectory: true)
+        var suffix = 2
+        while fileManager.fileExists(atPath: candidateURL.path) {
+            candidateURL = locations.backupsDirectoryURL
+                .appendingPathComponent("\(baseName)-\(suffix)", isDirectory: true)
+            suffix += 1
+        }
+        return candidateURL
+    }
+
+    private func uniqueRejectedLegacyImportDirectoryURL(for date: Date) -> URL {
+        let baseName = "rejected-legacy-import-\(backupDateFormatter.string(from: date))"
         var candidateURL = locations.backupsDirectoryURL
             .appendingPathComponent(baseName, isDirectory: true)
         var suffix = 2
@@ -164,5 +241,14 @@ struct IronsmithPersistentStorePreparer {
         var isDirectory = ObjCBool(false)
         return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
             && !isDirectory.boolValue
+    }
+
+    private struct PersistentStoreIdentity {
+        let entityNames: Set<String>
+        let storeUUID: String
+
+        var isIronsmith: Bool {
+            IronsmithPersistentStorePreparer.ironsmithEntityNames.isSubset(of: entityNames)
+        }
     }
 }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineDiagnosticWholeFileRewriteTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineDiagnosticWholeFileRewriteTests.swift
@@ -174,6 +174,84 @@ extension AgentPipelineTests {
 
     @MainActor
     @Test
+    func sparkRepairStallRunsDeterministicRecoveryBeforeScratchRegeneration() async throws {
+        let toolsDirectory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let executableName = "DeterministicStallRecoveryTool"
+        let responses = LanguageModelResponseQueue([
+            """
+            import SwiftUI
+
+            struct ContentView: View {
+                @State private var tokens = ["one", "two"]
+                @State private var newIdx = 0
+
+                var body: some View {
+                    Text(tokens[newIdx]).definitelyNotReal()
+                }
+            }
+            """,
+            """
+            --- a/ContentView.swift
+            +++ b/ContentView.swift
+            @@ -8,1 +8,3 @@
+            -        Text(tokens[newIdx]).definitelyNotReal()
+            +        if newIdx< tokens.count {
+            +            Text(tokens[newIdx])
+            +        }
+            """,
+            "not a patch",
+            "still not a patch",
+            Self.simpleContentViewSource(text: "Scratch regeneration should not run"),
+        ])
+        let prompts = PromptCapture()
+        let builds = ModelConversationBuilds(executableName: executableName)
+        let runtime = Self.makeRuntime(
+            languageModel: StubAgentLanguageModel { prompt, _ in
+                await prompts.record(prompt)
+                return try await responses.next()
+            },
+            pipelineConfiguration: .ironsmithSpark(
+                repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1),
+                diagnosticWholeFileRewriteEnabled: false
+            ),
+            toolsDirectoryURL: toolsDirectory,
+            processClient: SwiftPackageProcessClient(
+                build: { packageRoot in
+                    await builds.next(packageRoot: packageRoot)
+                },
+                showBinPath: { packageRoot in
+                    packageRoot.appendingPathComponent(".build/debug", isDirectory: true)
+                },
+                launch: { _ in },
+                stripQuarantine: { _ in }
+            ),
+            metadataClient: ToolMetadataClient { _ in
+                ToolMetadataSuggestion(
+                    displayName: "Deterministic Stall Recovery Tool",
+                    iconPrompt: ""
+                )
+            }
+        )
+
+        let result = try await runtime.generateTool(
+            for: "Build a deterministic stall recovery tool",
+            settings: .default
+        )
+
+        let source = try String(contentsOf: Self.contentViewURL(for: result), encoding: .utf8)
+        let capturedPrompts = await prompts.prompts
+        #expect(source.contains("if newIdx < tokens.count"))
+        #expect(!capturedPrompts.contains {
+            $0.contains("Narrow compiler repair stalled on this app.")
+        })
+        #expect(await responses.count == 4)
+        #expect(await builds.count == 3)
+    }
+
+    @MainActor
+    @Test
     func regressedDiagnosticRewriteGetsFreshDiffRepairConversation() async throws {
         let toolsDirectory = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: toolsDirectory) }

--- a/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderStoreTests.swift
@@ -602,7 +602,7 @@ extension InferenceTests {
 
         inferenceStore.startOllama(for: provider)
 
-        await Self.eventually {
+        await Self.eventually(timeoutNanoseconds: 15_000_000_000) {
             inferenceStore.remoteModels.contains { $0.identifier == "gemma4:e2b" }
                 && !inferenceStore.isStartingOllama(provider)
         }

--- a/IronsmithTests/Core/Persistence/PersistenceTests.swift
+++ b/IronsmithTests/Core/Persistence/PersistenceTests.swift
@@ -324,6 +324,81 @@ struct PersistenceTests {
         }
     }
 
+    @MainActor
+    @Test
+    func unrelatedDefaultStoreIsNotImportedAsLegacyIronsmithData() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let legacyStoreURL = root.appendingPathComponent("legacy/default.store")
+        try FileManager.default.createDirectory(
+            at: legacyStoreURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.makeUnrelatedStore(at: legacyStoreURL)
+
+        let locations = Self.makePersistentStoreLocations(
+            root: root,
+            legacyStoreURL: legacyStoreURL
+        )
+        try IronsmithPersistentStorePreparer(locations: locations).prepare()
+
+        #expect(FileManager.default.fileExists(atPath: legacyStoreURL.path))
+        #expect(!FileManager.default.fileExists(atPath: locations.storeURL.path))
+    }
+
+    @MainActor
+    @Test
+    func copiedUnrelatedLegacyStoreIsQuarantinedAndReplacedWithFreshStore() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let legacyStoreURL = root.appendingPathComponent("legacy/default.store")
+        try FileManager.default.createDirectory(
+            at: legacyStoreURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.makeUnrelatedStore(at: legacyStoreURL)
+
+        let locations = Self.makePersistentStoreLocations(
+            root: root,
+            legacyStoreURL: legacyStoreURL
+        )
+        try FileManager.default.createDirectory(
+            at: locations.databaseDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        for suffix in ["", "-wal", "-shm"] {
+            let sourceURL = URL(fileURLWithPath: legacyStoreURL.path + suffix)
+            guard FileManager.default.fileExists(atPath: sourceURL.path) else { continue }
+            try FileManager.default.copyItem(
+                at: sourceURL,
+                to: URL(fileURLWithPath: locations.storeURL.path + suffix)
+            )
+        }
+
+        try IronsmithPersistentStorePreparer(locations: locations)
+            .prepare(startupDate: Date(timeIntervalSince1970: 1_750_000_000))
+
+        #expect(!FileManager.default.fileExists(atPath: locations.storeURL.path))
+        let quarantines = try FileManager.default.contentsOfDirectory(
+            at: locations.backupsDirectoryURL,
+            includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("rejected-legacy-import-") }
+        let quarantine = try #require(quarantines.first)
+        #expect(FileManager.default.fileExists(
+            atPath: quarantine.appendingPathComponent(IronsmithPaths.databaseFileName).path
+        ))
+        #expect(FileManager.default.fileExists(atPath: legacyStoreURL.path))
+
+        let container = try IronsmithModelContainerFactory.make(
+            configuration: ModelConfiguration(url: locations.storeURL)
+        )
+        let context = ModelContext(container)
+        try AppDataBootstrapper.bootstrapIfNeeded(in: context)
+        #expect(try context.fetch(FetchDescriptor<ProviderConfig>()).count == 1)
+    }
+
     @Test
     func existingStoreIsBackedUpInsteadOfBeingReplacedByLegacyStore() throws {
         let root = try Self.makeTemporaryDirectory()
@@ -456,6 +531,29 @@ struct PersistenceTests {
         return root
     }
 
+    private static func makePersistentStoreLocations(
+        root: URL,
+        legacyStoreURL: URL
+    ) -> IronsmithPersistentStoreLocations {
+        IronsmithPersistentStoreLocations(
+            databaseDirectoryURL: root
+                .appendingPathComponent(".ironsmith", isDirectory: true)
+                .appendingPathComponent("db", isDirectory: true),
+            legacyStoreURL: legacyStoreURL
+        )
+    }
+
+    @MainActor
+    private static func makeUnrelatedStore(at url: URL) throws {
+        let container = try ModelContainer(
+            for: UnrelatedLegacyRecord.self,
+            configurations: ModelConfiguration(url: url)
+        )
+        let context = ModelContext(container)
+        context.insert(UnrelatedLegacyRecord(value: "Not Ironsmith"))
+        try context.save()
+    }
+
     private static func startupBackupDirectories(
         in locations: IronsmithPersistentStoreLocations
     ) throws -> [URL] {
@@ -464,5 +562,14 @@ struct PersistenceTests {
             includingPropertiesForKeys: [.isDirectoryKey],
             options: [.skipsHiddenFiles]
         )
+    }
+}
+
+@Model
+private final class UnrelatedLegacyRecord {
+    var value: String
+
+    init(value: String) {
+        self.value = value
     }
 }


### PR DESCRIPTION
## Summary

- Fixes a bug that occurred with swift data on launch if you had a specific configuration of sqlite files in your application support directory.
- Makes it so the popover opens automatically on startup.
- Adds a second deterministic pass for the Spark agent after model repair stalls.

## Testing

- Added focused Swift Testing coverage for legacy-store validation/quarantine and deterministic repair recovery.