### PR TITLE
Add tool publishing, store import, and image asset workflows

### DIFF
--- a/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
+++ b/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
@@ -20,7 +20,16 @@ final class IronsmithStoreWindowController: NSWindowController {
 
         let window = NSWindow()
         window.title = "App Store"
-        window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+        window.styleMask = [
+            .titled,
+            .closable,
+            .miniaturizable,
+            .resizable,
+            .fullSizeContentView,
+        ]
+        window.titleVisibility = .hidden
+        window.titlebarAppearsTransparent = true
+        window.titlebarSeparatorStyle = .none
         window.isReleasedWhenClosed = false
         window.minSize = NSSize(width: 980, height: 680)
         window.setContentSize(NSSize(width: 1200, height: 800))

--- a/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
+++ b/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
@@ -19,7 +19,7 @@ final class IronsmithStoreWindowController: NSWindowController {
         self.routeStore = routeStore
 
         let window = NSWindow()
-        window.title = "App Store"
+        window.title = "Ironsmith Store"
         window.styleMask = [
             .titled,
             .closable,

--- a/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
+++ b/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
@@ -4,20 +4,25 @@ import SwiftUI
 
 @MainActor
 final class IronsmithStoreWindowController: NSWindowController {
+    private static let initialContentSize = NSSize(width: 1000, height: 660)
+    private static let minimumContentSize = NSSize(width: 600, height: 400)
+
     private var hasCenteredWindow = false
-    private let modelContainer: ModelContainer
-    private let inferenceStore: InferenceStore
-    private let routeStore: IronsmithRouteStore
 
     init(
         modelContainer: ModelContainer,
         inferenceStore: InferenceStore,
         routeStore: IronsmithRouteStore
     ) {
-        self.modelContainer = modelContainer
-        self.inferenceStore = inferenceStore
-        self.routeStore = routeStore
-
+        let hostingController = NSHostingController(
+            rootView: AnyView(
+                StoreWindowView()
+                    .modelContainer(modelContainer)
+                    .environment(inferenceStore)
+                    .environment(routeStore)
+            )
+        )
+        hostingController.sceneBridgingOptions = [.toolbars]
         let window = NSWindow()
         window.title = "Ironsmith Store"
         window.styleMask = [
@@ -31,8 +36,9 @@ final class IronsmithStoreWindowController: NSWindowController {
         window.titlebarAppearsTransparent = true
         window.titlebarSeparatorStyle = .none
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 980, height: 680)
-        window.setContentSize(NSSize(width: 1200, height: 800))
+        window.contentViewController = hostingController
+        window.minSize = Self.minimumContentSize
+        window.setContentSize(Self.initialContentSize)
 
         super.init(window: window)
     }
@@ -44,17 +50,6 @@ final class IronsmithStoreWindowController: NSWindowController {
 
     func show() {
         guard let window else { return }
-        if window.contentViewController == nil {
-            window.contentViewController = NSHostingController(
-                rootView: AnyView(
-                    StoreWindowView()
-                        .modelContainer(modelContainer)
-                        .environment(inferenceStore)
-                        .environment(routeStore)
-                )
-            )
-        }
-
         if !hasCenteredWindow {
             window.center()
             hasCenteredWindow = true

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolIconClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolIconClient.swift
@@ -48,7 +48,8 @@ actor ToolHostedIconPaletteStore {
         let preferredIndex = ToolIconClient.hostedIconPaletteIndex(for: displayName)
         let recentIndices = recentPaletteIndices(paletteCount: paletteCount)
         let excludedIndices = Set(recentIndices)
-        let selectedIndex = (0..<paletteCount)
+        let selectedIndex =
+            (0..<paletteCount)
             .lazy
             .map { (preferredIndex + $0) % paletteCount }
             .first { !excludedIndices.contains($0) } ?? preferredIndex
@@ -80,8 +81,6 @@ actor ToolHostedIconPaletteStore {
 struct ToolIconClient: Sendable {
     var ensureIconAssets: @Sendable (ToolIconRequest) async throws -> URL
 
-    nonisolated private static let cachedPreviewPNGPixelSize = 256
-
     nonisolated static let noOp = ToolIconClient { request in
         request.layout.cachedAppIconICNSURL
     }
@@ -89,11 +88,11 @@ struct ToolIconClient: Sendable {
     static func cachedOnly(fileManager: FileManager = .default) -> ToolIconClient {
         let fileManagerBox = ToolIconFileManager(fileManager)
         return ToolIconClient { request in
-            if fileManagerBox.value.fileExists(atPath: request.layout.cachedAppIconICNSURL.path) {
-                return request.layout.cachedAppIconICNSURL
-            }
-            if fileManagerBox.value.fileExists(atPath: request.layout.cachedAppIconPNGURL.path) {
-                return request.layout.cachedAppIconPNGURL
+            if let cached = try Self.prepareCachedIconAssets(
+                request: request,
+                fileManager: fileManagerBox.value
+            ) {
+                return cached
             }
             throw ToolAppBundleError.iconGenerationProducedNoImage
         }
@@ -109,14 +108,16 @@ struct ToolIconClient: Sendable {
         let imageClient = imageClient ?? .live()
         let fileManagerBox = ToolIconFileManager(fileManager)
         return ToolIconClient { request in
-            if fileManagerBox.value.fileExists(atPath: request.layout.cachedAppIconICNSURL.path) {
-                return request.layout.cachedAppIconICNSURL
-            }
-
             try fileManagerBox.value.createDirectory(
                 at: request.layout.packageMetadataDirectoryURL,
                 withIntermediateDirectories: true
             )
+            if let cached = try Self.prepareCachedIconAssets(
+                request: request,
+                fileManager: fileManagerBox.value
+            ) {
+                return cached
+            }
 
             var selectedPaletteIndex: Int?
             if request.imageProvider != .imagePlayground {
@@ -154,8 +155,11 @@ struct ToolIconClient: Sendable {
                         Self.iconPrompt(for: request, hostedPalette: hostedPalette)
                     )
                 }
-                try Self.writePNG(cgImage, to: request.layout.cachedAppIconPNGURL)
-                try Self.writeICNS(cgImage, request: request, fileManager: fileManagerBox.value)
+                try Self.writeOriginalIconAssets(
+                    cgImage,
+                    request: request,
+                    fileManager: fileManagerBox.value
+                )
                 return request.layout.cachedAppIconICNSURL
             } catch is CancellationError {
                 throw CancellationError()
@@ -195,6 +199,11 @@ struct ToolIconClient: Sendable {
                 }
             }
 
+            if fileManagerBox.value.fileExists(
+                atPath: request.layout.cachedAppIconThumbnailJPEGURL.path
+            ) {
+                return request.layout.cachedAppIconThumbnailJPEGURL
+            }
             if fileManagerBox.value.fileExists(atPath: request.layout.cachedAppIconPNGURL.path) {
                 return request.layout.cachedAppIconPNGURL
             }
@@ -309,7 +318,8 @@ struct ToolIconClient: Sendable {
             foregroundRGB: 0xD9FFF4
         ),
         ToolIconPalette(
-            description: "a charcoal-to-graphite background with silver and muted chartreuse accents",
+            description:
+                "a charcoal-to-graphite background with silver and muted chartreuse accents",
             backgroundStartRGB: 0x2F3338,
             backgroundEndRGB: 0x59616A,
             foregroundRGB: 0xE7EBEF
@@ -327,7 +337,8 @@ struct ToolIconClient: Sendable {
             foregroundRGB: 0xDCEEFF
         ),
         ToolIconPalette(
-            description: "a crimson-to-vermilion background with warm ivory and deep maroon accents",
+            description:
+                "a crimson-to-vermilion background with warm ivory and deep maroon accents",
             backgroundStartRGB: 0xC92A3B,
             backgroundEndRGB: 0xF04E32,
             foregroundRGB: 0xFFF1E3
@@ -422,8 +433,11 @@ struct ToolIconClient: Sendable {
                 paletteIndex: paletteIndex
             )
         }
-        try Self.writePNG(fallback, to: request.layout.cachedAppIconPNGURL)
-        try Self.writeICNS(fallback, request: request, fileManager: fileManager)
+        try Self.writeOriginalIconAssets(
+            fallback,
+            request: request,
+            fileManager: fileManager
+        )
         return request.layout.cachedAppIconICNSURL
     }
 
@@ -509,28 +523,171 @@ struct ToolIconClient: Sendable {
         )
     }
 
-    nonisolated private static func writePNG(_ cgImage: CGImage, to url: URL) throws {
-        guard cgImage.width > 0, cgImage.height > 0 else {
-            throw ToolAppBundleError.iconEncodingFailed
+    nonisolated static func installDownloadedIconAssets(
+        masterJPEG: Data,
+        thumbnailJPEG: Data,
+        request: ToolIconRequest,
+        fileManager: FileManager = .default
+    ) throws {
+        let masterImage = try ToolImageAssetEncoder.validateIconMasterJPEG(masterJPEG)
+        _ = try ToolImageAssetEncoder.validateIconThumbnailJPEG(thumbnailJPEG)
+        try fileManager.createDirectory(
+            at: request.layout.packageMetadataDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try writeJPEGAssets(
+            master: masterJPEG,
+            thumbnail: thumbnailJPEG,
+            layout: request.layout,
+            fileManager: fileManager
+        )
+        try writeICNS(masterImage, request: request, fileManager: fileManager)
+        try? fileManager.removeItem(at: request.layout.cachedAppIconPNGURL)
+    }
+
+    nonisolated private static func writeOriginalIconAssets(
+        _ image: CGImage,
+        request: ToolIconRequest,
+        fileManager: FileManager
+    ) throws {
+        let assets = try ToolImageAssetEncoder.iconAssets(from: image)
+        try writeJPEGAssets(
+            master: assets.masterData,
+            thumbnail: assets.thumbnailData,
+            layout: request.layout,
+            fileManager: fileManager
+        )
+        try writeICNS(image, request: request, fileManager: fileManager)
+        try? fileManager.removeItem(at: request.layout.cachedAppIconPNGURL)
+    }
+
+    nonisolated private static func prepareCachedIconAssets(
+        request: ToolIconRequest,
+        fileManager: FileManager
+    ) throws -> URL? {
+        let layout = request.layout
+        let hasMaster = fileManager.fileExists(atPath: layout.cachedAppIconMasterJPEGURL.path)
+        let hasThumbnail = fileManager.fileExists(
+            atPath: layout.cachedAppIconThumbnailJPEGURL.path
+        )
+        let hasICNS = fileManager.fileExists(atPath: layout.cachedAppIconICNSURL.path)
+        let hasLegacyPNG = fileManager.fileExists(atPath: layout.cachedAppIconPNGURL.path)
+
+        if hasMaster, hasThumbnail {
+            if !hasICNS {
+                let masterData = try Data(contentsOf: layout.cachedAppIconMasterJPEGURL)
+                let masterImage = try ToolImageAssetEncoder.validateIconMasterJPEG(masterData)
+                try writeICNS(masterImage, request: request, fileManager: fileManager)
+            }
+            return layout.cachedAppIconICNSURL
         }
-        let previewPixelSize = min(max(cgImage.width, cgImage.height), cachedPreviewPNGPixelSize)
-        let previewImage = try scaledImage(cgImage, pixelSize: previewPixelSize)
-        let capacity = max(4_096, previewImage.width * previewImage.height * 4)
-        guard let data = NSMutableData(capacity: capacity),
-            let destination = CGImageDestinationCreateWithData(
-                data,
-                "public.png" as CFString,
-                1,
-                nil
+
+        if hasICNS {
+            do {
+                let sourceImage = try ToolImageAssetEncoder.largestImage(
+                    at: layout.cachedAppIconICNSURL
+                )
+                let assets = try ToolImageAssetEncoder.iconAssets(from: sourceImage)
+                let masterData =
+                    hasMaster
+                    ? try Data(contentsOf: layout.cachedAppIconMasterJPEGURL)
+                    : assets.masterData
+                let thumbnailData =
+                    hasThumbnail
+                    ? try Data(contentsOf: layout.cachedAppIconThumbnailJPEGURL)
+                    : assets.thumbnailData
+                try writeJPEGAssets(
+                    master: masterData,
+                    thumbnail: thumbnailData,
+                    layout: layout,
+                    fileManager: fileManager
+                )
+                try? fileManager.removeItem(at: layout.cachedAppIconPNGURL)
+            } catch {
+                AgentDiagnosticsLog.append(
+                    """
+                    Legacy ICNS migration failed; preserving the existing app icon.
+                    displayName: \(request.displayName)
+                    error:
+                    \(AgentDiagnosticsLog.renderError(error, limit: 500))
+                    """
+                )
+            }
+            return layout.cachedAppIconICNSURL
+        }
+
+        if hasMaster {
+            let masterData = try Data(contentsOf: layout.cachedAppIconMasterJPEGURL)
+            let masterImage = try ToolImageAssetEncoder.validateIconMasterJPEG(masterData)
+            if !hasThumbnail {
+                let assets = try ToolImageAssetEncoder.iconAssets(from: masterImage)
+                try writeJPEGAssets(
+                    master: masterData,
+                    thumbnail: assets.thumbnailData,
+                    layout: layout,
+                    fileManager: fileManager
+                )
+            }
+            try writeICNS(masterImage, request: request, fileManager: fileManager)
+            return layout.cachedAppIconICNSURL
+        }
+
+        if hasLegacyPNG {
+            let legacyData = try Data(contentsOf: layout.cachedAppIconPNGURL)
+            let legacyImage = try ToolImageAssetEncoder.decodeImage(
+                legacyData,
+                applyingOrientation: true
             )
-        else {
-            throw ToolAppBundleError.iconEncodingFailed
+            try writeOriginalIconAssets(
+                legacyImage,
+                request: request,
+                fileManager: fileManager
+            )
+            return layout.cachedAppIconICNSURL
         }
-        CGImageDestinationAddImage(destination, previewImage, nil)
-        guard CGImageDestinationFinalize(destination), data.length > 0 else {
-            throw ToolAppBundleError.iconEncodingFailed
+
+        return nil
+    }
+
+    nonisolated private static func writeJPEGAssets(
+        master: Data,
+        thumbnail: Data,
+        layout: ToolPackageLayout,
+        fileManager: FileManager
+    ) throws {
+        let masterURL = layout.cachedAppIconMasterJPEGURL
+        let thumbnailURL = layout.cachedAppIconThumbnailJPEGURL
+        let previousMaster = try existingData(at: masterURL, fileManager: fileManager)
+        let previousThumbnail = try existingData(at: thumbnailURL, fileManager: fileManager)
+
+        do {
+            try master.write(to: masterURL, options: .atomic)
+            try thumbnail.write(to: thumbnailURL, options: .atomic)
+        } catch {
+            restore(previousMaster, at: masterURL, fileManager: fileManager)
+            restore(previousThumbnail, at: thumbnailURL, fileManager: fileManager)
+            throw error
         }
-        try (data as Data).write(to: url, options: .atomic)
+    }
+
+    nonisolated private static func existingData(
+        at url: URL,
+        fileManager: FileManager
+    ) throws -> Data? {
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        return try Data(contentsOf: url)
+    }
+
+    nonisolated private static func restore(
+        _ data: Data?,
+        at url: URL,
+        fileManager: FileManager
+    ) {
+        if let data {
+            try? data.write(to: url, options: .atomic)
+        } else {
+            try? fileManager.removeItem(at: url)
+        }
     }
 
     nonisolated private static func writePNGFile(_ cgImage: CGImage, to url: URL) throws {
@@ -558,10 +715,14 @@ struct ToolIconClient: Sendable {
         request: ToolIconRequest,
         fileManager: FileManager
     ) throws {
+        let identifier = UUID().uuidString
         let iconsetURL = request.layout.packageMetadataDirectoryURL
-            .appendingPathComponent("AppIcon.iconset", isDirectory: true)
-        if fileManager.fileExists(atPath: iconsetURL.path) {
-            try fileManager.removeItem(at: iconsetURL)
+            .appendingPathComponent("AppIcon-\(identifier).iconset", isDirectory: true)
+        let stagedICNSURL = request.layout.packageMetadataDirectoryURL
+            .appendingPathComponent("AppIcon-\(identifier).icns")
+        defer {
+            try? fileManager.removeItem(at: iconsetURL)
+            try? fileManager.removeItem(at: stagedICNSURL)
         }
         try fileManager.createDirectory(at: iconsetURL, withIntermediateDirectories: true)
 
@@ -569,19 +730,21 @@ struct ToolIconClient: Sendable {
         for size in sizes {
             let baseURL = iconsetURL.appendingPathComponent("icon_\(size)x\(size).png")
             let retinaURL = iconsetURL.appendingPathComponent("icon_\(size)x\(size)@2x.png")
-            try Self.writePNGFile(Self.scaledImage(cgImage, pixelSize: size), to: baseURL)
-            try Self.writePNGFile(Self.scaledImage(cgImage, pixelSize: size * 2), to: retinaURL)
-        }
-
-        if fileManager.fileExists(atPath: request.layout.cachedAppIconICNSURL.path) {
-            try fileManager.removeItem(at: request.layout.cachedAppIconICNSURL)
+            try Self.writePNGFile(
+                ToolImageAssetEncoder.squareImage(cgImage, pixelSize: size, opaque: false),
+                to: baseURL
+            )
+            try Self.writePNGFile(
+                ToolImageAssetEncoder.squareImage(cgImage, pixelSize: size * 2, opaque: false),
+                to: retinaURL
+            )
         }
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/iconutil")
         process.arguments = [
             "-c", "icns",
-            "-o", request.layout.cachedAppIconICNSURL.path,
+            "-o", stagedICNSURL.path,
             iconsetURL.path,
         ]
         let outputPipe = Pipe()
@@ -597,10 +760,8 @@ struct ToolIconClient: Sendable {
             String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
             ?? ""
 
-        try? fileManager.removeItem(at: iconsetURL)
-
         guard process.terminationStatus == 0,
-            fileManager.fileExists(atPath: request.layout.cachedAppIconICNSURL.path)
+            fileManager.fileExists(atPath: stagedICNSURL.path)
         else {
             AgentDiagnosticsLog.append(
                 """
@@ -613,32 +774,17 @@ struct ToolIconClient: Sendable {
             )
             throw ToolAppBundleError.iconEncodingFailed
         }
-    }
-
-    nonisolated private static func scaledImage(_ cgImage: CGImage, pixelSize: Int) throws
-        -> CGImage
-    {
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        guard
-            let context = CGContext(
-                data: nil,
-                width: pixelSize,
-                height: pixelSize,
-                bitsPerComponent: 8,
-                bytesPerRow: 0,
-                space: colorSpace,
-                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        if fileManager.fileExists(atPath: request.layout.cachedAppIconICNSURL.path) {
+            _ = try fileManager.replaceItemAt(
+                request.layout.cachedAppIconICNSURL,
+                withItemAt: stagedICNSURL
             )
-        else {
-            throw ToolAppBundleError.iconEncodingFailed
+        } else {
+            try fileManager.moveItem(
+                at: stagedICNSURL,
+                to: request.layout.cachedAppIconICNSURL
+            )
         }
-
-        context.interpolationQuality = .high
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: pixelSize, height: pixelSize))
-        guard let scaled = context.makeImage() else {
-            throw ToolAppBundleError.iconEncodingFailed
-        }
-        return scaled
     }
 }
 

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageAssetEncoder.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageAssetEncoder.swift
@@ -82,7 +82,11 @@ nonisolated enum ToolImageAssetEncoder {
     }
 
     static func screenshot(from data: Data) throws -> ToolJPEGImageAsset {
-        let image = try decodeImage(data, applyingOrientation: true)
+        let image = try decodeImage(
+            data,
+            applyingOrientation: true,
+            maximumPixelSize: max(screenshotMaximumWidth, screenshotMaximumHeight)
+        )
         return try screenshot(from: image)
     }
 
@@ -144,7 +148,11 @@ nonisolated enum ToolImageAssetEncoder {
         )
     }
 
-    static func decodeImage(_ data: Data, applyingOrientation: Bool = false) throws -> CGImage {
+    static func decodeImage(
+        _ data: Data,
+        applyingOrientation: Bool = false,
+        maximumPixelSize: Int? = nil
+    ) throws -> CGImage {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil),
             CGImageSourceGetCount(source) == 1
         else {
@@ -156,7 +164,11 @@ nonisolated enum ToolImageAssetEncoder {
                 as? [CFString: Any]
             let width = properties?[kCGImagePropertyPixelWidth] as? Int ?? 0
             let height = properties?[kCGImagePropertyPixelHeight] as? Int ?? 0
-            let maximumDimension = max(width, height)
+            let sourceMaximumDimension = max(width, height)
+            let maximumDimension = min(
+                sourceMaximumDimension,
+                maximumPixelSize ?? sourceMaximumDimension
+            )
             guard maximumDimension > 0,
                 let image = CGImageSourceCreateThumbnailAtIndex(
                     source,

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageAssetEncoder.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageAssetEncoder.swift
@@ -1,0 +1,414 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+nonisolated struct ToolJPEGIconAssets: Sendable {
+    let masterData: Data
+    let thumbnailData: Data
+}
+
+nonisolated struct ToolJPEGImageAsset: Sendable {
+    let data: Data
+    let width: Int
+    let height: Int
+}
+
+nonisolated enum ToolImageAssetEncodingError: LocalizedError {
+    case invalidImage
+    case couldNotCreateImage
+    case couldNotEncodeJPEG
+    case masterTooLarge
+    case thumbnailTooLarge
+    case screenshotTooLarge
+    case invalidJPEG
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidImage:
+            "The selected image could not be decoded."
+        case .couldNotCreateImage:
+            "Ironsmith could not resize the image."
+        case .couldNotEncodeJPEG:
+            "Ironsmith could not encode the image as JPEG."
+        case .masterTooLarge:
+            "The 1024×1024 app icon master exceeds 256 KiB."
+        case .thumbnailTooLarge:
+            "The 256×256 app icon thumbnail exceeds 64 KiB."
+        case .screenshotTooLarge:
+            "The Store screenshot could not be reduced below 512 KiB."
+        case .invalidJPEG:
+            "The Store image is not a valid JPEG with the expected dimensions."
+        }
+    }
+}
+
+nonisolated enum ToolImageAssetEncoder {
+    static let iconMasterPixelSize = 1024
+    static let iconThumbnailPixelSize = 256
+    static let iconJPEGQuality = 0.60
+    static let iconMasterMaximumBytes = 256 * 1024
+    static let iconThumbnailMaximumBytes = 64 * 1024
+    static let screenshotMaximumWidth = 1280
+    static let screenshotMaximumHeight = 960
+    static let screenshotMaximumBytes = 512 * 1024
+    static let screenshotMinimumDimension = 64
+    static let screenshotJPEGQuality = 0.60
+
+    static func iconAssets(from image: CGImage) throws -> ToolJPEGIconAssets {
+        let master = try jpeg(
+            image: try squareImage(
+                image,
+                pixelSize: iconMasterPixelSize,
+                opaque: true
+            ),
+            quality: iconJPEGQuality
+        )
+        guard master.count <= iconMasterMaximumBytes else {
+            throw ToolImageAssetEncodingError.masterTooLarge
+        }
+
+        let thumbnail = try jpeg(
+            image: try squareImage(
+                image,
+                pixelSize: iconThumbnailPixelSize,
+                opaque: true
+            ),
+            quality: iconJPEGQuality
+        )
+        guard thumbnail.count <= iconThumbnailMaximumBytes else {
+            throw ToolImageAssetEncodingError.thumbnailTooLarge
+        }
+        return ToolJPEGIconAssets(masterData: master, thumbnailData: thumbnail)
+    }
+
+    static func screenshot(from data: Data) throws -> ToolJPEGImageAsset {
+        let image = try decodeImage(data, applyingOrientation: true)
+        return try screenshot(from: image)
+    }
+
+    static func screenshot(from image: CGImage) throws -> ToolJPEGImageAsset {
+        let initialScale = min(
+            1,
+            CGFloat(screenshotMaximumWidth) / CGFloat(image.width),
+            CGFloat(screenshotMaximumHeight) / CGFloat(image.height)
+        )
+        var width = max(1, Int((CGFloat(image.width) * initialScale).rounded(.down)))
+        var height = max(1, Int((CGFloat(image.height) * initialScale).rounded(.down)))
+        let minimumDimension = min(screenshotMinimumDimension, width, height)
+
+        for _ in 0..<10 {
+            let resized = try resizedImage(
+                image,
+                width: width,
+                height: height,
+                opaque: true
+            )
+            let encoded = try jpeg(image: resized, quality: screenshotJPEGQuality)
+            if encoded.count <= screenshotMaximumBytes {
+                return ToolJPEGImageAsset(data: encoded, width: width, height: height)
+            }
+
+            let reduction = min(
+                0.9,
+                sqrt(CGFloat(screenshotMaximumBytes) / CGFloat(encoded.count)) * 0.95
+            )
+            let minimumScale = max(
+                CGFloat(minimumDimension) / CGFloat(width),
+                CGFloat(minimumDimension) / CGFloat(height)
+            )
+            let nextScale = max(reduction, minimumScale)
+            let nextWidth = max(1, Int((CGFloat(width) * nextScale).rounded(.down)))
+            let nextHeight = max(1, Int((CGFloat(height) * nextScale).rounded(.down)))
+            guard nextWidth < width || nextHeight < height else { break }
+            width = nextWidth
+            height = nextHeight
+        }
+        throw ToolImageAssetEncodingError.screenshotTooLarge
+    }
+
+    static func validateIconMasterJPEG(_ data: Data) throws -> CGImage {
+        try validateJPEG(
+            data,
+            width: iconMasterPixelSize,
+            height: iconMasterPixelSize,
+            maximumBytes: iconMasterMaximumBytes
+        )
+    }
+
+    static func validateIconThumbnailJPEG(_ data: Data) throws -> CGImage {
+        try validateJPEG(
+            data,
+            width: iconThumbnailPixelSize,
+            height: iconThumbnailPixelSize,
+            maximumBytes: iconThumbnailMaximumBytes
+        )
+    }
+
+    static func decodeImage(_ data: Data, applyingOrientation: Bool = false) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+            CGImageSourceGetCount(source) == 1
+        else {
+            throw ToolImageAssetEncodingError.invalidImage
+        }
+        if applyingOrientation {
+            let properties =
+                CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+                as? [CFString: Any]
+            let width = properties?[kCGImagePropertyPixelWidth] as? Int ?? 0
+            let height = properties?[kCGImagePropertyPixelHeight] as? Int ?? 0
+            let maximumDimension = max(width, height)
+            guard maximumDimension > 0,
+                let image = CGImageSourceCreateThumbnailAtIndex(
+                    source,
+                    0,
+                    [
+                        kCGImageSourceCreateThumbnailFromImageAlways: true,
+                        kCGImageSourceCreateThumbnailWithTransform: true,
+                        kCGImageSourceThumbnailMaxPixelSize: maximumDimension,
+                        kCGImageSourceShouldCacheImmediately: true,
+                    ] as CFDictionary
+                )
+            else {
+                throw ToolImageAssetEncodingError.invalidImage
+            }
+            return image
+        }
+        guard
+            let image = CGImageSourceCreateImageAtIndex(
+                source,
+                0,
+                [kCGImageSourceShouldCacheImmediately: true] as CFDictionary
+            )
+        else {
+            throw ToolImageAssetEncodingError.invalidImage
+        }
+        return image
+    }
+
+    static func largestImage(at url: URL) throws -> CGImage {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+            CGImageSourceGetCount(source) > 0
+        else {
+            throw ToolImageAssetEncodingError.invalidImage
+        }
+        let index =
+            (0..<CGImageSourceGetCount(source)).max { lhs, rhs in
+                pixelArea(source: source, index: lhs) < pixelArea(source: source, index: rhs)
+            } ?? 0
+        guard
+            let image = CGImageSourceCreateImageAtIndex(
+                source,
+                index,
+                [kCGImageSourceShouldCacheImmediately: true] as CFDictionary
+            )
+        else {
+            throw ToolImageAssetEncodingError.invalidImage
+        }
+        return image
+    }
+
+    static func squareImage(
+        _ image: CGImage,
+        pixelSize: Int,
+        opaque: Bool
+    ) throws -> CGImage {
+        let scale = max(
+            CGFloat(pixelSize) / CGFloat(image.width),
+            CGFloat(pixelSize) / CGFloat(image.height)
+        )
+        let drawWidth = CGFloat(image.width) * scale
+        let drawHeight = CGFloat(image.height) * scale
+        return try renderedImage(
+            image,
+            width: pixelSize,
+            height: pixelSize,
+            drawRect: CGRect(
+                x: (CGFloat(pixelSize) - drawWidth) / 2,
+                y: (CGFloat(pixelSize) - drawHeight) / 2,
+                width: drawWidth,
+                height: drawHeight
+            ),
+            opaque: opaque
+        )
+    }
+
+    static func resizedImage(
+        _ image: CGImage,
+        width: Int,
+        height: Int,
+        opaque: Bool
+    ) throws -> CGImage {
+        try renderedImage(
+            image,
+            width: width,
+            height: height,
+            drawRect: CGRect(x: 0, y: 0, width: width, height: height),
+            opaque: opaque
+        )
+    }
+
+    private static func validateJPEG(
+        _ data: Data,
+        width: Int,
+        height: Int,
+        maximumBytes: Int
+    ) throws -> CGImage {
+        guard !data.isEmpty, data.count <= maximumBytes,
+            !containsForbiddenJPEGMetadata(data),
+            let source = CGImageSourceCreateWithData(data as CFData, nil),
+            CGImageSourceGetCount(source) == 1,
+            CGImageSourceGetType(source) as String? == "public.jpeg",
+            let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+                as? [CFString: Any],
+            properties[kCGImagePropertyPixelWidth] as? Int == width,
+            properties[kCGImagePropertyPixelHeight] as? Int == height,
+            let image = CGImageSourceCreateImageAtIndex(
+                source,
+                0,
+                [kCGImageSourceShouldCacheImmediately: true] as CFDictionary
+            )
+        else {
+            throw ToolImageAssetEncodingError.invalidJPEG
+        }
+        return image
+    }
+
+    private static func jpeg(image: CGImage, quality: Double) throws -> Data {
+        guard
+            let data = NSMutableData(
+                capacity: max(4_096, image.width * image.height)
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotEncodeJPEG
+        }
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                data,
+                "public.jpeg" as CFString,
+                1,
+                nil
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotEncodeJPEG
+        }
+        CGImageDestinationAddImage(
+            destination,
+            image,
+            [
+                kCGImageDestinationLossyCompressionQuality: min(max(quality, 0), 1)
+            ] as CFDictionary
+        )
+        guard CGImageDestinationFinalize(destination), data.length > 0 else {
+            throw ToolImageAssetEncodingError.couldNotEncodeJPEG
+        }
+        return try strippingForbiddenJPEGMetadata(data as Data)
+    }
+
+    static func containsForbiddenJPEGMetadata(_ data: Data) -> Bool {
+        guard let segments = try? jpegSegments(in: data) else {
+            return true
+        }
+        return segments.contains { $0.marker == 0xe1 || $0.marker == 0xed }
+    }
+
+    private static func strippingForbiddenJPEGMetadata(_ data: Data) throws -> Data {
+        let segments = try jpegSegments(in: data)
+        var result = data
+        for segment in segments.reversed()
+        where segment.marker == 0xe1 || segment.marker == 0xed {
+            result.removeSubrange(segment.range)
+        }
+        return result
+    }
+
+    private static func jpegSegments(in data: Data) throws -> [(
+        marker: UInt8, range: Range<Data.Index>
+    )] {
+        let bytes = [UInt8](data)
+        guard bytes.count >= 4, bytes[0] == 0xff, bytes[1] == 0xd8 else {
+            throw ToolImageAssetEncodingError.invalidJPEG
+        }
+        var segments: [(marker: UInt8, range: Range<Data.Index>)] = []
+        var index = 2
+        while index < bytes.count {
+            guard bytes[index] == 0xff else {
+                throw ToolImageAssetEncodingError.invalidJPEG
+            }
+            let markerStart = index
+            while index < bytes.count, bytes[index] == 0xff {
+                index += 1
+            }
+            guard index < bytes.count else {
+                throw ToolImageAssetEncodingError.invalidJPEG
+            }
+            let marker = bytes[index]
+            index += 1
+            if marker == 0xda || marker == 0xd9 {
+                break
+            }
+            if marker == 0x01 || (0xd0...0xd7).contains(marker) {
+                segments.append((marker, markerStart..<index))
+                continue
+            }
+            guard index + 1 < bytes.count else {
+                throw ToolImageAssetEncodingError.invalidJPEG
+            }
+            let length = Int(bytes[index]) << 8 | Int(bytes[index + 1])
+            guard length >= 2, index + length <= bytes.count else {
+                throw ToolImageAssetEncodingError.invalidJPEG
+            }
+            let segmentEnd = index + length
+            segments.append((marker, markerStart..<segmentEnd))
+            index = segmentEnd
+        }
+        return segments
+    }
+
+    private static func renderedImage(
+        _ image: CGImage,
+        width: Int,
+        height: Int,
+        drawRect: CGRect,
+        opaque: Bool
+    ) throws -> CGImage {
+        guard width > 0, height > 0 else {
+            throw ToolImageAssetEncodingError.couldNotCreateImage
+        }
+        let colorSpace =
+            CGColorSpace(name: CGColorSpace.sRGB)
+            ?? CGColorSpaceCreateDeviceRGB()
+        guard
+            let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotCreateImage
+        }
+        let canvas = CGRect(x: 0, y: 0, width: width, height: height)
+        if opaque {
+            context.setFillColor(CGColor(gray: 1, alpha: 1))
+            context.fill(canvas)
+        }
+        context.interpolationQuality = .high
+        context.draw(image, in: drawRect)
+        guard let rendered = context.makeImage() else {
+            throw ToolImageAssetEncodingError.couldNotCreateImage
+        }
+        return rendered
+    }
+
+    private static func pixelArea(source: CGImageSource, index: Int) -> Int {
+        let properties =
+            CGImageSourceCopyPropertiesAtIndex(source, index, nil)
+            as? [CFString: Any]
+        let width = properties?[kCGImagePropertyPixelWidth] as? Int ?? 0
+        let height = properties?[kCGImagePropertyPixelHeight] as? Int ?? 0
+        return width * height
+    }
+}

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageAssetEncoder.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageAssetEncoder.swift
@@ -48,11 +48,11 @@ nonisolated enum ToolImageAssetEncoder {
     static let iconJPEGQuality = 0.60
     static let iconMasterMaximumBytes = 256 * 1024
     static let iconThumbnailMaximumBytes = 64 * 1024
-    static let screenshotMaximumWidth = 1280
-    static let screenshotMaximumHeight = 960
+    static let screenshotMaximumWidth = 1920
+    static let screenshotMaximumHeight = 1440
     static let screenshotMaximumBytes = 512 * 1024
     static let screenshotMinimumDimension = 64
-    static let screenshotJPEGQuality = 0.60
+    static let screenshotJPEGQuality = 0.70
 
     static func iconAssets(from image: CGImage) throws -> ToolJPEGIconAssets {
         let master = try jpeg(

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageGenerationClient.swift
@@ -50,13 +50,18 @@ nonisolated struct ToolImageGenerationClient: Sendable {
 
     @MainActor
     static func live() -> Self {
+        live(imagePlayground: .shared)
+    }
+
+    @MainActor
+    static func live(imagePlayground: ImagePlaygroundSheetCoordinator) -> Self {
         make(
             httpClient: .live,
             credentialClient: .live,
             codexAuthClient: .live(),
             accountClient: .live,
             backendConfiguration: .live,
-            imagePlayground: .shared
+            imagePlayground: imagePlayground
         )
     }
 

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -385,6 +385,21 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
         packageMetadataDirectoryURL.appendingPathComponent("AppIcon.png")
     }
 
+    nonisolated var cachedAppIconMasterJPEGURL: URL {
+        packageMetadataDirectoryURL.appendingPathComponent("AppIconMaster.jpg")
+    }
+
+    nonisolated var cachedAppIconThumbnailJPEGURL: URL {
+        packageMetadataDirectoryURL.appendingPathComponent("AppIconThumbnail.jpg")
+    }
+
+    nonisolated var cachedAppIconPreviewURL: URL {
+        if FileManager.default.fileExists(atPath: cachedAppIconThumbnailJPEGURL.path) {
+            return cachedAppIconThumbnailJPEGURL
+        }
+        return cachedAppIconPNGURL
+    }
+
     nonisolated var cachedAppIconICNSURL: URL {
         packageMetadataDirectoryURL.appendingPathComponent("AppIcon.icns")
     }

--- a/Ironsmith/Features/Settings/Debug/DebugIconExportClient.swift
+++ b/Ironsmith/Features/Settings/Debug/DebugIconExportClient.swift
@@ -107,15 +107,15 @@
                 throw DebugIconExportError.unsupportedFormat(request.format)
             }
 
-            let masterImage = try squareImage(
+            let masterImage = try ToolImageAssetEncoder.squareImage(
                 request.image,
                 pixelSize: request.masterPixelSize,
-                fillsOpaqueBackground: request.format == .jpeg
+                opaque: request.format == .jpeg
             )
-            let thumbnailImage = try squareImage(
+            let thumbnailImage = try ToolImageAssetEncoder.squareImage(
                 request.image,
                 pixelSize: request.thumbnailPixelSize,
-                fillsOpaqueBackground: request.format == .jpeg
+                opaque: request.format == .jpeg
             )
             let requestedQuality = min(max(request.quality, minimumLossyQuality), 1)
             let masterEncoding = try encodeMaster(
@@ -224,55 +224,6 @@
             return data as Data
         }
 
-        private static func squareImage(
-            _ image: CGImage,
-            pixelSize: Int,
-            fillsOpaqueBackground: Bool
-        ) throws -> CGImage {
-            let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)
-                ?? CGColorSpaceCreateDeviceRGB()
-            guard
-                let context = CGContext(
-                    data: nil,
-                    width: pixelSize,
-                    height: pixelSize,
-                    bitsPerComponent: 8,
-                    bytesPerRow: 0,
-                    space: colorSpace,
-                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-                )
-            else {
-                throw DebugIconExportError.couldNotScaleImage
-            }
-
-            let canvas = CGRect(x: 0, y: 0, width: pixelSize, height: pixelSize)
-            if fillsOpaqueBackground {
-                context.setFillColor(CGColor(gray: 1, alpha: 1))
-                context.fill(canvas)
-            }
-
-            let scale = max(
-                CGFloat(pixelSize) / CGFloat(image.width),
-                CGFloat(pixelSize) / CGFloat(image.height)
-            )
-            let drawSize = CGSize(
-                width: CGFloat(image.width) * scale,
-                height: CGFloat(image.height) * scale
-            )
-            let drawRect = CGRect(
-                x: (CGFloat(pixelSize) - drawSize.width) / 2,
-                y: (CGFloat(pixelSize) - drawSize.height) / 2,
-                width: drawSize.width,
-                height: drawSize.height
-            )
-            context.interpolationQuality = .high
-            context.draw(image, in: drawRect)
-            guard let result = context.makeImage() else {
-                throw DebugIconExportError.couldNotScaleImage
-            }
-            return result
-        }
-
         private static func runDirectoryName(
             providerName: String,
             format: DebugIconImageFormat
@@ -280,7 +231,8 @@
             let formatter = DateFormatter()
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
-            let provider = providerName
+            let provider =
+                providerName
                 .lowercased()
                 .replacingOccurrences(
                     of: "[^a-z0-9]+",

--- a/Ironsmith/Features/Settings/Debug/DebugIconExportClient.swift
+++ b/Ironsmith/Features/Settings/Debug/DebugIconExportClient.swift
@@ -1,0 +1,294 @@
+#if DEBUG
+    import CoreGraphics
+    import Foundation
+    import ImageIO
+
+    enum DebugIconImageFormat: String, CaseIterable, Identifiable {
+        case png
+        case jpeg
+        case webP = "webp"
+        case heic
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .png:
+                "PNG"
+            case .jpeg:
+                "JPEG"
+            case .webP:
+                "WebP"
+            case .heic:
+                "HEIC"
+            }
+        }
+
+        var fileExtension: String { rawValue }
+
+        var typeIdentifier: CFString {
+            switch self {
+            case .png:
+                "public.png" as CFString
+            case .jpeg:
+                "public.jpeg" as CFString
+            case .webP:
+                "org.webmproject.webp" as CFString
+            case .heic:
+                "public.heic" as CFString
+            }
+        }
+
+        var supportsLossyQuality: Bool {
+            self != .png
+        }
+    }
+
+    struct DebugIconExportRequest {
+        let image: CGImage
+        let format: DebugIconImageFormat
+        let quality: Double
+        let masterPixelSize: Int
+        let thumbnailPixelSize: Int
+        let targetMasterByteCount: Int?
+        let outputRootURL: URL
+        let providerName: String
+    }
+
+    struct DebugIconExportResult {
+        let directoryURL: URL
+        let masterURL: URL
+        let thumbnailURL: URL
+        let masterData: Data
+        let thumbnailData: Data
+        let effectiveMasterQuality: Double?
+        let targetMasterByteCount: Int?
+
+        var metTargetMasterSize: Bool {
+            guard let targetMasterByteCount else { return true }
+            return masterData.count <= targetMasterByteCount
+        }
+    }
+
+    enum DebugIconExportError: LocalizedError {
+        case invalidPixelSize
+        case couldNotScaleImage
+        case unsupportedFormat(DebugIconImageFormat)
+        case couldNotEncode(DebugIconImageFormat)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidPixelSize:
+                "Icon dimensions must be greater than zero."
+            case .couldNotScaleImage:
+                "The generated icon could not be resized."
+            case .unsupportedFormat(let format):
+                "\(format.displayName) encoding is unavailable on this Mac."
+            case .couldNotEncode(let format):
+                "The icon could not be encoded as \(format.displayName)."
+            }
+        }
+    }
+
+    enum DebugIconExportClient {
+        private static let minimumLossyQuality = 0.05
+        private static let qualityStep = 0.05
+
+        static func supportsEncoding(_ format: DebugIconImageFormat) -> Bool {
+            let supportedTypes = CGImageDestinationCopyTypeIdentifiers() as? [String] ?? []
+            return supportedTypes.contains(format.typeIdentifier as String)
+        }
+
+        static func export(_ request: DebugIconExportRequest) throws -> DebugIconExportResult {
+            guard request.masterPixelSize > 0, request.thumbnailPixelSize > 0 else {
+                throw DebugIconExportError.invalidPixelSize
+            }
+            guard supportsEncoding(request.format) else {
+                throw DebugIconExportError.unsupportedFormat(request.format)
+            }
+
+            let masterImage = try squareImage(
+                request.image,
+                pixelSize: request.masterPixelSize,
+                fillsOpaqueBackground: request.format == .jpeg
+            )
+            let thumbnailImage = try squareImage(
+                request.image,
+                pixelSize: request.thumbnailPixelSize,
+                fillsOpaqueBackground: request.format == .jpeg
+            )
+            let requestedQuality = min(max(request.quality, minimumLossyQuality), 1)
+            let masterEncoding = try encodeMaster(
+                masterImage,
+                format: request.format,
+                requestedQuality: requestedQuality,
+                targetByteCount: request.targetMasterByteCount
+            )
+            let thumbnailData = try encode(
+                thumbnailImage,
+                format: request.format,
+                quality: request.format.supportsLossyQuality ? requestedQuality : nil
+            )
+
+            let runDirectoryURL = request.outputRootURL.appendingPathComponent(
+                runDirectoryName(
+                    providerName: request.providerName,
+                    format: request.format
+                ),
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: runDirectoryURL,
+                withIntermediateDirectories: true
+            )
+
+            let masterURL = runDirectoryURL.appendingPathComponent(
+                "AppIconMaster-\(request.masterPixelSize).\(request.format.fileExtension)"
+            )
+            let thumbnailURL = runDirectoryURL.appendingPathComponent(
+                "AppIconThumbnail-\(request.thumbnailPixelSize).\(request.format.fileExtension)"
+            )
+            try masterEncoding.data.write(to: masterURL, options: .atomic)
+            try thumbnailData.write(to: thumbnailURL, options: .atomic)
+
+            return DebugIconExportResult(
+                directoryURL: runDirectoryURL,
+                masterURL: masterURL,
+                thumbnailURL: thumbnailURL,
+                masterData: masterEncoding.data,
+                thumbnailData: thumbnailData,
+                effectiveMasterQuality: masterEncoding.quality,
+                targetMasterByteCount: request.targetMasterByteCount
+            )
+        }
+
+        private static func encodeMaster(
+            _ image: CGImage,
+            format: DebugIconImageFormat,
+            requestedQuality: Double,
+            targetByteCount: Int?
+        ) throws -> (data: Data, quality: Double?) {
+            guard format.supportsLossyQuality else {
+                return (try encode(image, format: format, quality: nil), nil)
+            }
+
+            var quality = requestedQuality
+            var smallest = try encode(image, format: format, quality: quality)
+            var effectiveQuality = quality
+            guard let targetByteCount, targetByteCount > 0 else {
+                return (smallest, effectiveQuality)
+            }
+
+            while smallest.count > targetByteCount,
+                quality - qualityStep >= minimumLossyQuality
+            {
+                quality = max(minimumLossyQuality, quality - qualityStep)
+                let candidate = try encode(image, format: format, quality: quality)
+                if candidate.count < smallest.count {
+                    smallest = candidate
+                    effectiveQuality = quality
+                }
+            }
+            return (smallest, effectiveQuality)
+        }
+
+        private static func encode(
+            _ image: CGImage,
+            format: DebugIconImageFormat,
+            quality: Double?
+        ) throws -> Data {
+            let capacity = max(4_096, image.width * image.height)
+            guard let data = NSMutableData(capacity: capacity),
+                let destination = CGImageDestinationCreateWithData(
+                    data,
+                    format.typeIdentifier,
+                    1,
+                    nil
+                )
+            else {
+                throw DebugIconExportError.unsupportedFormat(format)
+            }
+
+            var properties: [CFString: Any] = [:]
+            if let quality {
+                properties[kCGImageDestinationLossyCompressionQuality] = quality
+            }
+            CGImageDestinationAddImage(
+                destination,
+                image,
+                properties.isEmpty ? nil : properties as CFDictionary
+            )
+            guard CGImageDestinationFinalize(destination), data.length > 0 else {
+                throw DebugIconExportError.couldNotEncode(format)
+            }
+            return data as Data
+        }
+
+        private static func squareImage(
+            _ image: CGImage,
+            pixelSize: Int,
+            fillsOpaqueBackground: Bool
+        ) throws -> CGImage {
+            let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)
+                ?? CGColorSpaceCreateDeviceRGB()
+            guard
+                let context = CGContext(
+                    data: nil,
+                    width: pixelSize,
+                    height: pixelSize,
+                    bitsPerComponent: 8,
+                    bytesPerRow: 0,
+                    space: colorSpace,
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                )
+            else {
+                throw DebugIconExportError.couldNotScaleImage
+            }
+
+            let canvas = CGRect(x: 0, y: 0, width: pixelSize, height: pixelSize)
+            if fillsOpaqueBackground {
+                context.setFillColor(CGColor(gray: 1, alpha: 1))
+                context.fill(canvas)
+            }
+
+            let scale = max(
+                CGFloat(pixelSize) / CGFloat(image.width),
+                CGFloat(pixelSize) / CGFloat(image.height)
+            )
+            let drawSize = CGSize(
+                width: CGFloat(image.width) * scale,
+                height: CGFloat(image.height) * scale
+            )
+            let drawRect = CGRect(
+                x: (CGFloat(pixelSize) - drawSize.width) / 2,
+                y: (CGFloat(pixelSize) - drawSize.height) / 2,
+                width: drawSize.width,
+                height: drawSize.height
+            )
+            context.interpolationQuality = .high
+            context.draw(image, in: drawRect)
+            guard let result = context.makeImage() else {
+                throw DebugIconExportError.couldNotScaleImage
+            }
+            return result
+        }
+
+        private static func runDirectoryName(
+            providerName: String,
+            format: DebugIconImageFormat
+        ) -> String {
+            let formatter = DateFormatter()
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.dateFormat = "yyyyMMdd-HHmmss-SSS"
+            let provider = providerName
+                .lowercased()
+                .replacingOccurrences(
+                    of: "[^a-z0-9]+",
+                    with: "-",
+                    options: .regularExpression
+                )
+                .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+            return "\(formatter.string(from: Date()))-\(provider)-\(format.rawValue)"
+        }
+    }
+#endif

--- a/Ironsmith/Features/Settings/Sections/SettingsDebugSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsDebugSectionView.swift
@@ -57,7 +57,7 @@
                     Text("Feature Flags")
                         .font(.headline)
 
-                    Toggle("App Store", isOn: $storeFeatureEnabled)
+                    Toggle("Ironsmith Store", isOn: $storeFeatureEnabled)
                         .toggleStyle(.switch)
 
                     Toggle(

--- a/Ironsmith/Features/Settings/Sections/SettingsDebugSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsDebugSectionView.swift
@@ -1,10 +1,12 @@
 #if DEBUG
     import AppKit
+    import ImageIO
     import ImagePlayground
     import SwiftUI
     import UniformTypeIdentifiers
 
     struct SettingsDebugSectionView: View {
+        @Environment(InferenceStore.self) private var inferenceStore
         @AppStorage(IronsmithPreferenceKeys.debugAlwaysShowWelcomeOnboarding)
         private var alwaysShowWelcomeOnboarding = false
         @AppStorage(IronsmithPreferenceKeys.debugAlwaysOpenOllamaEditorAfterAdd)
@@ -18,12 +20,22 @@
         private var storeFeatureEnabled = false
         @AppStorage(IronsmithPreferenceKeys.featureDiagnosticWholeFileRewriteEnabled)
         private var diagnosticWholeFileRewriteEnabled = false
-        @State private var imagePlaygroundPrompt = ""
-        @State private var imagePlaygroundPreview: NSImage?
-        @State private var imagePlaygroundErrorMessage: String?
-        @State private var isGeneratingImagePlaygroundPreview = false
+        @State private var iconLabPrompt = ""
+        @State private var iconLabFormat = DebugIconImageFormat.png
+        @State private var iconLabQuality = 0.8
+        @State private var iconLabMasterPixelSize = 1024
+        @State private var iconLabTargetMasterKilobytes = "128"
+        @State private var iconLabMasterPreview: NSImage?
+        @State private var iconLabThumbnailPreview: NSImage?
+        @State private var iconLabResult: DebugIconExportResult?
+        @State private var iconLabDescription: String?
+        @State private var iconLabErrorMessage: String?
+        @State private var isGeneratingIconLabImages = false
         @State private var imagePlaygroundCoordinator = ImagePlaygroundSheetCoordinator()
-        @State private var isShowingImageDownscalerImporter = false
+        @State private var isShowingImageImporter = false
+        @State private var imageImporterPurpose = SettingsDebugImageImporterPurpose.iconPNG
+        @State private var importedIconLabPNG: CGImage?
+        @State private var importedIconLabPNGName: String?
         @State private var downscaledImagePreview: NSImage?
         @State private var downscaledImageOutputURL: URL?
         @State private var downscaledImageDescription: String?
@@ -68,54 +80,153 @@
                 }
 
                 VStack(alignment: .leading, spacing: 10) {
-                    Text("Image Playground")
+                    Text("App Icon Format Lab")
                         .font(.headline)
 
                     HStack(alignment: .firstTextBaseline, spacing: 10) {
                         TextField(
                             "Prompt",
-                            text: $imagePlaygroundPrompt,
+                            text: $iconLabPrompt,
                             prompt: Text("A friendly forge icon")
                         )
                         .textFieldStyle(.roundedBorder)
                         .onSubmit {
-                            startImagePlaygroundGeneration()
+                            startIconLabGeneration()
                         }
 
-                        Button(isGeneratingImagePlaygroundPreview ? "Generating..." : "Generate") {
-                            startImagePlaygroundGeneration()
+                        Button(isGeneratingIconLabImages ? "Working..." : "Generate & Export") {
+                            startIconLabGeneration()
                         }
-                        .disabled(isImagePlaygroundGenerateDisabled)
+                        .disabled(isIconLabGenerateDisabled)
                     }
 
-                    if isGeneratingImagePlaygroundPreview {
+                    Text(iconLabProviderDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 10) {
+                        Button("Choose PNG…") {
+                            presentImageImporter(for: .iconPNG)
+                        }
+
+                        if importedIconLabPNG != nil {
+                            Button("Export Selected PNG") {
+                                exportImportedIconLabPNG()
+                            }
+                            .disabled(isIconLabExportDisabled)
+                        }
+
+                        if let importedIconLabPNGName {
+                            Text(importedIconLabPNGName)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    HStack(spacing: 16) {
+                        Picker("Format", selection: $iconLabFormat) {
+                            ForEach(DebugIconImageFormat.allCases) { format in
+                                Text(format.displayName)
+                                    .tag(format)
+                            }
+                        }
+                        .frame(maxWidth: 180)
+
+                        Picker("Master", selection: $iconLabMasterPixelSize) {
+                            Text("512×512").tag(512)
+                            Text("1024×1024").tag(1024)
+                            Text("2048×2048").tag(2048)
+                        }
+                        .frame(maxWidth: 190)
+                    }
+
+                    HStack(spacing: 10) {
+                        Text("Quality")
+                        Slider(value: $iconLabQuality, in: 0.05...1, step: 0.05)
+                            .disabled(!iconLabFormat.supportsLossyQuality)
+                        Text(iconLabFormat.supportsLossyQuality
+                            ? iconLabQuality.formatted(.number.precision(.fractionLength(2)))
+                            : "Lossless")
+                            .font(.caption.monospacedDigit())
+                            .frame(width: 58, alignment: .trailing)
+                    }
+
+                    HStack(spacing: 10) {
+                        Text("Master target")
+                        TextField("Optional", text: $iconLabTargetMasterKilobytes)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 80)
+                        Text("KB")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text(
+                        "A target lowers lossy quality in 0.05 steps when necessary. "
+                            + "PNG ignores quality and the target."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                    if !DebugIconExportClient.supportsEncoding(iconLabFormat) {
+                        Text(
+                            "\(iconLabFormat.displayName) can be decoded but not encoded by "
+                                + "Image I/O on this Mac. A WebP codec dependency would be required."
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                    }
+
+                    if isGeneratingIconLabImages {
                         HStack(spacing: 8) {
                             ProgressView()
                                 .controlSize(.small)
-                            Text("Generating image")
+                            Text("Processing icon")
                                 .foregroundStyle(.secondary)
                         }
                         .font(.caption)
                     }
 
-                    if let imagePlaygroundErrorMessage {
-                        Text(imagePlaygroundErrorMessage)
+                    if let iconLabErrorMessage {
+                        Text(iconLabErrorMessage)
                             .font(.caption)
                             .foregroundStyle(.red)
                     }
 
-                    if let imagePlaygroundPreview {
-                        Image(nsImage: imagePlaygroundPreview)
-                            .resizable()
-                            .interpolation(.high)
-                            .scaledToFit()
-                            .frame(width: 180, height: 180)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(.quaternary, lineWidth: 1)
+                    if let iconLabMasterPreview, let iconLabThumbnailPreview {
+                        HStack(alignment: .top, spacing: 18) {
+                            iconLabPreview(
+                                title: "Master",
+                                image: iconLabMasterPreview,
+                                size: 180
+                            )
+                            iconLabPreview(
+                                title: "Thumbnail",
+                                image: iconLabThumbnailPreview,
+                                size: 96
+                            )
                         }
                     }
+
+                    if let iconLabDescription {
+                        Text(iconLabDescription)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let iconLabResult {
+                        Button("Show Exports in Finder") {
+                            NSWorkspace.shared.activateFileViewerSelecting([
+                                iconLabResult.masterURL,
+                                iconLabResult.thumbnailURL,
+                            ])
+                        }
+                    }
+
+                    Text("Writes each experiment to ~/.ironsmith/.debug/icon-format-lab.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
 
                 VStack(alignment: .leading, spacing: 10) {
@@ -124,7 +235,7 @@
 
                     HStack(spacing: 10) {
                         Button("Choose Image…") {
-                            isShowingImageDownscalerImporter = true
+                            presentImageImporter(for: .attachment)
                         }
 
                         if let downscaledImageOutputURL {
@@ -178,39 +289,229 @@
                 onCancellation: imagePlaygroundCoordinator.canceled
             )
             .fileImporter(
-                isPresented: $isShowingImageDownscalerImporter,
-                allowedContentTypes: [.image],
+                isPresented: $isShowingImageImporter,
+                allowedContentTypes: imageImporterPurpose.allowedContentTypes,
                 allowsMultipleSelection: false
             ) { result in
                 guard case .success(let urls) = result, let url = urls.first else { return }
-                downscaleAttachmentImage(at: url)
+                switch imageImporterPurpose {
+                case .iconPNG:
+                    importIconLabPNG(at: url)
+                case .attachment:
+                    downscaleAttachmentImage(at: url)
+                }
             }
         }
 
-        private var isImagePlaygroundGenerateDisabled: Bool {
-            isGeneratingImagePlaygroundPreview
-                || imagePlaygroundPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        private func presentImageImporter(for purpose: SettingsDebugImageImporterPurpose) {
+            imageImporterPurpose = purpose
+            isShowingImageImporter = true
         }
 
-        private func startImagePlaygroundGeneration() {
-            guard !isImagePlaygroundGenerateDisabled else { return }
+        private var isIconLabGenerateDisabled: Bool {
+            isGeneratingIconLabImages
+                || iconLabPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                || inferenceStore.effectiveImageGenerationProvider == .disabled
+                || !DebugIconExportClient.supportsEncoding(iconLabFormat)
+        }
 
-            isGeneratingImagePlaygroundPreview = true
-            imagePlaygroundErrorMessage = nil
+        private var isIconLabExportDisabled: Bool {
+            isGeneratingIconLabImages
+                || importedIconLabPNG == nil
+                || !DebugIconExportClient.supportsEncoding(iconLabFormat)
+        }
 
-            let prompt = imagePlaygroundPrompt
+        private var iconLabProviderDescription: String {
+            let selected = inferenceStore.generationPreferences.imageGenerationProvider
+            let effective = inferenceStore.effectiveImageGenerationProvider
+            if selected == .automatic {
+                return "Generator: Automatic → \(effective.displayName)"
+            }
+            return "Generator: \(effective.displayName)"
+        }
+
+        private func startIconLabGeneration() {
+            guard !isIconLabGenerateDisabled else { return }
+
+            isGeneratingIconLabImages = true
+            iconLabErrorMessage = nil
+            iconLabResult = nil
+            iconLabDescription = nil
+
+            let prompt = iconLabPrompt
+            let provider = inferenceStore.effectiveImageGenerationProvider
+            let format = iconLabFormat
+            let quality = iconLabQuality
+            let masterPixelSize = iconLabMasterPixelSize
+            let targetMasterByteCount = parsedIconLabTargetMasterByteCount
             Task {
                 do {
-                    imagePlaygroundPreview = try await ToolIconClient.debugImagePlaygroundPreview(
-                        prompt: prompt,
-                        coordinator: imagePlaygroundCoordinator
+                    let debugRootURL = IronsmithPaths.rootDirectory
+                        .appendingPathComponent(".debug", isDirectory: true)
+                        .appendingPathComponent("icon-format-lab", isDirectory: true)
+                    let promptRequest = ToolIconRequest(
+                        displayName: "Debug Icon",
+                        iconPrompt: prompt,
+                        layout: ToolPackageLayout(
+                            packageRootURL: debugRootURL,
+                            executableName: "DebugIcon"
+                        ),
+                        imageProvider: provider
+                    )
+                    let generatedImage = try await ToolImageGenerationClient.live(
+                        imagePlayground: imagePlaygroundCoordinator
+                    ).generate(
+                        provider,
+                        ToolIconClient.iconPrompt(for: promptRequest)
+                    )
+                    try exportIconLabImage(
+                        generatedImage,
+                        providerName: provider.displayName,
+                        format: format,
+                        quality: quality,
+                        masterPixelSize: masterPixelSize,
+                        targetMasterByteCount: targetMasterByteCount,
+                        debugRootURL: debugRootURL
                     )
                 } catch {
-                    imagePlaygroundPreview = nil
-                    imagePlaygroundErrorMessage = AgentDiagnosticsLog.renderError(error, limit: 300)
+                    iconLabMasterPreview = nil
+                    iconLabThumbnailPreview = nil
+                    iconLabErrorMessage = AgentDiagnosticsLog.renderError(error, limit: 300)
                 }
-                isGeneratingImagePlaygroundPreview = false
+                isGeneratingIconLabImages = false
             }
+        }
+
+        private func importIconLabPNG(at sourceURL: URL) {
+            iconLabErrorMessage = nil
+            let didAccess = sourceURL.startAccessingSecurityScopedResource()
+            defer {
+                if didAccess {
+                    sourceURL.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            do {
+                let data = try Data(contentsOf: sourceURL)
+                guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+                    CGImageSourceGetType(source) as String? == "public.png",
+                    let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+                else {
+                    throw DebugIconExportError.couldNotEncode(.png)
+                }
+                importedIconLabPNG = image
+                importedIconLabPNGName = sourceURL.lastPathComponent
+            } catch {
+                importedIconLabPNG = nil
+                importedIconLabPNGName = nil
+                iconLabErrorMessage = AgentDiagnosticsLog.renderError(error, limit: 300)
+            }
+        }
+
+        private func exportImportedIconLabPNG() {
+            guard let importedIconLabPNG, !isIconLabExportDisabled else { return }
+            isGeneratingIconLabImages = true
+            iconLabErrorMessage = nil
+            iconLabResult = nil
+            iconLabDescription = nil
+
+            do {
+                try exportIconLabImage(
+                    importedIconLabPNG,
+                    providerName: "Imported PNG",
+                    format: iconLabFormat,
+                    quality: iconLabQuality,
+                    masterPixelSize: iconLabMasterPixelSize,
+                    targetMasterByteCount: parsedIconLabTargetMasterByteCount,
+                    debugRootURL: IronsmithPaths.rootDirectory
+                        .appendingPathComponent(".debug", isDirectory: true)
+                        .appendingPathComponent("icon-format-lab", isDirectory: true)
+                )
+            } catch {
+                iconLabMasterPreview = nil
+                iconLabThumbnailPreview = nil
+                iconLabErrorMessage = AgentDiagnosticsLog.renderError(error, limit: 300)
+            }
+            isGeneratingIconLabImages = false
+        }
+
+        private func exportIconLabImage(
+            _ image: CGImage,
+            providerName: String,
+            format: DebugIconImageFormat,
+            quality: Double,
+            masterPixelSize: Int,
+            targetMasterByteCount: Int?,
+            debugRootURL: URL
+        ) throws {
+            let result = try DebugIconExportClient.export(
+                DebugIconExportRequest(
+                    image: image,
+                    format: format,
+                    quality: quality,
+                    masterPixelSize: masterPixelSize,
+                    thumbnailPixelSize: 256,
+                    targetMasterByteCount: targetMasterByteCount,
+                    outputRootURL: debugRootURL,
+                    providerName: providerName
+                )
+            )
+            iconLabResult = result
+            iconLabMasterPreview = NSImage(data: result.masterData)
+            iconLabThumbnailPreview = NSImage(data: result.thumbnailData)
+            iconLabDescription = iconLabResultDescription(result)
+        }
+
+        private var parsedIconLabTargetMasterByteCount: Int? {
+            guard iconLabFormat.supportsLossyQuality else { return nil }
+            let trimmed = iconLabTargetMasterKilobytes
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let kilobytes = Double(trimmed), kilobytes > 0 else { return nil }
+            return Int(kilobytes * 1_024)
+        }
+
+        @ViewBuilder
+        private func iconLabPreview(title: String, image: NSImage, size: CGFloat) -> some View {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Image(nsImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: size, height: size)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(.quaternary, lineWidth: 1)
+                    }
+            }
+        }
+
+        private func iconLabResultDescription(_ result: DebugIconExportResult) -> String {
+            let masterSize = ByteCountFormatter.string(
+                fromByteCount: Int64(result.masterData.count),
+                countStyle: .file
+            )
+            let thumbnailSize = ByteCountFormatter.string(
+                fromByteCount: Int64(result.thumbnailData.count),
+                countStyle: .file
+            )
+            var components = [
+                "Master \(masterSize)",
+                "Thumbnail \(thumbnailSize)",
+            ]
+            if let quality = result.effectiveMasterQuality {
+                components.append(
+                    "Master quality "
+                        + quality.formatted(.number.precision(.fractionLength(2)))
+                )
+            }
+            if result.targetMasterByteCount != nil, !result.metTargetMasterSize {
+                components.append("Target not reached")
+            }
+            return components.joined(separator: " • ")
         }
 
         private func downscaleAttachmentImage(at sourceURL: URL) {
@@ -267,6 +568,20 @@
                 dimensions = "Unknown dimensions"
             }
             return "\(dimensions) • \(byteCount) • \(outputURL.lastPathComponent)"
+        }
+    }
+
+    private enum SettingsDebugImageImporterPurpose {
+        case iconPNG
+        case attachment
+
+        var allowedContentTypes: [UTType] {
+            switch self {
+            case .iconPNG:
+                [.png]
+            case .attachment:
+                [.image]
+            }
         }
     }
 #endif

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -240,7 +240,7 @@ nonisolated struct StoreAppDetail: Decodable, Identifiable, Equatable, Sendable 
     let icon: StoreAsset?
     let screenshots: [StoreAsset]
     let currentVersion: StoreVersionMetadata
-    let recentVersions: [StoreVersionMetadata]
+    let versions: [StoreVersionMetadata]
     let remix: StoreRemixMetadata?
 
     var iconAsset: StoreAsset? {

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -29,31 +29,52 @@ nonisolated enum StoreAssetKind: String, Codable, Equatable, Sendable {
 }
 
 nonisolated enum StoreAppCategory: String, Codable, CaseIterable, Identifiable, Hashable, Sendable {
+    case business
+    case developerTools
+    case education
+    case entertainment
+    case finance
+    case games
+    case graphicsDesign
+    case healthFitness
+    case lifestyle
+    case music
     case productivity
     case utilities
-    case developerTools
-    case creativity
-    case education
-    case finance
-    case lifestyle
-    case entertainment
-    case reference
-    case other
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
+        case .business: "Business"
+        case .developerTools: "Developer Tools"
+        case .education: "Education"
+        case .entertainment: "Entertainment"
+        case .finance: "Finance"
+        case .games: "Games"
+        case .graphicsDesign: "Graphics & Design"
+        case .healthFitness: "Health & Fitness"
+        case .lifestyle: "Lifestyle"
+        case .music: "Music"
         case .productivity: "Productivity"
         case .utilities: "Utilities"
-        case .developerTools: "Developer Tools"
-        case .creativity: "Creativity"
-        case .education: "Education"
-        case .finance: "Finance"
-        case .lifestyle: "Lifestyle"
-        case .entertainment: "Entertainment"
-        case .reference: "Reference"
-        case .other: "Other"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .business: "briefcase"
+        case .developerTools: "hammer"
+        case .education: "graduationcap"
+        case .entertainment: "play.rectangle"
+        case .finance: "dollarsign.circle"
+        case .games: "gamecontroller"
+        case .graphicsDesign: "paintbrush"
+        case .healthFitness: "heart"
+        case .lifestyle: "leaf"
+        case .music: "music.note"
+        case .productivity: "checkmark.circle"
+        case .utilities: "wrench.and.screwdriver"
         }
     }
 }

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -327,11 +327,11 @@ nonisolated enum IronsmithStoreClientError: LocalizedError, Equatable {
         case .notConfigured:
             return "Ironsmith service is not configured."
         case .missingSession:
-            return "Sign in with Ironsmith before using the App Store."
+            return "Sign in with Ironsmith before using the Ironsmith Store."
         case .invalidResponse:
-            return "The App Store returned an invalid response."
+            return "The Ironsmith Store returned an invalid response."
         case .requestFailed(let statusCode, let message):
-            return "The App Store returned HTTP \(statusCode): \(message)"
+            return "The Ironsmith Store returned HTTP \(statusCode): \(message)"
         case .sourceHashMismatch:
             return "The downloaded source did not match the scanned source hash."
         }

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -26,6 +26,7 @@ nonisolated enum StoreAppStatus: String, Codable, Equatable, Sendable {
 
 nonisolated enum StoreAssetKind: String, Codable, Equatable, Sendable {
     case icon
+    case iconMaster
     case screenshot
 }
 
@@ -260,6 +261,7 @@ nonisolated struct StoreAppDetail: Decodable, Identifiable, Equatable, Sendable 
     let createdAt: String
     let updatedAt: String
     let icon: StoreAsset?
+    let iconMaster: StoreAsset?
     let screenshots: [StoreAsset]
     let currentVersion: StoreVersionMetadata
     let versions: [StoreVersionMetadata]
@@ -268,7 +270,6 @@ nonisolated struct StoreAppDetail: Decodable, Identifiable, Equatable, Sendable 
     var iconAsset: StoreAsset? {
         icon
     }
-
 }
 
 nonisolated struct StoreAppPage: Equatable, Sendable {
@@ -292,8 +293,9 @@ nonisolated struct StorePublicationRequest: Sendable {
     let category: StoreAppCategory
     let sourceCode: String
     let generationSettings: ToolGenerationSettings
-    let iconPNG: Data
-    let screenshotPNGs: [Data]
+    let iconMasterJPEG: Data
+    let iconThumbnailJPEG: Data
+    let screenshotJPEGs: [Data]
     let remixedFromVersionId: String?
 }
 
@@ -302,8 +304,9 @@ nonisolated struct StoreVersionPublicationRequest: Sendable {
     let appId: String
     let sourceCode: String
     let generationSettings: ToolGenerationSettings
-    let iconPNG: Data?
-    let screenshotPNGs: [Data]
+    let iconMasterJPEG: Data?
+    let iconThumbnailJPEG: Data?
+    let screenshotJPEGs: [Data]
     let replaceScreenshots: Bool
     let remixedFromVersionId: String?
 }
@@ -455,10 +458,18 @@ extension IronsmithStoreClient {
                         data: Data(request.sourceCode.utf8)
                     )
                     .addingFile(
-                        name: "icon", filename: "icon.png", contentType: "image/png",
-                        data: request.iconPNG
+                        name: "iconMaster",
+                        filename: "icon-master.jpg",
+                        contentType: "image/jpeg",
+                        data: request.iconMasterJPEG
                     )
-                    .addingScreenshotFiles(request.screenshotPNGs)
+                    .addingFile(
+                        name: "iconThumbnail",
+                        filename: "icon-thumbnail.jpg",
+                        contentType: "image/jpeg",
+                        data: request.iconThumbnailJPEG
+                    )
+                    .addingScreenshotFiles(request.screenshotJPEGs)
                 let response: StoreDataEnvelope<StoreAppDetail> = try await api.request(
                     "api/v1/stores/\(request.storeId)/apps",
                     method: "POST",
@@ -469,6 +480,12 @@ extension IronsmithStoreClient {
                 return response.data
             },
             publishVersion: { request in
+                guard
+                    (request.iconMasterJPEG == nil)
+                        == (request.iconThumbnailJPEG == nil)
+                else {
+                    throw IronsmithStoreClientError.invalidResponse
+                }
                 let metadata = StoreVersionMetadataPayload(
                     runtimeVersion: IronsmithStoreConstants.runtimeVersion,
                     generationSettings: StoreGenerationSettingsDTO(
@@ -484,11 +501,23 @@ extension IronsmithStoreClient {
                         contentType: "text/x-swift",
                         data: Data(request.sourceCode.utf8)
                     )
-                if let iconPNG = request.iconPNG {
+                if let iconMasterJPEG = request.iconMasterJPEG,
+                    let iconThumbnailJPEG = request.iconThumbnailJPEG
+                {
                     body = body.addingFile(
-                        name: "icon", filename: "icon.png", contentType: "image/png", data: iconPNG)
+                        name: "iconMaster",
+                        filename: "icon-master.jpg",
+                        contentType: "image/jpeg",
+                        data: iconMasterJPEG
+                    )
+                    body = body.addingFile(
+                        name: "iconThumbnail",
+                        filename: "icon-thumbnail.jpg",
+                        contentType: "image/jpeg",
+                        data: iconThumbnailJPEG
+                    )
                 }
-                body = body.addingScreenshotFiles(request.screenshotPNGs)
+                body = body.addingScreenshotFiles(request.screenshotJPEGs)
                 let response: StoreDataEnvelope<StoreAppDetail> = try await api.request(
                     "api/v1/stores/\(request.storeId)/apps/\(request.appId)/versions",
                     method: "POST",
@@ -679,7 +708,7 @@ nonisolated private struct StoreVersionMetadataPayload: Encodable {
     let replaceScreenshots: Bool
 }
 
-nonisolated private struct StoreMultipartBody {
+nonisolated struct StoreMultipartBody {
     let boundary: String
     private(set) var data = Data()
 
@@ -725,8 +754,8 @@ nonisolated private struct StoreMultipartBody {
         for (index, screenshot) in screenshots.enumerated() {
             copy = copy.addingFile(
                 name: "screenshots",
-                filename: "screenshot-\(index + 1).png",
-                contentType: "image/png",
+                filename: "screenshot-\(index + 1).jpg",
+                contentType: "image/jpeg",
                 data: screenshot
             )
         }

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -274,7 +274,7 @@ nonisolated struct StoreAppDetail: Decodable, Identifiable, Equatable, Sendable 
 
 nonisolated struct StoreAppPage: Equatable, Sendable {
     let apps: [StoreAppSummary]
-    let nextCursor: String?
+    let hasMore: Bool
 }
 
 nonisolated struct StoreHomeSection: Decodable, Identifiable, Equatable, Sendable {
@@ -350,7 +350,7 @@ nonisolated struct IronsmithStoreClient {
             _ storeId: String,
             _ scope: StoreAppListScope,
             _ search: String?,
-            _ cursor: String?,
+            _ offset: Int,
             _ sort: StoreAppListSort,
             _ category: StoreAppCategory?
         ) async throws
@@ -396,10 +396,11 @@ extension IronsmithStoreClient {
                 )
                 return response.data
             },
-            listApps: { storeId, scope, search, cursor, sort, category in
+            listApps: { storeId, scope, search, offset, sort, category in
                 var queryItems = [
                     URLQueryItem(name: "scope", value: scope.rawValue),
                     URLQueryItem(name: "sort", value: sort.rawValue),
+                    URLQueryItem(name: "offset", value: String(offset)),
                     URLQueryItem(
                         name: "limit",
                         value: String(IronsmithStoreConstants.appListPageSize)
@@ -411,16 +412,13 @@ extension IronsmithStoreClient {
                 if let category {
                     queryItems.append(URLQueryItem(name: "category", value: category.rawValue))
                 }
-                if let cursor {
-                    queryItems.append(URLQueryItem(name: "cursor", value: cursor))
-                }
                 let response: StorePageEnvelope<StoreAppSummary> = try await api.request(
                     "api/v1/stores/\(storeId)/apps",
                     method: "GET",
                     queryItems: queryItems,
                     authentication: scope == .mine ? .required : .optional
                 )
-                return StoreAppPage(apps: response.data, nextCursor: response.nextCursor)
+                return StoreAppPage(apps: response.data, hasMore: response.hasMore)
             },
             fetchApp: { storeId, appId in
                 let response: StoreDataEnvelope<StoreAppDetail> = try await api.request(
@@ -679,7 +677,7 @@ nonisolated private struct StoreDataEnvelope<DataValue: Decodable>: Decodable {
 
 nonisolated private struct StorePageEnvelope<DataValue: Decodable>: Decodable {
     let data: [DataValue]
-    let nextCursor: String?
+    let hasMore: Bool
 }
 
 nonisolated private struct StoreBackendErrorEnvelope: Decodable {

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -3,6 +3,7 @@ import Foundation
 
 nonisolated enum IronsmithStoreConstants {
     static let communityStoreId = "00000000-0000-4000-8000-000000000011"
+    static let appListPageSize = 30
 
     static var runtimeVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
@@ -396,6 +397,10 @@ extension IronsmithStoreClient {
                 var queryItems = [
                     URLQueryItem(name: "scope", value: scope.rawValue),
                     URLQueryItem(name: "sort", value: sort.rawValue),
+                    URLQueryItem(
+                        name: "limit",
+                        value: String(IronsmithStoreConstants.appListPageSize)
+                    ),
                 ]
                 if let search, !search.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     queryItems.append(URLQueryItem(name: "q", value: search))

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -1,0 +1,478 @@
+import SwiftUI
+
+struct StoreAppDetailView: View {
+    let app: StoreAppDetail?
+    let isLoading: Bool
+    let isWorking: Bool
+    let workingVersionID: String?
+    let installDisposition: StoreAppInstallDisposition
+    let canRemix: Bool
+    let versionInstallDisposition: (StoreAppDetail, StoreVersionMetadata) -> StoreAppInstallDisposition
+    let onGet: (StoreAppDetail) -> Void
+    let onRemix: (StoreAppDetail) -> Void
+    let onInstallVersion: (StoreAppDetail, StoreVersionMetadata) -> Void
+
+    @State private var expandedVersionID: String?
+
+    var body: some View {
+        Group {
+            if let app {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 28) {
+                        StoreDetailHeroView(
+                            app: app,
+                            isWorking: isWorking,
+                            installDisposition: installDisposition,
+                            canRemix: canRemix,
+                            onGet: { onGet(app) },
+                            onRemix: { onRemix(app) }
+                        )
+
+                        StoreDetailMetadataStrip(app: app)
+
+                        if let screenshot = app.screenshots.first {
+                            StoreDetailScreenshot(asset: screenshot)
+                        }
+
+                        Text(app.description)
+                            .font(.body)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        StorePermissionsSection(version: app.currentVersion)
+
+                        StoreVersionsCard(
+                            app: app,
+                            expandedVersionID: $expandedVersionID,
+                            isWorking: isWorking,
+                            workingVersionID: workingVersionID,
+                            installDisposition: versionInstallDisposition,
+                            onInstall: onInstallVersion
+                        )
+                    }
+                    .padding(28)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .task(id: app.id) {
+                    expandedVersionID = app.currentVersion.id
+                }
+            } else if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                StoreEmptyStateView(title: "App not found", systemImage: "square.grid.2x2")
+            }
+        }
+    }
+}
+
+private struct StoreDetailHeroView: View {
+    let app: StoreAppDetail
+    let isWorking: Bool
+    let installDisposition: StoreAppInstallDisposition
+    let canRemix: Bool
+    let onGet: () -> Void
+    let onRemix: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 18) {
+            StoreIconView(url: app.iconAsset?.url, size: 104)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(app.name)
+                    .font(.largeTitle.weight(.semibold))
+                Text(app.shortDescription)
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 10) {
+                    Button(installDisposition.buttonTitle, action: onGet)
+                        .buttonStyle(.borderedProminent)
+                        .buttonBorderShape(.capsule)
+                        .controlSize(.small)
+
+                    if canRemix {
+                        Button("Remix", action: onRemix)
+                            .buttonStyle(.bordered)
+                            .buttonBorderShape(.capsule)
+                            .controlSize(.small)
+                    }
+
+                    if isWorking {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                }
+                .padding(.top, 6)
+                .disabled(isWorking)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+}
+
+private struct StoreDetailMetadataStrip: View {
+    let app: StoreAppDetail
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: 140), spacing: 16, alignment: .top)]
+    }
+
+    var body: some View {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
+            StoreDetailMetadataItem(title: "Creator", value: app.authorDisplayName)
+            StoreDetailMetadataItem(
+                title: "Version",
+                value: String(app.currentVersion.versionNumber)
+            )
+            StoreDetailMetadataItem(title: "Category", value: app.category.title)
+            StoreDetailMetadataItem(title: "License", value: app.currentVersion.license)
+        }
+        .padding(.vertical, 16)
+        .overlay(alignment: .top) { Divider() }
+        .overlay(alignment: .bottom) { Divider() }
+    }
+}
+
+private struct StoreDetailMetadataItem: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.tertiary)
+            Text(value)
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+        }
+    }
+}
+
+private struct StoreDetailScreenshot: View {
+    let asset: StoreAsset
+
+    var body: some View {
+        Group {
+            if let url = asset.url {
+                AsyncImage(url: url) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .scaledToFit()
+                    case .failure:
+                        StoreImagePlaceholder(systemImage: "photo")
+                            .aspectRatio(aspectRatio, contentMode: .fit)
+                    case .empty:
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                            .aspectRatio(aspectRatio, contentMode: .fit)
+                    @unknown default:
+                        EmptyView()
+                    }
+                }
+            } else {
+                StoreImagePlaceholder(systemImage: "photo")
+                    .aspectRatio(aspectRatio, contentMode: .fit)
+            }
+        }
+        .frame(maxWidth: maximumDisplayWidth)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .strokeBorder(.quaternary, lineWidth: 0.5)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var aspectRatio: CGFloat {
+        guard asset.width > 0, asset.height > 0 else { return 16 / 10 }
+        return CGFloat(asset.width) / CGFloat(asset.height)
+    }
+
+    private var maximumDisplayWidth: CGFloat {
+        guard aspectRatio <= 1 else { return .infinity }
+        return 560 * aspectRatio
+    }
+}
+
+private struct StorePermissionsSection: View {
+    let version: StoreVersionMetadata
+
+    private var permissions: [StorePermissionPresentation] {
+        StorePermissionPresentation.items(for: version)
+    }
+
+    private var columns: [GridItem] {
+        [GridItem(.adaptive(minimum: 250), spacing: 28, alignment: .top)]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            Text("Permissions")
+                .font(.title2.weight(.semibold))
+
+            Group {
+                if permissions.isEmpty {
+                    VStack(spacing: 12) {
+                        Image(systemName: "checkmark.shield")
+                            .font(.system(size: 32))
+                            .foregroundStyle(.blue)
+                        Text("No Additional Permissions")
+                            .font(.headline)
+                        Text("This version does not request additional sandbox or system resources.")
+                            .font(.callout)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                } else {
+                    LazyVGrid(columns: columns, alignment: .leading, spacing: 24) {
+                        ForEach(permissions) { permission in
+                            StorePermissionItemView(permission: permission)
+                        }
+                    }
+                }
+            }
+            .padding(22)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary.opacity(0.25), in: RoundedRectangle(cornerRadius: 18))
+        }
+    }
+}
+
+private struct StorePermissionItemView: View {
+    let permission: StorePermissionPresentation
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: permission.systemImage)
+                .font(.title2)
+                .foregroundStyle(.blue)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(permission.title)
+                    .font(.headline)
+                Text(permission.explanation)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+nonisolated struct StorePermissionPresentation: Identifiable, Equatable, Sendable {
+    let id: String
+    let title: String
+    let explanation: String
+    let systemImage: String
+
+    static func items(for version: StoreVersionMetadata) -> [Self] {
+        let settings = version.generationSettings.toolSettings
+        let sandbox: [Self] = settings.sandboxEnabled
+            ? settings.sandboxPermissions.enabledPermissions.map { permission in
+                switch permission {
+                case .internet:
+                    Self(
+                        id: "sandbox.internet",
+                        title: permission.displayName,
+                        explanation: "Access to network connections",
+                        systemImage: "network"
+                    )
+                case .userSelectedFiles:
+                    Self(
+                        id: "sandbox.userSelectedFiles",
+                        title: permission.displayName,
+                        explanation: "Access to files you choose",
+                        systemImage: "folder.badge.plus"
+                    )
+                }
+            }
+            : []
+        let resources = settings.resourcePermissions.enabledPermissions.map { permission in
+            Self(
+                id: "resource.\(permission.rawValue)",
+                title: permission.displayName,
+                explanation: explanation(for: permission),
+                systemImage: systemImage(for: permission)
+            )
+        }
+        return sandbox + resources
+    }
+
+    private static func systemImage(for permission: GeneratedAppResourcePermission) -> String {
+        switch permission {
+        case .microphone: "mic"
+        case .camera: "camera"
+        case .location: "location"
+        case .contacts: "person.crop.circle"
+        case .calendar: "calendar"
+        case .photoLibrary: "photo.on.rectangle"
+        case .appleEvents: "gearshape.2"
+        }
+    }
+
+    private static func explanation(for permission: GeneratedAppResourcePermission) -> String {
+        switch permission {
+        case .microphone: "Access to audio input"
+        case .camera: "Access to photo and video capture"
+        case .location: "Access to your current location"
+        case .contacts: "Access to contact information"
+        case .calendar: "Access to calendar events"
+        case .photoLibrary: "Access to photos and videos"
+        case .appleEvents: "Permission to automate other apps"
+        }
+    }
+}
+
+private struct StoreVersionsCard: View {
+    let app: StoreAppDetail
+    @Binding var expandedVersionID: String?
+    let isWorking: Bool
+    let workingVersionID: String?
+    let installDisposition: (StoreAppDetail, StoreVersionMetadata) -> StoreAppInstallDisposition
+    let onInstall: (StoreAppDetail, StoreVersionMetadata) -> Void
+
+    private var versions: [StoreVersionMetadata] {
+        StoreVersionPresentation.newestFirst(app.versions)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Versions")
+                .font(.title2.weight(.semibold))
+
+            VStack(spacing: 0) {
+                ForEach(Array(versions.enumerated()), id: \.element.id) { index, version in
+                    StoreVersionAccordionRow(
+                        version: version,
+                        isCurrent: StoreVersionPresentation.isCurrent(version, in: app),
+                        isExpanded: Binding(
+                            get: { expandedVersionID == version.id },
+                            set: { expandedVersionID = $0 ? version.id : nil }
+                        ),
+                        isWorking: isWorking,
+                        isThisVersionWorking: workingVersionID == version.id,
+                        installDisposition: installDisposition(app, version),
+                        onInstall: { onInstall(app, version) }
+                    )
+                    if index < versions.count - 1 {
+                        Divider()
+                    }
+                }
+            }
+            .padding(.horizontal, 18)
+            .background(.quaternary.opacity(0.2), in: RoundedRectangle(cornerRadius: 18))
+        }
+    }
+}
+
+private struct StoreVersionAccordionRow: View {
+    let version: StoreVersionMetadata
+    let isCurrent: Bool
+    @Binding var isExpanded: Bool
+    let isWorking: Bool
+    let isThisVersionWorking: Bool
+    let installDisposition: StoreAppInstallDisposition
+    let onInstall: () -> Void
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 14) {
+                StoreVersionMetadataList(version: version)
+                HStack {
+                    Button(installDisposition.buttonTitle, action: onInstall)
+                        .buttonStyle(.borderedProminent)
+                        .buttonBorderShape(.capsule)
+                        .controlSize(.small)
+                        .disabled(isWorking)
+                    if isThisVersionWorking {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+                    Spacer()
+                }
+            }
+            .padding(.bottom, 16)
+        } label: {
+            HStack(spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Version \(version.versionNumber)")
+                        .font(.headline)
+                    Text(StoreVersionPresentation.formattedDate(version.publishedAt))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                if isCurrent {
+                    Text("Current")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.blue)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(.blue.opacity(0.12), in: Capsule())
+                }
+                Spacer()
+            }
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .disclosureGroupStyle(.automatic)
+    }
+}
+
+private struct StoreVersionMetadataList: View {
+    let version: StoreVersionMetadata
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            row("Published", StoreVersionPresentation.formattedDate(version.publishedAt))
+            row("App Type", version.generationSettings.appKind.displayName)
+            row("Permissions", StoreVersionPresentation.permissionsSummary(version))
+            row("License", version.license)
+            row("Runtime", version.runtimeVersion)
+            row("Source Hash", version.sourceSha256, monospaced: true)
+        }
+    }
+
+    private func row(_ label: String, _ value: String, monospaced: Bool = false) -> some View {
+        LabeledContent(label) {
+            Text(value)
+                .font(monospaced ? .caption.monospaced() : .caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
+        }
+        .font(.caption.weight(.medium))
+    }
+}
+
+nonisolated enum StoreVersionPresentation {
+    static func isCurrent(_ version: StoreVersionMetadata, in app: StoreAppDetail) -> Bool {
+        version.id == app.currentVersion.id
+    }
+
+    static func newestFirst(_ versions: [StoreVersionMetadata]) -> [StoreVersionMetadata] {
+        versions.sorted { lhs, rhs in
+            if lhs.versionNumber != rhs.versionNumber {
+                return lhs.versionNumber > rhs.versionNumber
+            }
+            return lhs.publishedAt > rhs.publishedAt
+        }
+    }
+
+    static func permissionsSummary(_ version: StoreVersionMetadata) -> String {
+        let names = StorePermissionPresentation.items(for: version).map(\.title)
+        return names.isEmpty ? "None" : names.joined(separator: ", ")
+    }
+
+    static func formattedDate(_ value: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+        return date?.formatted(date: .abbreviated, time: .omitted) ?? value
+    }
+}

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -50,7 +50,9 @@ struct StoreAppDetailView: View {
                             onInstall: onInstallVersion
                         )
                     }
-                    .padding(28)
+                    .padding(.horizontal, 28)
+                    .padding(.top, 12)
+                    .padding(.bottom, 28)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .task(id: app.id) {

--- a/Ironsmith/Features/Store/StoreToolImportClient.swift
+++ b/Ironsmith/Features/Store/StoreToolImportClient.swift
@@ -21,10 +21,11 @@ struct StoreToolImportResult {
 }
 
 struct StoreToolImportClient {
-    var importTool: @MainActor (
-        _ request: StoreToolImportRequest,
-        _ modelContext: ModelContext
-    ) async throws -> StoreToolImportResult
+    var importTool:
+        @MainActor (
+            _ request: StoreToolImportRequest,
+            _ modelContext: ModelContext
+        ) async throws -> StoreToolImportResult
 }
 
 extension StoreToolImportClient {
@@ -34,20 +35,26 @@ extension StoreToolImportClient {
 
     static func live(
         toolsDirectoryURL: URL,
-        packageMaterializer: ToolPackageMaterializer = .live
+        packageMaterializer: ToolPackageMaterializer = .live,
+        iconDataLoader: @escaping @Sendable (URL) async throws -> Data = {
+            try await downloadImage(from: $0)
+        }
     ) -> Self {
         StoreToolImportClient { request, modelContext in
             try IronsmithStoreClient.verifySourceHash(request.version)
 
-            let displayName = request.displayName ?? (request.mode == .remix
-                ? "\(request.app.name) Remix"
-                : request.app.name)
+            let displayName =
+                request.displayName
+                ?? (request.mode == .remix
+                    ? "\(request.app.name) Remix"
+                    : request.app.name)
             let packageRootURL = try packageMaterializer.makeUniquePackageRoot(
                 displayName: displayName,
                 toolsDirectoryURL: toolsDirectoryURL
             )
             let executableName = ToolNameSanitizer.executableName(from: displayName)
-            let layout = ToolPackageLayout(packageRootURL: packageRootURL, executableName: executableName)
+            let layout = ToolPackageLayout(
+                packageRootURL: packageRootURL, executableName: executableName)
             let settings = request.version.generationSettings.toolSettings
 
             try packageMaterializer.materializePackage(
@@ -56,10 +63,15 @@ extension StoreToolImportClient {
                 settings: settings,
                 contentViewSource: request.version.sourceCode
             )
-            try await cacheIconIfAvailable(app: request.app, layout: layout)
+            try await cacheIconIfAvailable(
+                app: request.app,
+                layout: layout,
+                dataLoader: iconDataLoader
+            )
 
             let now = Date()
-            let generationPhase: ToolGenerationPhase = request.initialGenerationState == .generating
+            let generationPhase: ToolGenerationPhase =
+                request.initialGenerationState == .generating
                 ? .packaging
                 : .completed
             let tool = Tool(
@@ -96,27 +108,56 @@ extension StoreToolImportClient {
         }
     }
 
-    private static func cacheIconIfAvailable(app: StoreAppDetail, layout: ToolPackageLayout) async throws {
-        guard let url = app.iconAsset?.url else { return }
+    static func cacheIconIfAvailable(
+        app: StoreAppDetail,
+        layout: ToolPackageLayout,
+        dataLoader: @escaping @Sendable (URL) async throws -> Data = {
+            try await downloadImage(from: $0)
+        }
+    ) async throws {
+        guard let thumbnailURL = app.iconAsset?.url else { return }
         do {
-            let (data, response) = try await URLSession.shared.data(from: url)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  (200...299).contains(httpResponse.statusCode),
-                  !data.isEmpty
-            else {
-                return
+            if let masterURL = app.iconMaster?.url {
+                async let masterData = dataLoader(masterURL)
+                async let thumbnailData = dataLoader(thumbnailURL)
+                let (master, thumbnail) = try await (masterData, thumbnailData)
+                try ToolIconClient.installDownloadedIconAssets(
+                    masterJPEG: master,
+                    thumbnailJPEG: thumbnail,
+                    request: ToolIconRequest(displayName: app.name, layout: layout)
+                )
+            } else {
+                let data = try await dataLoader(thumbnailURL)
+                try FileManager.default.createDirectory(
+                    at: layout.packageMetadataDirectoryURL,
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: layout.cachedAppIconPNGURL, options: .atomic)
+                _ = try await ToolIconClient.cachedOnly().ensureIconAssets(
+                    ToolIconRequest(displayName: app.name, layout: layout)
+                )
             }
-            try data.write(to: layout.cachedAppIconPNGURL, options: .atomic)
         } catch {
             AgentDiagnosticsLog.append(
                 """
                 Store app icon download failed.
                 app: \(app.id)
-                url: \(url.absoluteString)
+                thumbnailURL: \(thumbnailURL.absoluteString)
                 error:
                 \(AgentDiagnosticsLog.renderError(error, limit: 500))
                 """
             )
         }
+    }
+
+    private static func downloadImage(from url: URL) async throws -> Data {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+            (200...299).contains(httpResponse.statusCode),
+            !data.isEmpty
+        else {
+            throw IronsmithStoreClientError.invalidResponse
+        }
+        return data
     }
 }

--- a/Ironsmith/Features/Store/StoreToolImportClient.swift
+++ b/Ironsmith/Features/Store/StoreToolImportClient.swift
@@ -10,6 +10,7 @@ struct StoreToolImportRequest: Sendable {
     let app: StoreAppDetail
     let version: StoreVersionDownload
     let mode: StoreToolImportMode
+    var displayName: String? = nil
     var isOwnApp = false
     var initialGenerationState: ToolGenerationState = .ready
 }
@@ -38,9 +39,9 @@ extension StoreToolImportClient {
         StoreToolImportClient { request, modelContext in
             try IronsmithStoreClient.verifySourceHash(request.version)
 
-            let displayName = request.mode == .remix
+            let displayName = request.displayName ?? (request.mode == .remix
                 ? "\(request.app.name) Remix"
-                : request.app.name
+                : request.app.name)
             let packageRootURL = try packageMaterializer.makeUniquePackageRoot(
                 displayName: displayName,
                 toolsDirectoryURL: toolsDirectoryURL

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -371,6 +371,7 @@ final class StoreWindowStore {
         guard
             let matchingTool = tools.first(where: {
                 $0.storeAppId == app.id
+                    && $0.storeVersionId == version.id
                     && localSourceHash(for: $0) == version.sourceSha256.lowercased()
             })
         else {

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -31,9 +31,11 @@ final class StoreWindowStore {
     var selectedStoreId = IronsmithStoreConstants.communityStoreId
     var homeSections: [StoreHomeSection] = []
     var searchResults: [StoreAppSummary] = []
-    var searchResultsNextCursor: String?
+    var searchResultsNextOffset = 0
+    var searchResultsHasMore = false
     var publishedApps: [StoreAppSummary] = []
-    var publishedAppsNextCursor: String?
+    var publishedAppsNextOffset = 0
+    var publishedAppsHasMore = false
     var selectedAppID: String?
     var selectedAppDetail: StoreAppDetail?
     var searchText = ""
@@ -52,6 +54,8 @@ final class StoreWindowStore {
     @ObservationIgnored private let importClient: StoreToolImportClient
     @ObservationIgnored private let buildClient: ToolBuildClient
     @ObservationIgnored private let packageMaterializer: ToolPackageMaterializer
+    @ObservationIgnored private var searchPaginationRevision = 0
+    @ObservationIgnored private var publishedPaginationRevision = 0
 
     init() {
         self.client = .live
@@ -111,10 +115,12 @@ final class StoreWindowStore {
     }
 
     func refreshHome(showLoadingIndicator: Bool = true) async {
+        searchPaginationRevision += 1
         if showLoadingIndicator {
             isLoadingDiscover = true
         }
-        searchResultsNextCursor = nil
+        searchResultsNextOffset = 0
+        searchResultsHasMore = false
         defer {
             if showLoadingIndicator {
                 isLoadingDiscover = false
@@ -124,7 +130,8 @@ final class StoreWindowStore {
             homeSections = try await client.listHomeSections(selectedStoreId)
             if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 searchResults = []
-                searchResultsNextCursor = nil
+                searchResultsNextOffset = 0
+                searchResultsHasMore = false
             }
             reconcileSelection()
         } catch {
@@ -138,10 +145,14 @@ final class StoreWindowStore {
             await refreshHome(showLoadingIndicator: showLoadingIndicator)
             return
         }
+        searchPaginationRevision += 1
+        let revision = searchPaginationRevision
+        let storeId = selectedStoreId
         if showLoadingIndicator {
             isLoadingDiscover = true
         }
-        searchResultsNextCursor = nil
+        searchResultsNextOffset = 0
+        searchResultsHasMore = false
         defer {
             if showLoadingIndicator {
                 isLoadingDiscover = false
@@ -149,18 +160,22 @@ final class StoreWindowStore {
         }
         do {
             let page = try await client.listApps(
-                selectedStoreId,
+                storeId,
                 .discover,
                 trimmedSearch,
-                nil,
+                0,
                 .recent,
                 nil
             )
-            guard searchText.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedSearch else {
+            guard searchPaginationRevision == revision,
+                selectedStoreId == storeId,
+                searchText.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedSearch
+            else {
                 return
             }
             searchResults = page.apps
-            searchResultsNextCursor = page.nextCursor
+            searchResultsNextOffset = page.apps.count
+            searchResultsHasMore = page.hasMore
             reconcileSelection()
         } catch {
             present(error)
@@ -170,31 +185,38 @@ final class StoreWindowStore {
     func loadMoreSearchResults() async {
         let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSearch.isEmpty,
-            let cursor = searchResultsNextCursor,
+            searchResultsHasMore,
             !isLoadingMoreSearchResults
         else {
             return
         }
+        let offset = searchResultsNextOffset
+        let revision = searchPaginationRevision
+        let storeId = selectedStoreId
 
         isLoadingMoreSearchResults = true
         defer { isLoadingMoreSearchResults = false }
         do {
             let page = try await client.listApps(
-                selectedStoreId,
+                storeId,
                 .discover,
                 trimmedSearch,
-                cursor,
+                offset,
                 .recent,
                 nil
             )
-            guard searchText.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedSearch else {
+            guard searchPaginationRevision == revision,
+                selectedStoreId == storeId,
+                searchText.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedSearch
+            else {
                 return
             }
-            guard searchResultsNextCursor == cursor else {
+            guard searchResultsNextOffset == offset else {
                 return
             }
             appendUnique(page.apps, to: &searchResults)
-            searchResultsNextCursor = page.nextCursor
+            searchResultsNextOffset += page.apps.count
+            searchResultsHasMore = page.hasMore
             reconcileSelection()
         } catch {
             present(error)
@@ -204,14 +226,14 @@ final class StoreWindowStore {
     func loadSectionApps(
         sort: StoreAppListSort,
         category: StoreAppCategory?,
-        cursor: String? = nil
+        offset: Int = 0
     ) async -> StoreAppPage? {
         do {
             return try await client.listApps(
                 selectedStoreId,
                 .discover,
                 nil,
-                cursor,
+                offset,
                 sort,
                 category
             )
@@ -254,10 +276,14 @@ final class StoreWindowStore {
     }
 
     func refreshPublished(showLoadingIndicator: Bool = true) async {
+        publishedPaginationRevision += 1
+        let revision = publishedPaginationRevision
+        let storeId = selectedStoreId
         if showLoadingIndicator {
             isLoadingPublished = true
         }
-        publishedAppsNextCursor = nil
+        publishedAppsNextOffset = 0
+        publishedAppsHasMore = false
         defer {
             if showLoadingIndicator {
                 isLoadingPublished = false
@@ -265,15 +291,19 @@ final class StoreWindowStore {
         }
         do {
             let page = try await client.listApps(
-                selectedStoreId,
+                storeId,
                 .mine,
                 nil,
-                nil,
+                0,
                 .recent,
                 nil
             )
+            guard publishedPaginationRevision == revision, selectedStoreId == storeId else {
+                return
+            }
             publishedApps = page.apps
-            publishedAppsNextCursor = page.nextCursor
+            publishedAppsNextOffset = page.apps.count
+            publishedAppsHasMore = page.hasMore
             reconcileSelection()
         } catch {
             present(error)
@@ -281,26 +311,33 @@ final class StoreWindowStore {
     }
 
     func loadMorePublishedApps() async {
-        guard let cursor = publishedAppsNextCursor, !isLoadingMorePublishedApps else {
+        guard publishedAppsHasMore, !isLoadingMorePublishedApps else {
             return
         }
+        let offset = publishedAppsNextOffset
+        let revision = publishedPaginationRevision
+        let storeId = selectedStoreId
 
         isLoadingMorePublishedApps = true
         defer { isLoadingMorePublishedApps = false }
         do {
             let page = try await client.listApps(
-                selectedStoreId,
+                storeId,
                 .mine,
                 nil,
-                cursor,
+                offset,
                 .recent,
                 nil
             )
-            guard publishedAppsNextCursor == cursor else {
+            guard publishedPaginationRevision == revision,
+                selectedStoreId == storeId,
+                publishedAppsNextOffset == offset
+            else {
                 return
             }
             appendUnique(page.apps, to: &publishedApps)
-            publishedAppsNextCursor = page.nextCursor
+            publishedAppsNextOffset += page.apps.count
+            publishedAppsHasMore = page.hasMore
             reconcileSelection()
         } catch {
             present(error)

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -368,10 +368,12 @@ final class StoreWindowStore {
         of app: StoreAppDetail,
         tools: [Tool]
     ) -> StoreAppInstallDisposition {
-        guard let matchingTool = tools.first(where: {
-            $0.storeAppId == app.id
-                && localSourceHash(for: $0) == version.sourceSha256.lowercased()
-        }) else {
+        guard
+            let matchingTool = tools.first(where: {
+                $0.storeAppId == app.id
+                    && localSourceHash(for: $0) == version.sourceSha256.lowercased()
+            })
+        else {
             return .createCopy
         }
         return .openExisting(matchingTool)
@@ -479,7 +481,8 @@ final class StoreWindowStore {
                     actual: download.sourceSha256
                 )
             }
-            let displayName = version.id == app.currentVersion.id
+            let displayName =
+                version.id == app.currentVersion.id
                 ? app.name
                 : "\(app.name) v\(version.versionNumber)"
             try await importAndBuild(
@@ -533,6 +536,7 @@ final class StoreWindowStore {
         let previousError = tool.generationErrorSummary
         let previousLinkage = StoreToolLinkageSnapshot(tool: tool)
         let layout = tool.packageLayout
+        let previousIcons = ToolIconAssetSnapshot(layout: layout)
         let backup = try ToolVersionBackupClient.live.stageCurrentVersion(
             layout.packageRootURL,
             tool.contentViewSourcePath,
@@ -554,6 +558,10 @@ final class StoreWindowStore {
             )
             try IronsmithStoreClient.verifySourceHash(version)
             try writeStoreVersion(version, app: app, isOwnApp: isOwnApp, to: tool)
+            try await StoreToolImportClient.cacheIconIfAvailable(
+                app: app,
+                layout: tool.packageLayout
+            )
             try modelContext.save()
             try await buildClient.buildTool(tool)
             try ToolVersionBackupClient.live.promoteStagedVersion(backup)
@@ -569,6 +577,7 @@ final class StoreWindowStore {
                 settings: previousSettings
             )
             try? ToolVersionBackupClient.live.discardStagedVersion(backup)
+            previousIcons.restore()
             previousLinkage.apply(to: tool)
             tool.applyGenerationSettings(previousSettings)
             tool.generationState = previousState
@@ -752,6 +761,35 @@ final class StoreWindowStore {
         errorMessage =
             IronsmithErrorPresentation.message(for: error)
             ?? error.localizedDescription
+    }
+}
+
+private struct ToolIconAssetSnapshot {
+    private let files: [(url: URL, data: Data?)]
+
+    init(layout: ToolPackageLayout) {
+        files = [
+            layout.cachedAppIconICNSURL,
+            layout.cachedAppIconMasterJPEGURL,
+            layout.cachedAppIconThumbnailJPEGURL,
+            layout.cachedAppIconPNGURL,
+        ].map { url in
+            (url, try? Data(contentsOf: url))
+        }
+    }
+
+    func restore(fileManager: FileManager = .default) {
+        for file in files {
+            if let data = file.data {
+                try? fileManager.createDirectory(
+                    at: file.url.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try? data.write(to: file.url, options: .atomic)
+            } else {
+                try? fileManager.removeItem(at: file.url)
+            }
+        }
     }
 }
 

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -41,6 +41,7 @@ final class StoreWindowStore {
     var isLoadingDetail = false
     var workingAppID: String?
     var workingVersionID: String?
+    var contentRevision = 0
     var errorMessage: String?
 
     @ObservationIgnored private let client: IronsmithStoreClient
@@ -105,9 +106,15 @@ final class StoreWindowStore {
         }
     }
 
-    func refreshHome() async {
-        isLoadingDiscover = true
-        defer { isLoadingDiscover = false }
+    func refreshHome(showLoadingIndicator: Bool = true) async {
+        if showLoadingIndicator {
+            isLoadingDiscover = true
+        }
+        defer {
+            if showLoadingIndicator {
+                isLoadingDiscover = false
+            }
+        }
         do {
             homeSections = try await client.listHomeSections(selectedStoreId)
             if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -119,14 +126,20 @@ final class StoreWindowStore {
         }
     }
 
-    func refreshDiscover() async {
+    func refreshDiscover(showLoadingIndicator: Bool = true) async {
         let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedSearch.isEmpty else {
-            await refreshHome()
+            await refreshHome(showLoadingIndicator: showLoadingIndicator)
             return
         }
-        isLoadingDiscover = true
-        defer { isLoadingDiscover = false }
+        if showLoadingIndicator {
+            isLoadingDiscover = true
+        }
+        defer {
+            if showLoadingIndicator {
+                isLoadingDiscover = false
+            }
+        }
         do {
             let page = try await client.listApps(
                 selectedStoreId,
@@ -194,9 +207,15 @@ final class StoreWindowStore {
         }
     }
 
-    func refreshPublished() async {
-        isLoadingPublished = true
-        defer { isLoadingPublished = false }
+    func refreshPublished(showLoadingIndicator: Bool = true) async {
+        if showLoadingIndicator {
+            isLoadingPublished = true
+        }
+        defer {
+            if showLoadingIndicator {
+                isLoadingPublished = false
+            }
+        }
         do {
             let page = try await client.listApps(
                 selectedStoreId,
@@ -223,6 +242,32 @@ final class StoreWindowStore {
 
     func isOwnPublishedApp(_ app: StoreAppDetail) -> Bool {
         publishedApps.contains { $0.id == app.id }
+    }
+
+    func installDisposition(
+        for app: StoreAppSummary,
+        tools: [Tool]
+    ) -> StoreAppInstallDisposition {
+        let unchangedLinkedTools = tools.filter { tool in
+            guard tool.storeAppId == app.id,
+                let importedHash = tool.storeSourceSha256?.lowercased()
+            else {
+                return false
+            }
+            return localSourceHash(for: tool) == importedHash
+        }
+        if let currentTool = unchangedLinkedTools.first(where: {
+            $0.storeVersionNumber == app.latestVersionNumber
+        }) {
+            return .openExisting(currentTool)
+        }
+        if let olderTool = unchangedLinkedTools.first(where: {
+            guard let versionNumber = $0.storeVersionNumber else { return false }
+            return versionNumber < app.latestVersionNumber
+        }) {
+            return .updateExisting(olderTool)
+        }
+        return .createCopy
     }
 
     func installDisposition(for app: StoreAppDetail, tools: [Tool]) -> StoreAppInstallDisposition {
@@ -274,7 +319,7 @@ final class StoreWindowStore {
         }
         do {
             if inferenceStore.ironsmithSession != nil {
-                await refreshPublished()
+                await refreshPublished(showLoadingIndicator: false)
             }
             let isOwnApp = isOwnPublishedApp(app)
             if mode == .get {
@@ -291,6 +336,7 @@ final class StoreWindowStore {
                         routeStore: routeStore,
                         inferenceStore: inferenceStore
                     )
+                    contentRevision += 1
                     return
                 case .createCopy:
                     break
@@ -310,6 +356,7 @@ final class StoreWindowStore {
                 modelContext: modelContext,
                 routeStore: routeStore
             )
+            contentRevision += 1
         } catch {
             present(error)
         }
@@ -332,7 +379,7 @@ final class StoreWindowStore {
         }
         do {
             if inferenceStore.ironsmithSession != nil {
-                await refreshPublished()
+                await refreshPublished(showLoadingIndicator: false)
             }
             if case .openExisting(let tool) = installDisposition(
                 for: version,
@@ -369,6 +416,7 @@ final class StoreWindowStore {
                 modelContext: modelContext,
                 routeStore: routeStore
             )
+            contentRevision += 1
         } catch {
             present(error)
         }
@@ -388,6 +436,7 @@ final class StoreWindowStore {
             if selectedAppID == updated.id {
                 selectedAppDetail = updated
             }
+            contentRevision += 1
         } catch {
             present(error)
         }

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -40,6 +40,7 @@ final class StoreWindowStore {
     var isLoadingPublished = false
     var isLoadingDetail = false
     var workingAppID: String?
+    var workingVersionID: String?
     var errorMessage: String?
 
     @ObservationIgnored private let client: IronsmithStoreClient
@@ -227,7 +228,7 @@ final class StoreWindowStore {
     func installDisposition(for app: StoreAppDetail, tools: [Tool]) -> StoreAppInstallDisposition {
         let linkedTools = tools.filter { $0.storeAppId == app.id }
         if let currentTool = linkedTools.first(where: {
-            localSourceHash(for: $0) == app.currentVersion.sourceSha256
+            localSourceHash(for: $0) == app.currentVersion.sourceSha256.lowercased()
         }) {
             return .openExisting(currentTool)
         }
@@ -242,6 +243,20 @@ final class StoreWindowStore {
         return .createCopy
     }
 
+    func installDisposition(
+        for version: StoreVersionMetadata,
+        of app: StoreAppDetail,
+        tools: [Tool]
+    ) -> StoreAppInstallDisposition {
+        guard let matchingTool = tools.first(where: {
+            $0.storeAppId == app.id
+                && localSourceHash(for: $0) == version.sourceSha256.lowercased()
+        }) else {
+            return .createCopy
+        }
+        return .openExisting(matchingTool)
+    }
+
     func install(
         _ app: StoreAppDetail,
         mode: StoreToolImportMode,
@@ -252,7 +267,11 @@ final class StoreWindowStore {
     ) async {
         guard workingAppID == nil else { return }
         workingAppID = app.id
-        defer { workingAppID = nil }
+        workingVersionID = app.currentVersion.id
+        defer {
+            workingAppID = nil
+            workingVersionID = nil
+        }
         do {
             if inferenceStore.ironsmithSession != nil {
                 await refreshPublished()
@@ -282,37 +301,74 @@ final class StoreWindowStore {
                 app.id,
                 app.currentVersion.versionNumber
             )
-            let result = try await importClient.importTool(
-                StoreToolImportRequest(
-                    app: app,
-                    version: version,
-                    mode: mode,
-                    isOwnApp: isOwnApp,
-                    initialGenerationState: mode == .get ? .generating : .ready
-                ),
-                modelContext
+            try await importAndBuild(
+                version,
+                app: app,
+                mode: mode,
+                displayName: nil,
+                isOwnApp: isOwnApp,
+                modelContext: modelContext,
+                routeStore: routeStore
             )
-            routeStore.open(
-                .toolLibrary(
-                    .selectTool(id: result.tool.id, focusPrompt: mode == .remix)
-                )
-            )
-            if mode == .get {
-                do {
-                    try await buildClient.buildTool(result.tool)
-                    result.tool.generationState = .ready
-                    result.tool.generationPhase = .completed
-                    result.tool.generationErrorSummary = nil
-                    result.tool.updatedAt = Date()
-                    try modelContext.save()
-                } catch {
-                    result.tool.generationState = .failed
-                    result.tool.generationErrorSummary = error.localizedDescription
-                    result.tool.updatedAt = Date()
-                    try? modelContext.save()
-                    throw error
-                }
+        } catch {
+            present(error)
+        }
+    }
+
+    func installVersion(
+        _ version: StoreVersionMetadata,
+        of app: StoreAppDetail,
+        tools: [Tool],
+        modelContext: ModelContext,
+        routeStore: IronsmithRouteStore,
+        inferenceStore: InferenceStore
+    ) async {
+        guard workingAppID == nil else { return }
+        workingAppID = app.id
+        workingVersionID = version.id
+        defer {
+            workingAppID = nil
+            workingVersionID = nil
+        }
+        do {
+            if inferenceStore.ironsmithSession != nil {
+                await refreshPublished()
             }
+            if case .openExisting(let tool) = installDisposition(
+                for: version,
+                of: app,
+                tools: tools
+            ) {
+                routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
+                return
+            }
+
+            let download = try await client.fetchVersion(
+                app.storeId,
+                app.id,
+                version.versionNumber
+            )
+            guard download.id == version.id else {
+                throw IronsmithStoreClientError.invalidResponse
+            }
+            guard download.sourceSha256.lowercased() == version.sourceSha256.lowercased() else {
+                throw IronsmithStoreClientError.sourceHashMismatch(
+                    expected: version.sourceSha256,
+                    actual: download.sourceSha256
+                )
+            }
+            let displayName = version.id == app.currentVersion.id
+                ? app.name
+                : "\(app.name) v\(version.versionNumber)"
+            try await importAndBuild(
+                download,
+                app: app,
+                mode: .get,
+                displayName: displayName,
+                isOwnApp: isOwnPublishedApp(app),
+                modelContext: modelContext,
+                routeStore: routeStore
+            )
         } catch {
             present(error)
         }
@@ -395,6 +451,49 @@ final class StoreWindowStore {
             tool.generationPhase = previousPhase
             tool.generationErrorSummary = previousError
             tool.updatedAt = Date()
+            try? modelContext.save()
+            throw error
+        }
+    }
+
+    private func importAndBuild(
+        _ version: StoreVersionDownload,
+        app: StoreAppDetail,
+        mode: StoreToolImportMode,
+        displayName: String?,
+        isOwnApp: Bool,
+        modelContext: ModelContext,
+        routeStore: IronsmithRouteStore
+    ) async throws {
+        let result = try await importClient.importTool(
+            StoreToolImportRequest(
+                app: app,
+                version: version,
+                mode: mode,
+                displayName: displayName,
+                isOwnApp: isOwnApp,
+                initialGenerationState: mode == .get ? .generating : .ready
+            ),
+            modelContext
+        )
+        routeStore.open(
+            .toolLibrary(
+                .selectTool(id: result.tool.id, focusPrompt: mode == .remix)
+            )
+        )
+        guard mode == .get else { return }
+
+        do {
+            try await buildClient.buildTool(result.tool)
+            result.tool.generationState = .ready
+            result.tool.generationPhase = .completed
+            result.tool.generationErrorSummary = nil
+            result.tool.updatedAt = Date()
+            try modelContext.save()
+        } catch {
+            result.tool.generationState = .failed
+            result.tool.generationErrorSummary = error.localizedDescription
+            result.tool.updatedAt = Date()
             try? modelContext.save()
             throw error
         }

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -30,14 +30,18 @@ final class StoreWindowStore {
     var stores: [AppStoreDescriptor] = []
     var selectedStoreId = IronsmithStoreConstants.communityStoreId
     var homeSections: [StoreHomeSection] = []
-    var discoverApps: [StoreAppSummary] = []
+    var searchResults: [StoreAppSummary] = []
+    var searchResultsNextCursor: String?
     var publishedApps: [StoreAppSummary] = []
+    var publishedAppsNextCursor: String?
     var selectedAppID: String?
     var selectedAppDetail: StoreAppDetail?
     var searchText = ""
     var isLoadingStores = false
     var isLoadingDiscover = false
+    var isLoadingMoreSearchResults = false
     var isLoadingPublished = false
+    var isLoadingMorePublishedApps = false
     var isLoadingDetail = false
     var workingAppID: String?
     var workingVersionID: String?
@@ -78,7 +82,7 @@ final class StoreWindowStore {
             homeSections
             .flatMap(\.apps)
             .first { $0.id == id }
-            ?? discoverApps.first { $0.id == id }
+            ?? searchResults.first { $0.id == id }
             ?? publishedApps.first { $0.id == id }
     }
 
@@ -110,6 +114,7 @@ final class StoreWindowStore {
         if showLoadingIndicator {
             isLoadingDiscover = true
         }
+        searchResultsNextCursor = nil
         defer {
             if showLoadingIndicator {
                 isLoadingDiscover = false
@@ -118,7 +123,8 @@ final class StoreWindowStore {
         do {
             homeSections = try await client.listHomeSections(selectedStoreId)
             if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                discoverApps = []
+                searchResults = []
+                searchResultsNextCursor = nil
             }
             reconcileSelection()
         } catch {
@@ -135,6 +141,7 @@ final class StoreWindowStore {
         if showLoadingIndicator {
             isLoadingDiscover = true
         }
+        searchResultsNextCursor = nil
         defer {
             if showLoadingIndicator {
                 isLoadingDiscover = false
@@ -149,7 +156,45 @@ final class StoreWindowStore {
                 .recent,
                 nil
             )
-            discoverApps = page.apps
+            guard searchText.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedSearch else {
+                return
+            }
+            searchResults = page.apps
+            searchResultsNextCursor = page.nextCursor
+            reconcileSelection()
+        } catch {
+            present(error)
+        }
+    }
+
+    func loadMoreSearchResults() async {
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSearch.isEmpty,
+            let cursor = searchResultsNextCursor,
+            !isLoadingMoreSearchResults
+        else {
+            return
+        }
+
+        isLoadingMoreSearchResults = true
+        defer { isLoadingMoreSearchResults = false }
+        do {
+            let page = try await client.listApps(
+                selectedStoreId,
+                .discover,
+                trimmedSearch,
+                cursor,
+                .recent,
+                nil
+            )
+            guard searchText.trimmingCharacters(in: .whitespacesAndNewlines) == trimmedSearch else {
+                return
+            }
+            guard searchResultsNextCursor == cursor else {
+                return
+            }
+            appendUnique(page.apps, to: &searchResults)
+            searchResultsNextCursor = page.nextCursor
             reconcileSelection()
         } catch {
             present(error)
@@ -158,20 +203,21 @@ final class StoreWindowStore {
 
     func loadSectionApps(
         sort: StoreAppListSort,
-        category: StoreAppCategory?
-    ) async -> [StoreAppSummary] {
+        category: StoreAppCategory?,
+        cursor: String? = nil
+    ) async -> StoreAppPage? {
         do {
             return try await client.listApps(
                 selectedStoreId,
                 .discover,
                 nil,
-                nil,
+                cursor,
                 sort,
                 category
-            ).apps
+            )
         } catch {
             present(error)
-            return []
+            return nil
         }
     }
 
@@ -211,6 +257,7 @@ final class StoreWindowStore {
         if showLoadingIndicator {
             isLoadingPublished = true
         }
+        publishedAppsNextCursor = nil
         defer {
             if showLoadingIndicator {
                 isLoadingPublished = false
@@ -226,6 +273,34 @@ final class StoreWindowStore {
                 nil
             )
             publishedApps = page.apps
+            publishedAppsNextCursor = page.nextCursor
+            reconcileSelection()
+        } catch {
+            present(error)
+        }
+    }
+
+    func loadMorePublishedApps() async {
+        guard let cursor = publishedAppsNextCursor, !isLoadingMorePublishedApps else {
+            return
+        }
+
+        isLoadingMorePublishedApps = true
+        defer { isLoadingMorePublishedApps = false }
+        do {
+            let page = try await client.listApps(
+                selectedStoreId,
+                .mine,
+                nil,
+                cursor,
+                .recent,
+                nil
+            )
+            guard publishedAppsNextCursor == cursor else {
+                return
+            }
+            appendUnique(page.apps, to: &publishedApps)
+            publishedAppsNextCursor = page.nextCursor
             reconcileSelection()
         } catch {
             present(error)
@@ -635,8 +710,8 @@ final class StoreWindowStore {
         } else {
             publishedApps.insert(summary, at: 0)
         }
-        if let index = discoverApps.firstIndex(where: { $0.id == app.id }) {
-            discoverApps[index] = summary
+        if let index = searchResults.firstIndex(where: { $0.id == app.id }) {
+            searchResults[index] = summary
         }
         for sectionIndex in homeSections.indices {
             if let appIndex = homeSections[sectionIndex].apps.firstIndex(where: { $0.id == app.id })
@@ -666,6 +741,11 @@ final class StoreWindowStore {
         }
         selectedAppDetail = nil
         self.selectedAppID = nil
+    }
+
+    private func appendUnique(_ apps: [StoreAppSummary], to existingApps: inout [StoreAppSummary]) {
+        let existingIDs = Set(existingApps.map(\.id))
+        existingApps.append(contentsOf: apps.filter { !existingIDs.contains($0.id) })
     }
 
     private func present(_ error: Error) {

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -425,9 +425,9 @@ private struct StoreAppStoreRowView: View {
                     .frame(width: 88)
             } else {
                 Button(actionTitle, action: onAction)
-                    .font(.headline)
-                    .controlSize(.regular)
                     .buttonStyle(.borderedProminent)
+                    .buttonBorderShape(.capsule)
+                    .controlSize(.small)
                     .frame(width: 88)
             }
         }

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -8,88 +8,109 @@ struct StoreWindowView: View {
     @Query(sort: \Tool.updatedAt, order: .reverse) private var tools: [Tool]
     @State private var store = StoreWindowStore()
     @State private var path: [StoreNavigationDestination] = []
+    @State private var sidebarSelection: StoreSidebarSelection? = .discover
+    @State private var categoryRefreshToken = 0
     @State private var searchTask: Task<Void, Never>?
 
     var body: some View {
         @Bindable var store = store
 
-        NavigationStack(path: $path) {
-            StoreDiscoverHomeView(
-                store: store,
-                tools: tools,
-                inferenceStore: inferenceStore,
-                onOpen: openApp,
-                onSeeAll: openSection,
-                onGet: install
+        NavigationSplitView(columnVisibility: .constant(.all)) {
+            StoreSidebarView(
+                selection: $sidebarSelection,
+                searchText: $store.searchText
             )
-            .navigationTitle("App Store")
-            .searchable(text: $store.searchText, placement: .toolbar, prompt: "Search App Store")
-            .toolbar {
-                ToolbarItemGroup {
-                    Button {
-                        Task {
-                            if store.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-                                .isEmpty
-                            {
-                                await store.refreshHome()
-                            } else {
-                                await store.refreshDiscover()
+                .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 260)
+        } detail: {
+            NavigationStack(path: $path) {
+                Group {
+                    switch sidebarSelection ?? .discover {
+                    case .discover:
+                        StoreDiscoverHomeView(
+                            store: store,
+                            tools: tools,
+                            inferenceStore: inferenceStore,
+                            onOpen: openApp,
+                            onSeeAll: openSection,
+                            onGet: install
+                        )
+                    case .category(let category):
+                        StoreSectionAppsView(
+                            section: StoreSectionRoute(category: category),
+                            refreshToken: categoryRefreshToken,
+                            store: store,
+                            tools: tools,
+                            inferenceStore: inferenceStore,
+                            onOpen: openApp,
+                            onGet: install
+                        )
+                    case .published:
+                        StorePublishedListView(
+                            store: store,
+                            tools: tools,
+                            inferenceStore: inferenceStore,
+                            onOpen: openApp,
+                            onUpdateVersion: { tool in
+                                routeStore.open(.toolLibrary(.publishTool(tool.id)))
                             }
-                        }
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
+                        )
                     }
-                    .help("Refresh")
-
-                    Button {
-                        path = [.published]
-                        Task { await store.refreshPublished() }
-                    } label: {
-                        Label("Published", systemImage: "square.and.arrow.up")
-                    }
-                    .help("Published")
                 }
-            }
-            .navigationDestination(for: StoreNavigationDestination.self) { destination in
-                switch destination {
-                case .app(let appID):
-                    StoreAppDetailDestinationView(
-                        appID: appID,
-                        store: store,
-                        tools: tools,
-                        modelContext: modelContext,
-                        routeStore: routeStore,
-                        inferenceStore: inferenceStore
-                    )
-                case .section(let section):
-                    StoreSectionAppsView(
-                        section: section,
-                        store: store,
-                        tools: tools,
-                        inferenceStore: inferenceStore,
-                        onOpen: openApp,
-                        onGet: install
-                    )
-                case .published:
-                    StorePublishedListView(
-                        store: store,
-                        tools: tools,
-                        inferenceStore: inferenceStore,
-                        onOpen: openApp,
-                        onUpdateVersion: { tool in
-                            routeStore.open(.toolLibrary(.publishTool(tool.id)))
-                        }
-                    )
+                .navigationTitle(navigationTitle)
+                .navigationDestination(for: StoreNavigationDestination.self) { destination in
+                    switch destination {
+                    case .app(let appID):
+                        StoreAppDetailDestinationView(
+                            appID: appID,
+                            store: store,
+                            tools: tools,
+                            modelContext: modelContext,
+                            routeStore: routeStore,
+                            inferenceStore: inferenceStore
+                        )
+                    case .section(let section):
+                        StoreSectionAppsView(
+                            section: section,
+                            refreshToken: 0,
+                            store: store,
+                            tools: tools,
+                            inferenceStore: inferenceStore,
+                            onOpen: openApp,
+                            onGet: install
+                        )
+                    }
                 }
             }
         }
+        .navigationSplitViewStyle(.balanced)
+        .toolbar(removing: .sidebarToggle)
         .onChange(of: store.searchText) { _, _ in
             searchTask?.cancel()
             searchTask = Task {
                 try? await Task.sleep(for: .milliseconds(300))
                 guard !Task.isCancelled else { return }
-                await store.refreshDiscover()
+                if store.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    await store.refreshHome(showLoadingIndicator: false)
+                } else {
+                    sidebarSelection = .discover
+                    path = []
+                    await store.refreshDiscover()
+                }
             }
+        }
+        .onChange(of: sidebarSelection) { _, selection in
+            path = []
+            if selection != .discover {
+                store.searchText = ""
+            }
+            if selection == .discover {
+                Task { await store.refreshHome(showLoadingIndicator: false) }
+            } else if selection == .published {
+                Task { await store.refreshPublished() }
+            }
+        }
+        .onChange(of: store.contentRevision) { _, _ in
+            Task { await refreshStoreContent() }
         }
         .task {
             await store.loadInitial(inferenceStore: inferenceStore)
@@ -140,22 +161,48 @@ struct StoreWindowView: View {
         }
     }
 
+    private var navigationTitle: String {
+        switch sidebarSelection ?? .discover {
+        case .discover: "App Store"
+        case .category(let category): category.title
+        case .published: "Published"
+        }
+    }
+
+    @MainActor
+    private func refreshStoreContent() async {
+        if store.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            await store.refreshHome(showLoadingIndicator: false)
+        } else {
+            await store.refreshDiscover(showLoadingIndicator: false)
+        }
+        if inferenceStore.ironsmithSession != nil {
+            await store.refreshPublished(showLoadingIndicator: false)
+        }
+        categoryRefreshToken += 1
+    }
+
     @MainActor
     private func handleStoreRoute(_ route: IronsmithStoreRoute) {
         switch route {
         case .root:
+            sidebarSelection = .discover
             path = []
-            Task { await store.refreshHome() }
+            Task { await store.refreshHome(showLoadingIndicator: false) }
         case .published:
-            path = [.published]
+            sidebarSelection = .published
+            path = []
             Task { await store.refreshPublished() }
         case .publishedApp(let appID):
-            path = [.published]
+            sidebarSelection = .published
+            path = []
             Task { @MainActor in
-                await store.refreshPublished()
+                await store.refreshHome(showLoadingIndicator: false)
+                await store.refreshPublished(showLoadingIndicator: false)
+                categoryRefreshToken += 1
                 if let app = store.publishedApps.first(where: { $0.id == appID }) {
                     store.select(app)
-                    path = [.published, .app(app.id)]
+                    path = [.app(app.id)]
                 }
             }
         }
@@ -165,7 +212,34 @@ struct StoreWindowView: View {
 private enum StoreNavigationDestination: Hashable {
     case app(String)
     case section(StoreSectionRoute)
+}
+
+private enum StoreSidebarSelection: Hashable {
+    case discover
+    case category(StoreAppCategory)
     case published
+}
+
+private struct StoreSidebarView: View {
+    @Binding var selection: StoreSidebarSelection?
+    @Binding var searchText: String
+
+    var body: some View {
+        List(selection: $selection) {
+            Label("Discover", systemImage: "sparkles")
+                .tag(StoreSidebarSelection.discover)
+
+            ForEach(StoreAppCategory.allCases) { category in
+                Label(category.title, systemImage: category.systemImage)
+                    .tag(StoreSidebarSelection.category(category))
+            }
+
+            Label("Published", systemImage: "square.and.arrow.up")
+                .tag(StoreSidebarSelection.published)
+        }
+        .listStyle(.sidebar)
+        .searchable(text: $searchText, placement: .sidebar, prompt: "Search")
+    }
 }
 
 private struct StoreSectionRoute: Hashable, Identifiable {
@@ -179,6 +253,13 @@ private struct StoreSectionRoute: Hashable, Identifiable {
         title = section.title
         sort = section.sort
         category = section.category
+    }
+
+    init(category: StoreAppCategory) {
+        id = "category-\(category.rawValue)"
+        title = category.title
+        sort = .recent
+        self.category = category
     }
 }
 
@@ -219,12 +300,15 @@ private struct StoreDiscoverHomeView: View {
                             .frame(maxWidth: .infinity, alignment: .trailing)
                             .padding(.horizontal, 28)
                     }
-                    ForEach(store.homeSections) { section in
+                    ForEach(store.homeSections.filter { $0.category == nil }) { section in
                         StoreHomeSectionView(
                             section: section,
                             tools: tools,
                             inferenceStore: inferenceStore,
                             workingAppID: store.workingAppID,
+                            actionTitle: {
+                                store.installDisposition(for: $0, tools: tools).buttonTitle
+                            },
                             onOpen: onOpen,
                             onSeeAll: { onSeeAll(section) },
                             onGet: onGet
@@ -261,7 +345,9 @@ private struct StoreSearchResultsView: View {
                 StoreAppRowsView(
                     apps: store.discoverApps,
                     workingAppID: store.workingAppID,
-                    actionTitle: "Get",
+                    actionTitle: {
+                        store.installDisposition(for: $0, tools: tools).buttonTitle
+                    },
                     onOpen: onOpen,
                     onAction: { onGet($0, .get) }
                 )
@@ -276,6 +362,7 @@ private struct StoreHomeSectionView: View {
     let tools: [Tool]
     let inferenceStore: InferenceStore
     let workingAppID: String?
+    let actionTitle: (StoreAppSummary) -> String
     let onOpen: (StoreAppSummary) -> Void
     let onSeeAll: () -> Void
     let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
@@ -303,7 +390,7 @@ private struct StoreHomeSectionView: View {
                     VStack(spacing: 0) {
                         StoreAppStoreRowView(
                             app: app,
-                            actionTitle: "Get",
+                            actionTitle: actionTitle(app),
                             isWorking: workingAppID == app.id,
                             onOpen: { onOpen(app) },
                             onAction: { onGet(app, .get) }
@@ -320,6 +407,7 @@ private struct StoreHomeSectionView: View {
 
 private struct StoreSectionAppsView: View {
     let section: StoreSectionRoute
+    let refreshToken: Int
     @Bindable var store: StoreWindowStore
     let tools: [Tool]
     let inferenceStore: InferenceStore
@@ -348,7 +436,9 @@ private struct StoreSectionAppsView: View {
                     StoreAppRowsView(
                         apps: apps,
                         workingAppID: store.workingAppID,
-                        actionTitle: "Get",
+                        actionTitle: {
+                            store.installDisposition(for: $0, tools: tools).buttonTitle
+                        },
                         onOpen: onOpen,
                         onAction: { onGet($0, .get) }
                     )
@@ -358,10 +448,15 @@ private struct StoreSectionAppsView: View {
             .padding(.vertical, 24)
         }
         .navigationTitle(section.title)
-        .task(id: section) {
-            isLoading = true
+        .task(id: "\(section.id)-\(refreshToken)") {
+            let showsLoadingIndicator = apps.isEmpty
+            if showsLoadingIndicator {
+                isLoading = true
+            }
             apps = await store.loadSectionApps(sort: section.sort, category: section.category)
-            isLoading = false
+            if showsLoadingIndicator {
+                isLoading = false
+            }
         }
     }
 }
@@ -369,7 +464,7 @@ private struct StoreSectionAppsView: View {
 private struct StoreAppRowsView: View {
     let apps: [StoreAppSummary]
     let workingAppID: String?
-    let actionTitle: String
+    let actionTitle: (StoreAppSummary) -> String
     let onOpen: (StoreAppSummary) -> Void
     let onAction: (StoreAppSummary) -> Void
 
@@ -378,7 +473,7 @@ private struct StoreAppRowsView: View {
             ForEach(apps) { app in
                 StoreAppStoreRowView(
                     app: app,
-                    actionTitle: actionTitle,
+                    actionTitle: actionTitle(app),
                     isWorking: workingAppID == app.id,
                     onOpen: { onOpen(app) },
                     onAction: { onAction(app) }
@@ -494,14 +589,6 @@ private struct StorePublishedListView: View {
             .padding(.vertical, 24)
         }
         .navigationTitle("Published")
-        .toolbar {
-            Button {
-                Task { await store.refreshPublished() }
-            } label: {
-                Image(systemName: "arrow.clockwise")
-            }
-            .help("Refresh")
-        }
     }
 }
 

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -90,7 +90,8 @@ struct StoreWindowView: View {
         .frame(minWidth: 600, minHeight: 400)
         .onChange(of: store.searchText) { _, _ in
             searchTask?.cancel()
-            store.searchResultsNextCursor = nil
+            store.searchResultsNextOffset = 0
+            store.searchResultsHasMore = false
             searchTask = Task {
                 try? await Task.sleep(for: .milliseconds(300))
                 guard !Task.isCancelled else { return }
@@ -421,9 +422,11 @@ private struct StoreSectionAppsView: View {
     let onOpen: (StoreAppSummary) -> Void
     let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
     @State private var apps: [StoreAppSummary] = []
-    @State private var nextCursor: String?
+    @State private var nextOffset = 0
+    @State private var hasMore = false
     @State private var isLoading = true
     @State private var isLoadingMore = false
+    @State private var paginationRevision = 0
 
     var body: some View {
         ScrollView {
@@ -467,6 +470,8 @@ private struct StoreSectionAppsView: View {
     }
 
     private func reload() async {
+        paginationRevision += 1
+        let revision = paginationRevision
         let showsLoadingIndicator = apps.isEmpty
         if showsLoadingIndicator {
             isLoading = true
@@ -484,31 +489,38 @@ private struct StoreSectionAppsView: View {
         else {
             return
         }
+        guard paginationRevision == revision else {
+            return
+        }
         apps = page.apps
-        nextCursor = page.nextCursor
+        nextOffset = page.apps.count
+        hasMore = page.hasMore
     }
 
     private func loadMore() async {
-        guard let nextCursor, !isLoadingMore else {
+        guard hasMore, !isLoadingMore else {
             return
         }
+        let offset = nextOffset
+        let revision = paginationRevision
         isLoadingMore = true
         defer { isLoadingMore = false }
         guard
             let page = await store.loadSectionApps(
                 sort: section.sort,
                 category: section.category,
-                cursor: nextCursor
+                offset: offset
             )
         else {
             return
         }
-        guard self.nextCursor == nextCursor else {
+        guard paginationRevision == revision, nextOffset == offset else {
             return
         }
         let existingIDs = Set(apps.map(\.id))
         apps.append(contentsOf: page.apps.filter { !existingIDs.contains($0.id) })
-        self.nextCursor = page.nextCursor
+        nextOffset += page.apps.count
+        hasMore = page.hasMore
     }
 }
 

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -469,18 +469,24 @@ private struct StoreAppRowsView: View {
     let onOpen: (StoreAppSummary) -> Void
     let onAction: (StoreAppSummary) -> Void
 
+    private let columns = [
+        GridItem(.adaptive(minimum: 430), spacing: 44, alignment: .top)
+    ]
+
     var body: some View {
-        VStack(spacing: 0) {
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 0) {
             ForEach(apps) { app in
-                StoreAppStoreRowView(
-                    app: app,
-                    actionTitle: actionTitle(app),
-                    isWorking: workingAppID == app.id,
-                    onOpen: { onOpen(app) },
-                    onAction: { onAction(app) }
-                )
-                Divider()
-                    .padding(.leading, 88)
+                VStack(spacing: 0) {
+                    StoreAppStoreRowView(
+                        app: app,
+                        actionTitle: actionTitle(app),
+                        isWorking: workingAppID == app.id,
+                        onOpen: { onOpen(app) },
+                        onAction: { onAction(app) }
+                    )
+                    Divider()
+                        .padding(.leading, 88)
+                }
             }
         }
     }
@@ -538,6 +544,10 @@ private struct StorePublishedListView: View {
     let onOpen: (StoreAppSummary) -> Void
     let onUpdateVersion: (Tool) -> Void
 
+    private let columns = [
+        GridItem(.adaptive(minimum: 430), spacing: 44, alignment: .top)
+    ]
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
@@ -562,26 +572,28 @@ private struct StorePublishedListView: View {
                     )
                     .frame(minHeight: 420)
                 } else {
-                    VStack(spacing: 0) {
+                    LazyVGrid(columns: columns, alignment: .leading, spacing: 0) {
                         ForEach(store.publishedApps) { app in
-                            StorePublishedRowView(
-                                app: app,
-                                linkedTool: tools.first { $0.storeAppId == app.id },
-                                isWorking: store.workingAppID == app.id,
-                                onSelect: { onOpen(app) },
-                                onUpdateVersion: onUpdateVersion,
-                                onToggleStatus: {
-                                    Task {
-                                        await store.setStatus(
-                                            app,
-                                            status: app.status == .published
-                                                ? .unlisted : .published
-                                        )
+                            VStack(spacing: 0) {
+                                StorePublishedRowView(
+                                    app: app,
+                                    linkedTool: tools.first { $0.storeAppId == app.id },
+                                    isWorking: store.workingAppID == app.id,
+                                    onSelect: { onOpen(app) },
+                                    onUpdateVersion: onUpdateVersion,
+                                    onToggleStatus: {
+                                        Task {
+                                            await store.setStatus(
+                                                app,
+                                                status: app.status == .published
+                                                    ? .unlisted : .published
+                                            )
+                                        }
                                     }
-                                }
-                            )
-                            Divider()
-                                .padding(.leading, 72)
+                                )
+                                Divider()
+                                    .padding(.leading, 72)
+                            }
                         }
                     }
                     .padding(.horizontal, 28)

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -1,6 +1,10 @@
 import SwiftData
 import SwiftUI
 
+private let storeAppGridColumns = [
+    GridItem(.adaptive(minimum: 340), spacing: 28, alignment: .top)
+]
+
 struct StoreWindowView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(InferenceStore.self) private var inferenceStore
@@ -83,6 +87,7 @@ struct StoreWindowView: View {
             }
         }
         .navigationSplitViewStyle(.balanced)
+        .frame(minWidth: 600, minHeight: 400)
         .onChange(of: store.searchText) { _, _ in
             searchTask?.cancel()
             store.searchResultsNextCursor = nil
@@ -373,10 +378,6 @@ private struct StoreHomeSectionView: View {
     let onSeeAll: () -> Void
     let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
 
-    private let columns = [
-        GridItem(.adaptive(minimum: 430), spacing: 44, alignment: .top)
-    ]
-
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
             HStack(alignment: .firstTextBaseline) {
@@ -391,7 +392,7 @@ private struct StoreHomeSectionView: View {
             }
             .padding(.horizontal, 28)
 
-            LazyVGrid(columns: columns, alignment: .leading, spacing: 0) {
+            LazyVGrid(columns: storeAppGridColumns, alignment: .leading, spacing: 0) {
                 ForEach(Array(section.apps.prefix(6))) { app in
                     VStack(spacing: 0) {
                         StoreAppStoreRowView(
@@ -518,7 +519,7 @@ private struct StorePaginationProgressView: View {
         if isLoading {
             ProgressView()
                 .controlSize(.small)
-            .frame(maxWidth: .infinity, minHeight: 32)
+                .frame(maxWidth: .infinity, minHeight: 32)
         }
     }
 }
@@ -531,13 +532,10 @@ private struct StoreAppRowsView: View {
     let onAction: (StoreAppSummary) -> Void
     var onApproachingEnd: (() async -> Void)? = nil
 
-    private let columns = [
-        GridItem(.adaptive(minimum: 430), spacing: 44, alignment: .top)
-    ]
     private let paginationPrefetchItemCount = 4
 
     var body: some View {
-        LazyVGrid(columns: columns, alignment: .leading, spacing: 0) {
+        LazyVGrid(columns: storeAppGridColumns, alignment: .leading, spacing: 0) {
             ForEach(Array(apps.enumerated()), id: \.element.id) { index, app in
                 VStack(spacing: 0) {
                     StoreAppStoreRowView(
@@ -618,10 +616,6 @@ private struct StorePublishedListView: View {
     let onOpen: (StoreAppSummary) -> Void
     let onUpdateVersion: (Tool) -> Void
 
-    private let columns = [
-        GridItem(.adaptive(minimum: 430), spacing: 44, alignment: .top)
-    ]
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
@@ -646,7 +640,7 @@ private struct StorePublishedListView: View {
                     )
                     .frame(minHeight: 420)
                 } else {
-                    LazyVGrid(columns: columns, alignment: .leading, spacing: 0) {
+                    LazyVGrid(columns: storeAppGridColumns, alignment: .leading, spacing: 0) {
                         ForEach(Array(store.publishedApps.enumerated()), id: \.element.id) {
                             index, app in
                             VStack(spacing: 0) {

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -286,9 +286,6 @@ private struct StoreHomeSectionView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Divider()
-                .padding(.horizontal, 28)
-
             HStack(alignment: .firstTextBaseline) {
                 Text(section.title)
                     .font(.largeTitle.weight(.semibold))
@@ -573,10 +570,14 @@ private struct StoreAppDetailDestinationView: View {
             app: store.selectedAppDetail?.id == appID ? store.selectedAppDetail : nil,
             isLoading: store.isLoadingDetail,
             isWorking: store.workingAppID == appID,
+            workingVersionID: store.workingVersionID,
             installDisposition: detail.map {
                 store.installDisposition(for: $0, tools: tools)
             } ?? .createCopy,
             canRemix: detail.map { !store.isOwnPublishedApp($0) } ?? false,
+            versionInstallDisposition: { app, version in
+                store.installDisposition(for: version, of: app, tools: tools)
+            },
             onGet: { app in
                 Task {
                     await store.install(
@@ -594,6 +595,18 @@ private struct StoreAppDetailDestinationView: View {
                     await store.install(
                         app,
                         mode: .remix,
+                        tools: tools,
+                        modelContext: modelContext,
+                        routeStore: routeStore,
+                        inferenceStore: inferenceStore
+                    )
+                }
+            },
+            onInstallVersion: { app, version in
+                Task {
+                    await store.installVersion(
+                        version,
+                        of: app,
                         tools: tools,
                         modelContext: modelContext,
                         routeStore: routeStore,
@@ -619,190 +632,7 @@ private struct StoreAppDetailDestinationView: View {
     }
 }
 
-private struct StoreAppDetailView: View {
-    let app: StoreAppDetail?
-    let isLoading: Bool
-    let isWorking: Bool
-    let installDisposition: StoreAppInstallDisposition
-    let canRemix: Bool
-    let onGet: (StoreAppDetail) -> Void
-    let onRemix: (StoreAppDetail) -> Void
-
-    var body: some View {
-        Group {
-            if let app {
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 18) {
-                        HStack(alignment: .top, spacing: 16) {
-                            StoreIconView(url: app.iconAsset?.url, size: 88)
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text(app.name)
-                                    .font(.largeTitle.weight(.semibold))
-                                Text(app.shortDescription)
-                                    .font(.title3.weight(.medium))
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(2)
-                                Text(
-                                    "\(app.authorDisplayName) · \(app.category.title) · Version \(app.currentVersion.versionNumber)"
-                                )
-                                .font(.callout.weight(.medium))
-                                .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                        }
-
-                        HStack {
-                            Button {
-                                onGet(app)
-                            } label: {
-                                Label(
-                                    installDisposition.buttonTitle,
-                                    systemImage: installDisposition.systemImage)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .disabled(isWorking)
-
-                            if canRemix {
-                                Button {
-                                    onRemix(app)
-                                } label: {
-                                    Label("Remix", systemImage: "wand.and.sparkles")
-                                }
-                                .disabled(isWorking)
-                            }
-
-                            if isWorking {
-                                ProgressView()
-                                    .controlSize(.small)
-                            }
-                        }
-
-                        Text(app.description)
-                            .font(.body)
-                            .textSelection(.enabled)
-
-                        if let screenshot = app.screenshots.first {
-                            Group {
-                                if let url = screenshot.url {
-                                    AsyncImage(url: url) { phase in
-                                        switch phase {
-                                        case .success(let image):
-                                            image
-                                                .resizable()
-                                                .scaledToFit()
-                                        case .failure:
-                                            StoreImagePlaceholder(systemImage: "photo")
-                                        case .empty:
-                                            ProgressView()
-                                        @unknown default:
-                                            EmptyView()
-                                        }
-                                    }
-                                } else {
-                                    StoreImagePlaceholder(systemImage: "photo")
-                                }
-                            }
-                            .frame(maxWidth: .infinity, maxHeight: 360)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                        }
-
-                        StoreDetailMetadataView(app: app)
-                        StoreVersionHistoryView(versions: app.recentVersions)
-                    }
-                    .padding(28)
-                    .frame(maxWidth: 860, alignment: .leading)
-                }
-            } else if isLoading {
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                StoreEmptyStateView(title: "App not found", systemImage: "square.grid.2x2")
-            }
-        }
-    }
-}
-
-private struct StoreDetailMetadataView: View {
-    let app: StoreAppDetail
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            StorePermissionChipsView(
-                permissions: app.currentVersion.generationSettings.permissionChips)
-
-            LabeledContent("Category") {
-                Text(app.category.title)
-            }
-            LabeledContent("Source Hash") {
-                Text(shortHash(app.currentVersion.sourceSha256))
-                    .monospaced()
-                    .textSelection(.enabled)
-            }
-            LabeledContent("Runtime") {
-                Text(app.currentVersion.runtimeVersion)
-                    .textSelection(.enabled)
-            }
-            LabeledContent("Scanner") {
-                Text(app.currentVersion.scannerVersion)
-                    .textSelection(.enabled)
-            }
-            LabeledContent("License") {
-                Text(app.currentVersion.license)
-            }
-            if let remix = app.remix {
-                LabeledContent("Remixed From") {
-                    Text("\(remix.appName) v\(remix.versionNumber)")
-                }
-            }
-        }
-    }
-
-    private func shortHash(_ hash: String) -> String {
-        guard hash.count > 16 else { return hash }
-        return "\(hash.prefix(12))...\(hash.suffix(6))"
-    }
-}
-
-private struct StoreVersionHistoryView: View {
-    let versions: [StoreVersionMetadata]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Versions")
-                .font(.headline)
-
-            VStack(alignment: .leading, spacing: 8) {
-                ForEach(versions) { version in
-                    HStack {
-                        Text("v\(version.versionNumber)")
-                            .font(.subheadline.weight(.semibold))
-                        Text(shortHash(version.sourceSha256))
-                            .font(.caption.monospaced())
-                            .foregroundStyle(.secondary)
-                        Spacer()
-                        Text(formattedDate(version.publishedAt))
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-            }
-        }
-    }
-
-    private func shortHash(_ hash: String) -> String {
-        guard hash.count > 12 else { return hash }
-        return String(hash.prefix(12))
-    }
-
-    private func formattedDate(_ value: String) -> String {
-        guard let date = ISO8601DateFormatter().date(from: value) else {
-            return value
-        }
-        return date.formatted(date: .abbreviated, time: .omitted)
-    }
-}
-
-private struct StoreIconView: View {
+struct StoreIconView: View {
     let url: URL?
     let size: CGFloat
 
@@ -836,7 +666,7 @@ private struct StoreIconView: View {
     }
 }
 
-private struct StoreImagePlaceholder: View {
+struct StoreImagePlaceholder: View {
     let systemImage: String
 
     var body: some View {
@@ -849,29 +679,7 @@ private struct StoreImagePlaceholder: View {
     }
 }
 
-private struct StorePermissionChipsView: View {
-    let permissions: [String]
-
-    var body: some View {
-        if permissions.isEmpty {
-            Text("No extra permissions")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        } else {
-            FlowLayout(spacing: 6) {
-                ForEach(permissions, id: \.self) { permission in
-                    Text(permission)
-                        .font(.caption.weight(.medium))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(.quaternary.opacity(0.45), in: Capsule())
-                }
-            }
-        }
-    }
-}
-
-private struct StoreEmptyStateView: View {
+struct StoreEmptyStateView: View {
     let title: String
     let systemImage: String
 
@@ -887,48 +695,6 @@ private struct StoreEmptyStateView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(24)
-    }
-}
-
-private struct FlowLayout: Layout {
-    let spacing: CGFloat
-
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        layout(in: proposal.replacingUnspecifiedDimensions().width, subviews: subviews).size
-    }
-
-    func placeSubviews(
-        in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()
-    ) {
-        let placements = layout(in: bounds.width, subviews: subviews).placements
-        for placement in placements {
-            subviews[placement.index].place(
-                at: CGPoint(
-                    x: bounds.minX + placement.frame.minX, y: bounds.minY + placement.frame.minY),
-                proposal: ProposedViewSize(placement.frame.size)
-            )
-        }
-    }
-
-    private func layout(in width: CGFloat, subviews: Subviews) -> (
-        size: CGSize, placements: [(index: Int, frame: CGRect)]
-    ) {
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var lineHeight: CGFloat = 0
-        var placements: [(Int, CGRect)] = []
-        for index in subviews.indices {
-            let size = subviews[index].sizeThatFits(.unspecified)
-            if x > 0, x + size.width > width {
-                x = 0
-                y += lineHeight + spacing
-                lineHeight = 0
-            }
-            placements.append((index, CGRect(origin: CGPoint(x: x, y: y), size: size)))
-            x += size.width + spacing
-            lineHeight = max(lineHeight, size.height)
-        }
-        return (CGSize(width: width, height: y + lineHeight), placements)
     }
 }
 

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -15,12 +15,12 @@ struct StoreWindowView: View {
     var body: some View {
         @Bindable var store = store
 
-        NavigationSplitView(columnVisibility: .constant(.all)) {
+        NavigationSplitView {
             StoreSidebarView(
                 selection: $sidebarSelection,
                 searchText: $store.searchText
             )
-                .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 260)
+            .navigationSplitViewColumnWidth(min: 180, ideal: 220, max: 260)
         } detail: {
             NavigationStack(path: $path) {
                 Group {
@@ -83,7 +83,6 @@ struct StoreWindowView: View {
             }
         }
         .navigationSplitViewStyle(.balanced)
-        .toolbar(removing: .sidebarToggle)
         .onChange(of: store.searchText) { _, _ in
             searchTask?.cancel()
             searchTask = Task {
@@ -123,7 +122,7 @@ struct StoreWindowView: View {
             handleStoreRoute(route)
         }
         .alert(
-            "App Store",
+            "Ironsmith Store",
             isPresented: Binding(
                 get: { store.errorMessage != nil },
                 set: { isPresented in
@@ -163,7 +162,7 @@ struct StoreWindowView: View {
 
     private var navigationTitle: String {
         switch sidebarSelection ?? .discover {
-        case .discover: "App Store"
+        case .discover: "Ironsmith Store"
         case .category(let category): category.title
         case .published: "Published"
         }
@@ -316,7 +315,8 @@ private struct StoreDiscoverHomeView: View {
                     }
                 }
             }
-            .padding(.vertical, 24)
+            .padding(.top, 10)
+            .padding(.bottom, 24)
         }
     }
 }
@@ -445,7 +445,8 @@ private struct StoreSectionAppsView: View {
                     .padding(.horizontal, 28)
                 }
             }
-            .padding(.vertical, 24)
+            .padding(.top, 10)
+            .padding(.bottom, 24)
         }
         .navigationTitle(section.title)
         .task(id: "\(section.id)-\(refreshToken)") {
@@ -586,7 +587,8 @@ private struct StorePublishedListView: View {
                     .padding(.horizontal, 28)
                 }
             }
-            .padding(.vertical, 24)
+            .padding(.top, 10)
+            .padding(.bottom, 24)
         }
         .navigationTitle("Published")
     }

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -85,6 +85,7 @@ struct StoreWindowView: View {
         .navigationSplitViewStyle(.balanced)
         .onChange(of: store.searchText) { _, _ in
             searchTask?.cancel()
+            store.searchResultsNextCursor = nil
             searchTask = Task {
                 try? await Task.sleep(for: .milliseconds(300))
                 guard !Task.isCancelled else { return }
@@ -334,24 +335,29 @@ private struct StoreSearchResultsView: View {
                 .font(.largeTitle.weight(.semibold))
                 .padding(.horizontal, 28)
 
-            if store.isLoadingDiscover, store.discoverApps.isEmpty {
+            if store.isLoadingDiscover, store.searchResults.isEmpty {
                 ProgressView()
                     .frame(maxWidth: .infinity)
                     .padding(.top, 80)
-            } else if store.discoverApps.isEmpty {
+            } else if store.searchResults.isEmpty {
                 StoreEmptyStateView(title: "No search results", systemImage: "magnifyingglass")
                     .frame(minHeight: 360)
             } else {
                 StoreAppRowsView(
-                    apps: store.discoverApps,
+                    apps: store.searchResults,
                     workingAppID: store.workingAppID,
                     actionTitle: {
                         store.installDisposition(for: $0, tools: tools).buttonTitle
                     },
                     onOpen: onOpen,
-                    onAction: { onGet($0, .get) }
+                    onAction: { onGet($0, .get) },
+                    onApproachingEnd: {
+                        await store.loadMoreSearchResults()
+                    }
                 )
                 .padding(.horizontal, 28)
+
+                StorePaginationProgressView(isLoading: store.isLoadingMoreSearchResults)
             }
         }
     }
@@ -414,7 +420,9 @@ private struct StoreSectionAppsView: View {
     let onOpen: (StoreAppSummary) -> Void
     let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
     @State private var apps: [StoreAppSummary] = []
+    @State private var nextCursor: String?
     @State private var isLoading = true
+    @State private var isLoadingMore = false
 
     var body: some View {
         ScrollView {
@@ -440,9 +448,12 @@ private struct StoreSectionAppsView: View {
                             store.installDisposition(for: $0, tools: tools).buttonTitle
                         },
                         onOpen: onOpen,
-                        onAction: { onGet($0, .get) }
+                        onAction: { onGet($0, .get) },
+                        onApproachingEnd: loadMore
                     )
                     .padding(.horizontal, 28)
+
+                    StorePaginationProgressView(isLoading: isLoadingMore)
                 }
             }
             .padding(.top, 10)
@@ -450,14 +461,64 @@ private struct StoreSectionAppsView: View {
         }
         .navigationTitle(section.title)
         .task(id: "\(section.id)-\(refreshToken)") {
-            let showsLoadingIndicator = apps.isEmpty
-            if showsLoadingIndicator {
-                isLoading = true
-            }
-            apps = await store.loadSectionApps(sort: section.sort, category: section.category)
+            await reload()
+        }
+    }
+
+    private func reload() async {
+        let showsLoadingIndicator = apps.isEmpty
+        if showsLoadingIndicator {
+            isLoading = true
+        }
+        defer {
             if showsLoadingIndicator {
                 isLoading = false
             }
+        }
+        guard
+            let page = await store.loadSectionApps(
+                sort: section.sort,
+                category: section.category
+            )
+        else {
+            return
+        }
+        apps = page.apps
+        nextCursor = page.nextCursor
+    }
+
+    private func loadMore() async {
+        guard let nextCursor, !isLoadingMore else {
+            return
+        }
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+        guard
+            let page = await store.loadSectionApps(
+                sort: section.sort,
+                category: section.category,
+                cursor: nextCursor
+            )
+        else {
+            return
+        }
+        guard self.nextCursor == nextCursor else {
+            return
+        }
+        let existingIDs = Set(apps.map(\.id))
+        apps.append(contentsOf: page.apps.filter { !existingIDs.contains($0.id) })
+        self.nextCursor = page.nextCursor
+    }
+}
+
+private struct StorePaginationProgressView: View {
+    let isLoading: Bool
+
+    var body: some View {
+        if isLoading {
+            ProgressView()
+                .controlSize(.small)
+            .frame(maxWidth: .infinity, minHeight: 32)
         }
     }
 }
@@ -468,14 +529,16 @@ private struct StoreAppRowsView: View {
     let actionTitle: (StoreAppSummary) -> String
     let onOpen: (StoreAppSummary) -> Void
     let onAction: (StoreAppSummary) -> Void
+    var onApproachingEnd: (() async -> Void)? = nil
 
     private let columns = [
         GridItem(.adaptive(minimum: 430), spacing: 44, alignment: .top)
     ]
+    private let paginationPrefetchItemCount = 4
 
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 0) {
-            ForEach(apps) { app in
+            ForEach(Array(apps.enumerated()), id: \.element.id) { index, app in
                 VStack(spacing: 0) {
                     StoreAppStoreRowView(
                         app: app,
@@ -486,6 +549,17 @@ private struct StoreAppRowsView: View {
                     )
                     Divider()
                         .padding(.leading, 88)
+                }
+                .onAppear {
+                    guard
+                        index >= max(apps.count - paginationPrefetchItemCount, 0),
+                        let onApproachingEnd
+                    else {
+                        return
+                    }
+                    Task {
+                        await onApproachingEnd()
+                    }
                 }
             }
         }
@@ -573,7 +647,8 @@ private struct StorePublishedListView: View {
                     .frame(minHeight: 420)
                 } else {
                     LazyVGrid(columns: columns, alignment: .leading, spacing: 0) {
-                        ForEach(store.publishedApps) { app in
+                        ForEach(Array(store.publishedApps.enumerated()), id: \.element.id) {
+                            index, app in
                             VStack(spacing: 0) {
                                 StorePublishedRowView(
                                     app: app,
@@ -594,9 +669,21 @@ private struct StorePublishedListView: View {
                                 Divider()
                                     .padding(.leading, 72)
                             }
+                            .onAppear {
+                                guard
+                                    index >= max(store.publishedApps.count - 4, 0)
+                                else {
+                                    return
+                                }
+                                Task {
+                                    await store.loadMorePublishedApps()
+                                }
+                            }
                         }
                     }
                     .padding(.horizontal, 28)
+
+                    StorePaginationProgressView(isLoading: store.isLoadingMorePublishedApps)
                 }
             }
             .padding(.top, 10)

--- a/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
+++ b/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
@@ -204,7 +204,7 @@ private struct AgentOutputToolIconView: View {
 
     private var loadKey: AgentOutputToolIconLoadKey {
         AgentOutputToolIconLoadKey(
-            path: tool.packageLayout.cachedAppIconPNGURL.path,
+            path: tool.packageLayout.cachedAppIconPreviewURL.path,
             updatedAt: tool.updatedAt
         )
     }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
@@ -36,6 +36,16 @@ struct ToolLibraryPopoverHeaderView: View {
                 .accessibilityIdentifier("app-update-button")
             }
 
+            Button(action: toggleSearch) {
+                Image(systemName: isSearchPresented ? "xmark" : "magnifyingglass")
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(.secondary)
+            .help(isSearchPresented ? "Close Search" : "Search Apps")
+            .accessibilityLabel(isSearchPresented ? "Close app search" : "Search apps")
+            .accessibilityIdentifier("tool-search-button")
+
             if isStoreEnabled {
                 Button(action: onOpenStore) {
                     Image(systemName: "shippingbox")
@@ -47,16 +57,6 @@ struct ToolLibraryPopoverHeaderView: View {
                 .accessibilityLabel("App Store")
                 .accessibilityIdentifier("app-store-button")
             }
-
-            Button(action: toggleSearch) {
-                Image(systemName: isSearchPresented ? "xmark" : "magnifyingglass")
-                    .font(.system(size: 15, weight: .semibold))
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(.secondary)
-            .help(isSearchPresented ? "Close Search" : "Search Apps")
-            .accessibilityLabel(isSearchPresented ? "Close app search" : "Search apps")
-            .accessibilityIdentifier("tool-search-button")
 
             Button(action: onOpenSettings) {
                 Image(systemName: "gearshape")

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
@@ -48,7 +48,7 @@ struct ToolLibraryPopoverHeaderView: View {
 
             if isStoreEnabled {
                 Button(action: onOpenStore) {
-                    Image(systemName: "shippingbox")
+                    Image(systemName: "storefront")
                         .font(.system(size: 15, weight: .semibold))
                 }
                 .buttonStyle(.plain)

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverHeaderView.swift
@@ -53,8 +53,8 @@ struct ToolLibraryPopoverHeaderView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
-                .help("App Store")
-                .accessibilityLabel("App Store")
+                .help("Ironsmith Store")
+                .accessibilityLabel("Ironsmith Store")
                 .accessibilityIdentifier("app-store-button")
             }
 
@@ -102,7 +102,7 @@ struct ToolLibraryPopoverHeaderView: View {
                 Divider()
 
                 if isStoreEnabled {
-                    Button("Browse App Store...") {
+                    Button("Browse Ironsmith Store...") {
                         onOpenStore()
                     }
 

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -234,7 +234,7 @@ struct ToolLibraryPopoverView: View {
             Text(inferenceStore.presentedErrorMessage ?? "")
         }
         .alert(
-            "App Store",
+            "Ironsmith Store",
             isPresented: storeErrorPresentedBinding
         ) {
             Button("OK", role: .cancel) {}

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -20,7 +20,7 @@ struct ToolLibraryStorePublishSheetView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text(isUpdatingPublishedListing ? "Update Store Version" : "Publish to App Store")
+            Text(isUpdatingPublishedListing ? "Update Store Version" : "Publish to Ironsmith Store")
                 .font(.headline)
 
             if needsDisplayName {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -155,6 +155,15 @@ final class ToolLibraryStorePublisher {
                 encoding: .utf8
             )
             let settings = tool.generationSettings(defaults: defaultSettings)
+            _ = try await iconClient.ensureIconAssets(
+                ToolIconRequest(displayName: tool.name, layout: tool.packageLayout)
+            )
+            let iconMasterJPEG = try Data(
+                contentsOf: tool.packageLayout.cachedAppIconMasterJPEGURL
+            )
+            let iconThumbnailJPEG = try Data(
+                contentsOf: tool.packageLayout.cachedAppIconThumbnailJPEGURL
+            )
             let app: StoreAppDetail
             if let linkedApp = linkedPublishedApp(for: tool) {
                 app = try await storeClient.publishVersion(
@@ -163,17 +172,14 @@ final class ToolLibraryStorePublisher {
                         appId: linkedApp.id,
                         sourceCode: source,
                         generationSettings: settings,
-                        iconPNG: nil,
-                        screenshotPNGs: publishScreenshotData.map { [$0] } ?? [],
+                        iconMasterJPEG: iconMasterJPEG,
+                        iconThumbnailJPEG: iconThumbnailJPEG,
+                        screenshotJPEGs: publishScreenshotData.map { [$0] } ?? [],
                         replaceScreenshots: publishScreenshotData != nil,
                         remixedFromVersionId: tool.storeRemixedFromVersionId
                     )
                 )
             } else {
-                _ = try await iconClient.ensureIconAssets(
-                    ToolIconRequest(displayName: tool.name, layout: tool.packageLayout)
-                )
-                let iconPNG = try Data(contentsOf: tool.packageLayout.cachedAppIconPNGURL)
                 app = try await storeClient.publishApp(
                     StorePublicationRequest(
                         storeId: tool.storeId ?? IronsmithStoreConstants.communityStoreId,
@@ -185,8 +191,9 @@ final class ToolLibraryStorePublisher {
                         category: publishCategory,
                         sourceCode: source,
                         generationSettings: settings,
-                        iconPNG: iconPNG,
-                        screenshotPNGs: publishScreenshotData.map { [$0] } ?? [],
+                        iconMasterJPEG: iconMasterJPEG,
+                        iconThumbnailJPEG: iconThumbnailJPEG,
+                        screenshotJPEGs: publishScreenshotData.map { [$0] } ?? [],
                         remixedFromVersionId: tool.storeRemixedFromVersionId
                     )
                 )
@@ -211,8 +218,15 @@ final class ToolLibraryStorePublisher {
             }
         }
         do {
-            publishScreenshotData = try Data(contentsOf: url)
-            publishScreenshotName = url.lastPathComponent
+            let source = try Data(contentsOf: url)
+            let decoded = try ToolImageAssetEncoder.decodeImage(
+                source,
+                applyingOrientation: true
+            )
+            let screenshot = try ToolImageAssetEncoder.screenshot(from: decoded)
+            publishScreenshotData = screenshot.data
+            publishScreenshotName =
+                url.deletingPathExtension().lastPathComponent + ".jpg"
         } catch {
             present(error)
         }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -98,7 +98,7 @@ final class ToolLibraryStorePublisher {
     ) async {
         await inferenceStore.refreshIronsmithAccountSummary()
         guard inferenceStore.ironsmithSession != nil else {
-            errorMessage = "Sign in with Ironsmith before publishing to the App Store."
+            errorMessage = "Sign in with Ironsmith before publishing to the Ironsmith Store."
             return
         }
         await refreshPublishedStoreApps(

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -107,10 +107,8 @@ final class ToolLibraryStorePublisher {
         )
         publishingToolID = tool.id
         publishName = tool.name
-        publishShortDescription =
-            linkedPublishedApp(for: tool)?.shortDescription
-            ?? Self.defaultShortDescription(for: tool)
-        publishDescription = "Created with Ironsmith."
+        publishShortDescription = ""
+        publishDescription = ""
         publishCategory = linkedPublishedApp(for: tool)?.category ?? .utilities
         publishDisplayName = inferenceStore.ironsmithAccountSummary?.profile?.displayName ?? ""
         publishScreenshotData = nil
@@ -223,14 +221,6 @@ final class ToolLibraryStorePublisher {
     private func linkedPublishedApp(for tool: Tool) -> StoreAppSummary? {
         guard let storeAppId = tool.storeAppId else { return nil }
         return publishedStoreAppsByID[storeAppId]
-    }
-
-    private static func defaultShortDescription(for tool: Tool) -> String {
-        let trimmedName = tool.name.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedName.isEmpty {
-            return String(trimmedName.prefix(40))
-        }
-        return "Created with Ironsmith."
     }
 
     private func applyPublishedStoreLinkage(_ app: StoreAppDetail, to tool: Tool) {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -219,11 +219,7 @@ final class ToolLibraryStorePublisher {
         }
         do {
             let source = try Data(contentsOf: url)
-            let decoded = try ToolImageAssetEncoder.decodeImage(
-                source,
-                applyingOrientation: true
-            )
-            let screenshot = try ToolImageAssetEncoder.screenshot(from: decoded)
+            let screenshot = try ToolImageAssetEncoder.screenshot(from: source)
             publishScreenshotData = screenshot.data
             publishScreenshotName =
                 url.deletingPathExtension().lastPathComponent + ".jpg"

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -62,13 +62,14 @@ final class ToolLibraryStorePublisher {
             let linkedAppIDs = Set(tools.compactMap(\.storeAppId))
             var ownedAppsByID: [String: StoreAppSummary] = [:]
             for storeID in storeIDs {
-                var cursor: String?
+                var offset = 0
+                var hasMore: Bool
                 repeat {
                     let page = try await storeClient.listApps(
                         storeID,
                         .mine,
                         nil,
-                        cursor,
+                        offset,
                         .recent,
                         nil
                     )
@@ -76,8 +77,9 @@ final class ToolLibraryStorePublisher {
                         guard linkedAppIDs.contains(app.id) else { continue }
                         ownedAppsByID[app.id] = app
                     }
-                    cursor = page.nextCursor
-                } while cursor != nil
+                    offset += page.apps.count
+                    hasMore = page.hasMore
+                } while hasMore
             }
             publishedStoreAppsByID = ownedAppsByID
         } catch {

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolItemActions.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolItemActions.swift
@@ -122,7 +122,7 @@ struct ToolItemActionsMenu: View {
     }
 
     private var storePublishActionTitle: String {
-        state.canUpdateStoreVersion ? "Update Store Version..." : "Publish to App Store..."
+        state.canUpdateStoreVersion ? "Update Store Version..." : "Publish to Ironsmith Store..."
     }
 
     private var canContinue: Bool {

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -249,7 +249,9 @@ enum ToolRowGenerationStatusResolver {
         switch phase {
         case .generatingSource, .generatingEditDiff, .generatingRepairDiff, .repairing:
             return true
-        case .initializing, .planning, .generatingIcon, .waitingForIcon, .refiningPrompt, .packaging, .completed, nil:
+        case .initializing, .planning, .generatingIcon, .waitingForIcon, .refiningPrompt,
+            .packaging,
+            .completed, nil:
             return false
         }
     }
@@ -303,7 +305,7 @@ struct ToolIconImageView: View {
         let layout = ToolPackageLayout(
             packageRootURL: tool.packageRootURL, executableName: tool.executableName)
         return ToolIconLoadKey(
-            path: layout.cachedAppIconPNGURL.path,
+            path: layout.cachedAppIconPreviewURL.path,
             updatedAt: tool.updatedAt
         )
     }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import ImageIO
 import SwiftData
 import Testing
+
 @testable import Ironsmith
 
 extension AgentPipelineTests {
@@ -44,14 +45,14 @@ extension AgentPipelineTests {
         )
         let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: executableName)
         let source = """
-        import SwiftUI
+            import SwiftUI
 
-        struct ContentView: View {
-            var body: some View {
-                Text("materialized")
+            struct ContentView: View {
+                var body: some View {
+                    Text("materialized")
+                }
             }
-        }
-        """
+            """
         let settings = ToolGenerationSettings(appKind: .menuBar, menuBarSystemImage: "hammer")
 
         try materializer.materializePackage(
@@ -116,20 +117,23 @@ extension AgentPipelineTests {
 
         #expect(!FileManager.default.fileExists(atPath: placeholderRoot.path))
         #expect(FileManager.default.fileExists(atPath: finalLayout.packageManifestURL.path))
-        #expect(FileManager.default.fileExists(
-            atPath: finalLayout.currentRunAttachmentsDirectoryURL
-                .appendingPathComponent("1-reference.txt").path
-        ))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: finalLayout.currentRunAttachmentsDirectoryURL
+                    .appendingPathComponent("1-reference.txt").path
+            ))
 
         try materializer.restorePlaceholderPackage(from: finalLayout, to: placeholderRoot)
         #expect(!FileManager.default.fileExists(atPath: finalRoot.path))
-        #expect(!FileManager.default.fileExists(
-            atPath: placeholderRoot.appendingPathComponent("Package.swift").path
-        ))
-        #expect(FileManager.default.fileExists(
-            atPath: placeholderLayout.currentRunAttachmentsDirectoryURL
-                .appendingPathComponent("1-reference.txt").path
-        ))
+        #expect(
+            !FileManager.default.fileExists(
+                atPath: placeholderRoot.appendingPathComponent("Package.swift").path
+            ))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: placeholderLayout.currentRunAttachmentsDirectoryURL
+                    .appendingPathComponent("1-reference.txt").path
+            ))
     }
 
     @MainActor
@@ -189,7 +193,8 @@ extension AgentPipelineTests {
         let packageRoot = root.appendingPathComponent("VersionedTool", isDirectory: true)
         let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: "VersionedTool")
         let contentViewURL = try layout.packageFileURL(for: layout.contentViewSourcePath)
-        try FileManager.default.createDirectory(at: contentViewURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: contentViewURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try #"Text("current")"#.write(to: contentViewURL, atomically: true, encoding: .utf8)
 
         let settings = ToolGenerationSettings(
@@ -224,12 +229,17 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("LegacyVersionedTool", isDirectory: true)
-        let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: "LegacyVersionedTool")
+        let layout = ToolPackageLayout(
+            packageRootURL: packageRoot, executableName: "LegacyVersionedTool")
         let contentViewURL = try layout.packageFileURL(for: layout.contentViewSourcePath)
-        try FileManager.default.createDirectory(at: contentViewURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try FileManager.default.createDirectory(at: layout.previousContentViewVersionURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: contentViewURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: layout.previousContentViewVersionURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
         try #"Text("current")"#.write(to: contentViewURL, atomically: true, encoding: .utf8)
-        try #"Text("previous")"#.write(to: layout.previousContentViewVersionURL, atomically: true, encoding: .utf8)
+        try #"Text("previous")"#.write(
+            to: layout.previousContentViewVersionURL, atomically: true, encoding: .utf8)
         try """
         {
           "appKindRawValue": "menu_bar",
@@ -305,7 +315,8 @@ extension AgentPipelineTests {
         let languageModelContext = AgentLanguageModelContext(
             languageModel: EmptyLanguageModel(),
             generationOptions: GenerationOptions(),
-            pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1))
+            pipelineConfiguration: .ironsmithSpark(
+                repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1))
         )
         let dependencies = ToolGenerationRuntimeDependencies(
             toolsDirectoryURL: root,
@@ -322,7 +333,9 @@ extension AgentPipelineTests {
             for: "Sources/Demo/main.swift",
             packageRootURL: root
         )
-        #expect(resolved.path == root.appendingPathComponent("Sources/Demo/main.swift").standardizedFileURL.path)
+        #expect(
+            resolved.path
+                == root.appendingPathComponent("Sources/Demo/main.swift").standardizedFileURL.path)
 
         #expect(throws: AgentFileError.self) {
             try context.packageFileURL(for: "../outside.swift", packageRootURL: root)
@@ -333,34 +346,37 @@ extension AgentPipelineTests {
     func processHelpersFindCompilerFilesAndTrimOutput() {
         let root = URL(fileURLWithPath: "/tmp/GeneratedTool", isDirectory: true)
         let output = """
-        /tmp/GeneratedTool/Sources/GeneratedTool/main.swift:4:12: error: cannot find 'x' in scope
-        lots of detail
-        """
+            /tmp/GeneratedTool/Sources/GeneratedTool/main.swift:4:12: error: cannot find 'x' in scope
+            lots of detail
+            """
 
         #expect(
             SwiftPackageProcessClient.firstActionableSwiftFile(in: output, packageRootURL: root)
-            == "Sources/GeneratedTool/main.swift"
+                == "Sources/GeneratedTool/main.swift"
         )
-        #expect(SwiftPackageProcessClient.compilerExcerpt(from: String(repeating: "a", count: 20), limit: 8) == "aaaaaaaa")
+        #expect(
+            SwiftPackageProcessClient.compilerExcerpt(
+                from: String(repeating: "a", count: 20), limit: 8)
+                == "aaaaaaaa")
     }
 
     @Test
     func processHelpersFilterDiagnosticsToOneFile() {
         let root = URL(fileURLWithPath: "/tmp/GeneratedTool", isDirectory: true)
         let output = """
-        [4/9] Compiling GeneratedTool main.swift
-        /tmp/GeneratedTool/Sources/GeneratedTool/ContentView.swift:16:27: error: extra argument 'onDecrement' in call
-        14 | Stepper(...)
-        15 | ...
-        16 | ...
+            [4/9] Compiling GeneratedTool main.swift
+            /tmp/GeneratedTool/Sources/GeneratedTool/ContentView.swift:16:27: error: extra argument 'onDecrement' in call
+            14 | Stepper(...)
+            15 | ...
+            16 | ...
 
-        /tmp/GeneratedTool/Sources/GeneratedTool/OtherView.swift:8:10: error: cannot find 'x' in scope
-        6 | ...
-        7 | ...
-        8 | ...
+            /tmp/GeneratedTool/Sources/GeneratedTool/OtherView.swift:8:10: error: cannot find 'x' in scope
+            6 | ...
+            7 | ...
+            8 | ...
 
-        [5/9] Emitting module GeneratedTool
-        """
+            [5/9] Emitting module GeneratedTool
+            """
 
         let diagnostics = SwiftPackageProcessClient.diagnostics(
             for: "Sources/GeneratedTool/ContentView.swift",
@@ -375,7 +391,8 @@ extension AgentPipelineTests {
 
     @Test
     func adHocGeneratedAppSigningUsesHardenedRuntime() {
-        let appURL = URL(fileURLWithPath: "/tmp/GeneratedTool/Generated Tool.app", isDirectory: true)
+        let appURL = URL(
+            fileURLWithPath: "/tmp/GeneratedTool/Generated Tool.app", isDirectory: true)
         let entitlementsURL = URL(fileURLWithPath: "/tmp/GeneratedTool/sandbox.entitlements")
 
         #expect(
@@ -415,23 +432,30 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("SandboxedTool", isDirectory: true)
-        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
-        let cachedIconURL = packageRoot
+        let releaseBinDirectory = packageRoot.appendingPathComponent(
+            ".build/release", isDirectory: true)
+        let cachedIconURL =
+            packageRoot
             .appendingPathComponent(".ironsmith", isDirectory: true)
             .appendingPathComponent("AppIcon.icns")
-        try FileManager.default.createDirectory(at: cachedIconURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: cachedIconURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data("icon".utf8).write(to: cachedIconURL)
 
         let capture = BundleProcessCapture()
         let processClient = SwiftPackageProcessClient(
             build: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             buildRelease: { packageRoot in
                 await capture.recordReleaseBuild(packageRoot)
-                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
-                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("SandboxedTool"))
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                try FileManager.default.createDirectory(
+                    at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(
+                    to: releaseBinDirectory.appendingPathComponent("SandboxedTool"))
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             showBinPath: { _ in releaseBinDirectory },
             showReleaseBinPath: { _ in releaseBinDirectory },
@@ -442,11 +466,13 @@ extension AgentPipelineTests {
             },
             signAdHoc: { appURL, entitlementsURL in
                 await capture.recordSign(appURL: appURL, entitlementsURL: entitlementsURL)
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             verifyCodeSignature: { appURL in
                 await capture.recordVerify(appURL)
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             }
         )
         let client = ToolAppBundleClient.live(
@@ -459,13 +485,15 @@ extension AgentPipelineTests {
             bundleIdentifier: "com.ironsmith.tests.sandboxed-tool",
             packageRootURL: packageRoot,
             settings: ToolGenerationSettings(
-                resourcePermissions: GeneratedAppResourcePermissions(GeneratedAppResourcePermission.allCases)
+                resourcePermissions: GeneratedAppResourcePermissions(
+                    GeneratedAppResourcePermission.allCases)
             )
         )
 
         let appURL = try await client.buildInternalApp(request)
 
-        let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
+        let plist = try Self.plistDictionary(
+            at: appURL.appendingPathComponent("Contents/Info.plist"))
         let entitlements = try Self.plistDictionary(at: request.layout.sandboxEntitlementsURL)
         #expect(appURL == request.internalAppBundleURL)
         #expect(appURL.lastPathComponent == "Sandboxed Tool.app")
@@ -496,21 +524,23 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("ExistingWindowTool", isDirectory: true)
-        let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: "ExistingWindowTool")
+        let layout = ToolPackageLayout(
+            packageRootURL: packageRoot, executableName: "ExistingWindowTool")
         let appEntryURL = packageRoot.appendingPathComponent(layout.appEntrySourcePath)
-        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
+        let releaseBinDirectory = packageRoot.appendingPathComponent(
+            ".build/release", isDirectory: true)
         let originalAppEntrySource = """
-        import SwiftUI
+            import SwiftUI
 
-        @main
-        struct ExistingWindowTool: App {
-            var body: some Scene {
-                WindowGroup {
-                    ContentView()
+            @main
+            struct ExistingWindowTool: App {
+                var body: some Scene {
+                    WindowGroup {
+                        ContentView()
+                    }
                 }
             }
-        }
-        """
+            """
         try FileManager.default.createDirectory(
             at: appEntryURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
@@ -519,12 +549,16 @@ extension AgentPipelineTests {
 
         let processClient = SwiftPackageProcessClient(
             build: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             buildRelease: { _ in
-                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
-                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("ExistingWindowTool"))
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                try FileManager.default.createDirectory(
+                    at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(
+                    to: releaseBinDirectory.appendingPathComponent("ExistingWindowTool"))
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             showBinPath: { _ in releaseBinDirectory },
             showReleaseBinPath: { _ in releaseBinDirectory },
@@ -532,10 +566,12 @@ extension AgentPipelineTests {
             launchApp: { _ in },
             stripQuarantine: { _ in },
             signAdHoc: { _, _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             verifyCodeSignature: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             }
         )
         let client = ToolAppBundleClient.live(
@@ -556,7 +592,8 @@ extension AgentPipelineTests {
 
         let currentAppEntrySource = try String(contentsOf: appEntryURL, encoding: .utf8)
         #expect(currentAppEntrySource != originalAppEntrySource)
-        #expect(currentAppEntrySource.contains("MenuBarExtra(\"Existing Window Tool\", systemImage:"))
+        #expect(
+            currentAppEntrySource.contains("MenuBarExtra(\"Existing Window Tool\", systemImage:"))
         #expect(!(currentAppEntrySource.contains("WindowGroup")))
     }
 
@@ -571,15 +608,20 @@ extension AgentPipelineTests {
             sandboxPermissions: GeneratedAppSandboxPermissions
         ) async throws -> [String: Any] {
             let packageRoot = root.appendingPathComponent(executableName, isDirectory: true)
-            let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
+            let releaseBinDirectory = packageRoot.appendingPathComponent(
+                ".build/release", isDirectory: true)
             let processClient = SwiftPackageProcessClient(
                 build: { _ in
-                    SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                    SwiftPackageBuildResult(
+                        succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
                 },
                 buildRelease: { _ in
-                    try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
-                    try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent(executableName))
-                    return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                    try FileManager.default.createDirectory(
+                        at: releaseBinDirectory, withIntermediateDirectories: true)
+                    try Data("binary".utf8).write(
+                        to: releaseBinDirectory.appendingPathComponent(executableName))
+                    return SwiftPackageBuildResult(
+                        succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
                 },
                 showBinPath: { _ in releaseBinDirectory },
                 showReleaseBinPath: { _ in releaseBinDirectory },
@@ -587,10 +629,12 @@ extension AgentPipelineTests {
                 launchApp: { _ in },
                 stripQuarantine: { _ in },
                 signAdHoc: { _, _ in
-                    SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                    SwiftPackageBuildResult(
+                        succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
                 },
                 verifyCodeSignature: { _ in
-                    SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                    SwiftPackageBuildResult(
+                        succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
                 }
             )
             let request = ToolAppBundleRequest(
@@ -617,7 +661,8 @@ extension AgentPipelineTests {
         )
         #expect(withoutInternet["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(withoutInternet["com.apple.security.network.client"] == nil)
-        #expect(withoutInternet["com.apple.security.files.user-selected.read-write"] as? Bool == true)
+        #expect(
+            withoutInternet["com.apple.security.files.user-selected.read-write"] as? Bool == true)
 
         let withoutUserSelectedFiles = try await buildEntitlements(
             executableName: "NoFilesTool",
@@ -625,7 +670,8 @@ extension AgentPipelineTests {
         )
         #expect(withoutUserSelectedFiles["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(withoutUserSelectedFiles["com.apple.security.network.client"] as? Bool == true)
-        #expect(withoutUserSelectedFiles["com.apple.security.files.user-selected.read-write"] == nil)
+        #expect(
+            withoutUserSelectedFiles["com.apple.security.files.user-selected.read-write"] == nil)
     }
 
     @MainActor
@@ -681,7 +727,8 @@ extension AgentPipelineTests {
                 .appendingPathComponent("Info.plist")
         )
 
-        let storedRequest = ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(storedTool)
+        let storedRequest = ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(
+            storedTool)
 
         #expect(storedRequest.sandboxPermissions.enabled == [.userSelectedFiles])
         #expect(storedRequest.resourcePermissions.enabled == [.camera])
@@ -695,7 +742,10 @@ extension AgentPipelineTests {
             packageRootPath: legacyPackageRoot.path
         )
 
-        #expect(ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(legacyTool).sandboxPermissions == .default)
+        #expect(
+            ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(legacyTool)
+                .sandboxPermissions
+                == .default)
 
         let unsandboxedTool = StoredTool(
             name: "Unsandboxed",
@@ -705,7 +755,9 @@ extension AgentPipelineTests {
             packageRootPath: root.appendingPathComponent("UnsandboxedTool", isDirectory: true).path
         )
 
-        #expect(ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(unsandboxedTool).sandboxPermissions == .none)
+        #expect(
+            ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(unsandboxedTool)
+                .sandboxPermissions == .none)
     }
 
     @MainActor
@@ -715,23 +767,30 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("ExportedTool", isDirectory: true)
-        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
+        let releaseBinDirectory = packageRoot.appendingPathComponent(
+            ".build/release", isDirectory: true)
         let applicationsDirectory = root.appendingPathComponent("Applications", isDirectory: true)
-        let cachedIconURL = packageRoot
+        let cachedIconURL =
+            packageRoot
             .appendingPathComponent(".ironsmith", isDirectory: true)
             .appendingPathComponent("AppIcon.icns")
-        try FileManager.default.createDirectory(at: cachedIconURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: cachedIconURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data("icon".utf8).write(to: cachedIconURL)
 
         let capture = BundleProcessCapture()
         let processClient = SwiftPackageProcessClient(
             build: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             buildRelease: { _ in
-                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
-                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("ExportedTool"))
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                try FileManager.default.createDirectory(
+                    at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(
+                    to: releaseBinDirectory.appendingPathComponent("ExportedTool"))
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             showBinPath: { _ in releaseBinDirectory },
             showReleaseBinPath: { _ in releaseBinDirectory },
@@ -740,10 +799,12 @@ extension AgentPipelineTests {
             stripQuarantine: { _ in },
             signAdHoc: { appURL, entitlementsURL in
                 await capture.recordSign(appURL: appURL, entitlementsURL: entitlementsURL)
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             verifyCodeSignature: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             }
         )
         let client = ToolAppBundleClient.live(
@@ -757,21 +818,36 @@ extension AgentPipelineTests {
             packageRootURL: packageRoot,
             settings: ToolGenerationSettings(
                 sandboxEnabled: false,
-                resourcePermissions: GeneratedAppResourcePermissions([.contacts, .photoLibrary, .appleEvents])
+                resourcePermissions: GeneratedAppResourcePermissions([
+                    .contacts, .photoLibrary, .appleEvents,
+                ])
             )
         )
 
         let appURL = try await client.exportApp(request, applicationsDirectory)
 
-        let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
-        #expect(appURL == applicationsDirectory.appendingPathComponent("Exported Tool.app", isDirectory: true))
+        let plist = try Self.plistDictionary(
+            at: appURL.appendingPathComponent("Contents/Info.plist"))
+        #expect(
+            appURL
+                == applicationsDirectory.appendingPathComponent(
+                    "Exported Tool.app", isDirectory: true)
+        )
         #expect(plist["CFBundleIdentifier"] as? String == request.bundleIdentifier)
         #expect(plist["LSUIElement"] == nil)
         #expect(plist["IronsmithQuitOnLastWindowClose"] == nil)
-        #expect(plist["NSContactsUsageDescription"] as? String == GeneratedAppResourcePermission.contacts.usageDescription)
-        #expect(plist["NSPhotoLibraryUsageDescription"] as? String == GeneratedAppResourcePermission.photoLibrary.usageDescription)
-        #expect(plist["NSPhotoLibraryAddUsageDescription"] as? String == GeneratedAppResourcePermission.photoLibrary.usageDescription)
-        #expect(plist["NSAppleEventsUsageDescription"] as? String == GeneratedAppResourcePermission.appleEvents.usageDescription)
+        #expect(
+            plist["NSContactsUsageDescription"] as? String
+                == GeneratedAppResourcePermission.contacts.usageDescription)
+        #expect(
+            plist["NSPhotoLibraryUsageDescription"] as? String
+                == GeneratedAppResourcePermission.photoLibrary.usageDescription)
+        #expect(
+            plist["NSPhotoLibraryAddUsageDescription"] as? String
+                == GeneratedAppResourcePermission.photoLibrary.usageDescription)
+        #expect(
+            plist["NSAppleEventsUsageDescription"] as? String
+                == GeneratedAppResourcePermission.appleEvents.usageDescription)
         let recordedSignedAppURL = await capture.signedAppURL
         let signedAppURL = try #require(recordedSignedAppURL)
         #expect(signedAppURL != appURL)
@@ -786,16 +862,21 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("MenuBarTool", isDirectory: true)
-        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
+        let releaseBinDirectory = packageRoot.appendingPathComponent(
+            ".build/release", isDirectory: true)
         let applicationsDirectory = root.appendingPathComponent("Applications", isDirectory: true)
         let processClient = SwiftPackageProcessClient(
             build: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             buildRelease: { _ in
-                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
-                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("MenuBarTool"))
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                try FileManager.default.createDirectory(
+                    at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(
+                    to: releaseBinDirectory.appendingPathComponent("MenuBarTool"))
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             showBinPath: { _ in releaseBinDirectory },
             showReleaseBinPath: { _ in releaseBinDirectory },
@@ -803,10 +884,12 @@ extension AgentPipelineTests {
             launchApp: { _ in },
             stripQuarantine: { _ in },
             signAdHoc: { _, _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             verifyCodeSignature: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             }
         )
         let client = ToolAppBundleClient.live(
@@ -825,7 +908,8 @@ extension AgentPipelineTests {
 
         let appURL = try await client.exportApp(request, applicationsDirectory)
 
-        let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
+        let plist = try Self.plistDictionary(
+            at: appURL.appendingPathComponent("Contents/Info.plist"))
         #expect(plist["LSUIElement"] as? Bool == true)
         #expect(plist["IronsmithQuitOnLastWindowClose"] == nil)
     }
@@ -837,9 +921,12 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("RestoredTool", isDirectory: true)
-        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
-        let existingAppURL = packageRoot.appendingPathComponent("Restored Tool.app", isDirectory: true)
-        let existingMarkerURL = existingAppURL
+        let releaseBinDirectory = packageRoot.appendingPathComponent(
+            ".build/release", isDirectory: true)
+        let existingAppURL = packageRoot.appendingPathComponent(
+            "Restored Tool.app", isDirectory: true)
+        let existingMarkerURL =
+            existingAppURL
             .appendingPathComponent("Contents", isDirectory: true)
             .appendingPathComponent("Resources", isDirectory: true)
             .appendingPathComponent("old-marker.txt")
@@ -851,12 +938,16 @@ extension AgentPipelineTests {
 
         let processClient = SwiftPackageProcessClient(
             build: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             buildRelease: { _ in
-                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
-                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("RestoredTool"))
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                try FileManager.default.createDirectory(
+                    at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(
+                    to: releaseBinDirectory.appendingPathComponent("RestoredTool"))
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             showBinPath: { _ in releaseBinDirectory },
             showReleaseBinPath: { _ in releaseBinDirectory },
@@ -864,7 +955,8 @@ extension AgentPipelineTests {
             launchApp: { _ in },
             stripQuarantine: { _ in },
             signAdHoc: { _, _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             verifyCodeSignature: { appURL in
                 if appURL == existingAppURL {
@@ -875,7 +967,8 @@ extension AgentPipelineTests {
                         terminationStatus: 1
                     )
                 }
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             }
         )
         let client = ToolAppBundleClient.live(
@@ -903,7 +996,9 @@ extension AgentPipelineTests {
         }
 
         #expect(try String(contentsOf: existingMarkerURL, encoding: .utf8) == "previous bundle")
-        #expect(!(FileManager.default.fileExists(atPath: existingAppURL.appendingPathComponent("Contents/MacOS/RestoredTool").path)))
+        #expect(
+            !(FileManager.default.fileExists(
+                atPath: existingAppURL.appendingPathComponent("Contents/MacOS/RestoredTool").path)))
     }
 
     @MainActor
@@ -913,17 +1008,22 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("NoIconTool", isDirectory: true)
-        let releaseBinDirectory = packageRoot.appendingPathComponent(".build/release", isDirectory: true)
+        let releaseBinDirectory = packageRoot.appendingPathComponent(
+            ".build/release", isDirectory: true)
 
         let capture = BundleProcessCapture()
         let processClient = SwiftPackageProcessClient(
             build: { _ in
-                SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             buildRelease: { _ in
-                try FileManager.default.createDirectory(at: releaseBinDirectory, withIntermediateDirectories: true)
-                try Data("binary".utf8).write(to: releaseBinDirectory.appendingPathComponent("NoIconTool"))
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                try FileManager.default.createDirectory(
+                    at: releaseBinDirectory, withIntermediateDirectories: true)
+                try Data("binary".utf8).write(
+                    to: releaseBinDirectory.appendingPathComponent("NoIconTool"))
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             showBinPath: { _ in releaseBinDirectory },
             showReleaseBinPath: { _ in releaseBinDirectory },
@@ -932,11 +1032,13 @@ extension AgentPipelineTests {
             stripQuarantine: { _ in },
             signAdHoc: { appURL, entitlementsURL in
                 await capture.recordSign(appURL: appURL, entitlementsURL: entitlementsURL)
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             },
             verifyCodeSignature: { appURL in
                 await capture.recordVerify(appURL)
-                return SwiftPackageBuildResult(succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
+                return SwiftPackageBuildResult(
+                    succeeded: true, stdout: "", stderr: "", terminationStatus: 0)
             }
         )
         let client = ToolAppBundleClient.live(
@@ -955,10 +1057,15 @@ extension AgentPipelineTests {
 
         let appURL = try await client.buildInternalApp(request)
 
-        let plist = try Self.plistDictionary(at: appURL.appendingPathComponent("Contents/Info.plist"))
+        let plist = try Self.plistDictionary(
+            at: appURL.appendingPathComponent("Contents/Info.plist"))
         let entitlements = try Self.plistDictionary(at: request.layout.sandboxEntitlementsURL)
-        #expect(FileManager.default.fileExists(atPath: appURL.appendingPathComponent("Contents/MacOS/NoIconTool").path))
-        #expect(FileManager.default.fileExists(atPath: appURL.appendingPathComponent("Contents/Resources").path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: appURL.appendingPathComponent("Contents/MacOS/NoIconTool").path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: appURL.appendingPathComponent("Contents/Resources").path))
         #expect(plist["CFBundleIdentifier"] as? String == request.bundleIdentifier)
         #expect(plist["CFBundleIconFile"] == nil)
         #expect(plist["LSUIElement"] as? Bool == true)
@@ -985,7 +1092,8 @@ extension AgentPipelineTests {
         defer { try? FileManager.default.removeItem(at: root) }
 
         let packageRoot = root.appendingPathComponent("FallbackIconTool", isDirectory: true)
-        let layout = ToolPackageLayout(packageRootURL: packageRoot, executableName: "FallbackIconTool")
+        let layout = ToolPackageLayout(
+            packageRootURL: packageRoot, executableName: "FallbackIconTool")
         let iconPrompt = "Silver hammer"
         let client = ToolIconClient.live(
             imageGenerator: { _ in
@@ -1002,14 +1110,21 @@ extension AgentPipelineTests {
         )
 
         let icnsData = try Data(contentsOf: layout.cachedAppIconICNSURL)
-        let pngData = try Data(contentsOf: layout.cachedAppIconPNGURL)
+        let masterData = try Data(contentsOf: layout.cachedAppIconMasterJPEGURL)
+        let thumbnailData = try Data(contentsOf: layout.cachedAppIconThumbnailJPEGURL)
         #expect(iconURL == layout.cachedAppIconICNSURL)
         #expect(!(icnsData.isEmpty))
-        #expect(!(pngData.isEmpty))
-        let pngSize = try Self.imagePixelSize(at: layout.cachedAppIconPNGURL)
-        #expect(max(pngSize.width, pngSize.height) <= 256)
+        #expect(masterData.count <= ToolImageAssetEncoder.iconMasterMaximumBytes)
+        #expect(thumbnailData.count <= ToolImageAssetEncoder.iconThumbnailMaximumBytes)
+        let masterSize = try Self.imagePixelSize(at: layout.cachedAppIconMasterJPEGURL)
+        let thumbnailSize = try Self.imagePixelSize(at: layout.cachedAppIconThumbnailJPEGURL)
+        #expect(masterSize.width == 1024)
+        #expect(masterSize.height == 1024)
+        #expect(thumbnailSize.width == 256)
+        #expect(thumbnailSize.height == 256)
+        #expect(!FileManager.default.fileExists(atPath: layout.cachedAppIconPNGURL.path))
 
-        let imageRep = try #require(NSBitmapImageRep(data: pngData))
+        let imageRep = try #require(NSBitmapImageRep(data: thumbnailData))
         let corners = [
             NSPoint(x: 0, y: 0),
             NSPoint(x: imageRep.pixelsWide - 1, y: 0),
@@ -1059,9 +1174,9 @@ extension AgentPipelineTests {
             )
         )
 
-        let amberPNG = try Data(contentsOf: amberLayout.cachedAppIconPNGURL)
-        let azurePNG = try Data(contentsOf: azureLayout.cachedAppIconPNGURL)
-        #expect(amberPNG != azurePNG)
+        let amberJPEG = try Data(contentsOf: amberLayout.cachedAppIconThumbnailJPEGURL)
+        let azureJPEG = try Data(contentsOf: azureLayout.cachedAppIconThumbnailJPEGURL)
+        #expect(amberJPEG != azureJPEG)
     }
 
     @MainActor
@@ -1076,7 +1191,7 @@ extension AgentPipelineTests {
             hostedIconPaletteStore: ToolHostedIconPaletteStore(userDefaults: userDefaults)
         )
 
-        var generatedPNGs: [Data] = []
+        var generatedJPEGs: [Data] = []
         for index in 0...ToolHostedIconPaletteStore.recentPaletteLimit {
             let executableName = "RepeatedName\(index)"
             let layout = ToolPackageLayout(
@@ -1090,13 +1205,16 @@ extension AgentPipelineTests {
                     imageProvider: .disabled
                 )
             )
-            generatedPNGs.append(try Data(contentsOf: layout.cachedAppIconPNGURL))
+            generatedJPEGs.append(
+                try Data(contentsOf: layout.cachedAppIconThumbnailJPEGURL)
+            )
         }
 
-        #expect(Set(generatedPNGs.prefix(10)).count == 10)
-        #expect(Set(generatedPNGs.suffix(10)).count == 10)
+        #expect(Set(generatedJPEGs.prefix(10)).count == 10)
+        #expect(Set(generatedJPEGs.suffix(10)).count == 10)
         #expect(
-            userDefaults.array(forKey: IronsmithPreferenceKeys.recentHostedIconPaletteIndices)?.count
+            userDefaults.array(forKey: IronsmithPreferenceKeys.recentHostedIconPaletteIndices)?
+                .count
                 == ToolHostedIconPaletteStore.recentPaletteLimit
         )
     }
@@ -1105,11 +1223,11 @@ extension AgentPipelineTests {
     func processHelpersParseStructuredDiagnostics() {
         let root = URL(fileURLWithPath: "/tmp/GeneratedTool", isDirectory: true)
         let output = """
-        /tmp/GeneratedTool/Sources/GeneratedTool/ContentView.swift:16:27: error: extra argument 'onDecrement' in call
-        14 | Stepper(...)
-        15 | ...
-        16 | ...
-        """
+            /tmp/GeneratedTool/Sources/GeneratedTool/ContentView.swift:16:27: error: extra argument 'onDecrement' in call
+            14 | Stepper(...)
+            15 | ...
+            16 | ...
+            """
 
         let diagnostics = SwiftPackageProcessClient.parseDiagnostics(
             in: output,
@@ -1135,7 +1253,7 @@ extension AgentPipelineTests {
                 message: "extra argument 'onDecrement' in call",
                 supportingLines: [
                     "14 | Stepper(...)",
-                    "   | `- error: extra argument 'onDecrement' in call"
+                    "   | `- error: extra argument 'onDecrement' in call",
                 ]
             ),
             SwiftCompilerDiagnostic(
@@ -1153,12 +1271,15 @@ extension AgentPipelineTests {
                 severity: .error,
                 message: "cannot find 'payment' in scope",
                 supportingLines: []
-            )
+            ),
         ]
 
         let rendered = AgentDiagnosticsLog.renderDiagnostics(diagnostics, limit: 1)
 
-        #expect(rendered.contains("Sources/GeneratedTool/ContentView.swift:16:27: error: extra argument 'onDecrement' in call"))
+        #expect(
+            rendered.contains(
+                "Sources/GeneratedTool/ContentView.swift:16:27: error: extra argument 'onDecrement' in call"
+            ))
         #expect(!(rendered.contains("14 | Stepper")))
         #expect(rendered.contains("... 1 more diagnostics omitted"))
         #expect(rendered.contains("... 1 duplicate diagnostics omitted"))
@@ -1170,7 +1291,7 @@ extension AgentPipelineTests {
             ContentViewRepairSnippet(startLine: 1, endLine: 3, text: "Text(\"A\")\nText(\"B\")"),
             ContentViewRepairSnippet(startLine: 1, endLine: 3, text: "Text(\"A\")\nText(\"B\")"),
             ContentViewRepairSnippet(startLine: 10, endLine: 12, text: "Text(\"C\")"),
-            ContentViewRepairSnippet(startLine: 20, endLine: 22, text: "Text(\"D\")")
+            ContentViewRepairSnippet(startLine: 20, endLine: 22, text: "Text(\"D\")"),
         ]
 
         let rendered = AgentDiagnosticsLog.renderRepairSnippets(snippets, limit: 500)

--- a/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
@@ -201,6 +201,27 @@ struct ToolImageAssetEncoderTests {
         #expect(asset.height >= ToolImageAssetEncoder.screenshotMinimumDimension)
     }
 
+    @Test
+    func screenshotDecodeDownsamplesLargeSourceBeforeEncoding() throws {
+        let source = try Self.solidImage(width: 4000, height: 2000)
+        let sourceData = try Self.pngData(from: source)
+
+        let decoded = try ToolImageAssetEncoder.decodeImage(
+            sourceData,
+            applyingOrientation: true,
+            maximumPixelSize: max(
+                ToolImageAssetEncoder.screenshotMaximumWidth,
+                ToolImageAssetEncoder.screenshotMaximumHeight
+            )
+        )
+        let asset = try ToolImageAssetEncoder.screenshot(from: sourceData)
+
+        #expect(decoded.width <= ToolImageAssetEncoder.screenshotMaximumWidth)
+        #expect(decoded.height <= ToolImageAssetEncoder.screenshotMaximumHeight)
+        #expect(asset.width == 1920)
+        #expect(asset.height == 960)
+    }
+
     private static func transparentIconImage() throws -> CGImage {
         let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
         guard

--- a/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
@@ -1,0 +1,322 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ImageIO
+import Testing
+
+@testable import Ironsmith
+
+@Suite("Tool image asset encoder")
+struct ToolImageAssetEncoderTests {
+    @Test
+    func iconJPEGsUseRequiredDimensionsLimitsColorAndOpaqueBackground() throws {
+        let source = try Self.transparentIconImage()
+
+        let assets = try ToolImageAssetEncoder.iconAssets(from: source)
+
+        let master = try Self.imageProperties(assets.masterData)
+        let thumbnail = try Self.imageProperties(assets.thumbnailData)
+        #expect(master.type == "public.jpeg")
+        #expect(master.width == 1024)
+        #expect(master.height == 1024)
+        #expect(thumbnail.type == "public.jpeg")
+        #expect(thumbnail.width == 256)
+        #expect(thumbnail.height == 256)
+        #expect(assets.masterData.count <= ToolImageAssetEncoder.iconMasterMaximumBytes)
+        #expect(
+            assets.thumbnailData.count
+                <= ToolImageAssetEncoder.iconThumbnailMaximumBytes
+        )
+        #expect(!ToolImageAssetEncoder.containsForbiddenJPEGMetadata(assets.masterData))
+        #expect(
+            !ToolImageAssetEncoder.containsForbiddenJPEGMetadata(
+                assets.thumbnailData
+            )
+        )
+
+        let thumbnailImage = try ToolImageAssetEncoder.validateIconThumbnailJPEG(
+            assets.thumbnailData
+        )
+        #expect(thumbnailImage.bitsPerComponent == 8)
+        #expect(thumbnailImage.colorSpace?.name == CGColorSpace.sRGB)
+        let corner = try #require(NSBitmapImageRep(cgImage: thumbnailImage).colorAt(x: 0, y: 0))
+        #expect(corner.alphaComponent > 0.99)
+        #expect(corner.redComponent > 0.95)
+        #expect(corner.greenComponent > 0.95)
+        #expect(corner.blueComponent > 0.95)
+    }
+
+    @MainActor
+    @Test
+    func generatedICNSKeepsOriginalTransparencyWhileJPEGsAreOpaque() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = ToolPackageLayout(
+            packageRootURL: root.appendingPathComponent("OriginalIcon", isDirectory: true),
+            executableName: "OriginalIcon"
+        )
+        let source = try Self.transparentIconImage()
+        let client = ToolIconClient.live(imageGenerator: { _ in source })
+
+        _ = try await client.ensureIconAssets(
+            ToolIconRequest(
+                displayName: "Original Icon",
+                layout: layout,
+                imageProvider: .openAI
+            )
+        )
+
+        let icnsImage = try ToolImageAssetEncoder.largestImage(
+            at: layout.cachedAppIconICNSURL
+        )
+        let icnsCorner = try #require(
+            NSBitmapImageRep(cgImage: icnsImage).colorAt(x: 0, y: 0)
+        )
+        let thumbnailData = try Data(
+            contentsOf: layout.cachedAppIconThumbnailJPEGURL
+        )
+        let thumbnailImage = try ToolImageAssetEncoder.validateIconThumbnailJPEG(
+            thumbnailData
+        )
+        let thumbnailCorner = try #require(
+            NSBitmapImageRep(cgImage: thumbnailImage).colorAt(x: 0, y: 0)
+        )
+
+        #expect(icnsCorner.alphaComponent < 0.1)
+        #expect(thumbnailCorner.alphaComponent > 0.99)
+        #expect(thumbnailCorner.redComponent > 0.95)
+        #expect(thumbnailCorner.greenComponent > 0.95)
+        #expect(thumbnailCorner.blueComponent > 0.95)
+    }
+
+    @MainActor
+    @Test
+    func legacyICNSMigrationPreservesICNSAndCreatesJPEGs() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = ToolPackageLayout(
+            packageRootURL: root.appendingPathComponent("LegacyICNS", isDirectory: true),
+            executableName: "LegacyICNS"
+        )
+        let source = try Self.transparentIconImage()
+        let liveClient = ToolIconClient.live(imageGenerator: { _ in source })
+        let request = ToolIconRequest(
+            displayName: "Legacy ICNS",
+            layout: layout,
+            imageProvider: .openAI
+        )
+        _ = try await liveClient.ensureIconAssets(request)
+        let originalICNS = try Data(contentsOf: layout.cachedAppIconICNSURL)
+        try FileManager.default.removeItem(at: layout.cachedAppIconMasterJPEGURL)
+        try FileManager.default.removeItem(at: layout.cachedAppIconThumbnailJPEGURL)
+
+        _ = try await ToolIconClient.cachedOnly().ensureIconAssets(request)
+
+        #expect(try Data(contentsOf: layout.cachedAppIconICNSURL) == originalICNS)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.cachedAppIconMasterJPEGURL.path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.cachedAppIconThumbnailJPEGURL.path
+            )
+        )
+    }
+
+    @Test
+    func legacyPNGMigrationCreatesCompleteAssetSetThenRemovesPNG() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = ToolPackageLayout(
+            packageRootURL: root.appendingPathComponent("LegacyPNG", isDirectory: true),
+            executableName: "LegacyPNG"
+        )
+        try FileManager.default.createDirectory(
+            at: layout.packageMetadataDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try Self.pngData(from: Self.transparentIconImage()).write(
+            to: layout.cachedAppIconPNGURL,
+            options: .atomic
+        )
+
+        _ = try await ToolIconClient.cachedOnly().ensureIconAssets(
+            ToolIconRequest(displayName: "Legacy PNG", layout: layout)
+        )
+
+        #expect(
+            FileManager.default.fileExists(atPath: layout.cachedAppIconICNSURL.path)
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.cachedAppIconMasterJPEGURL.path
+            )
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.cachedAppIconThumbnailJPEGURL.path
+            )
+        )
+        #expect(!FileManager.default.fileExists(atPath: layout.cachedAppIconPNGURL.path))
+    }
+
+    @Test
+    func screenshotsFitWithoutEnlargementAndStripMetadata() throws {
+        let wide = try Self.solidImage(width: 2000, height: 1000)
+        let small = try Self.solidImage(width: 400, height: 300)
+
+        let wideAsset = try ToolImageAssetEncoder.screenshot(from: wide)
+        let smallAsset = try ToolImageAssetEncoder.screenshot(from: small)
+
+        #expect(wideAsset.width == 1280)
+        #expect(wideAsset.height == 640)
+        #expect(smallAsset.width == 400)
+        #expect(smallAsset.height == 300)
+        #expect(wideAsset.data.count <= ToolImageAssetEncoder.screenshotMaximumBytes)
+        let properties = try Self.imageProperties(wideAsset.data)
+        #expect(properties.type == "public.jpeg")
+        #expect(!ToolImageAssetEncoder.containsForbiddenJPEGMetadata(wideAsset.data))
+    }
+
+    @Test
+    func oversizedScreenshotShrinksDimensionsAtFixedQuality() throws {
+        let noisy = try Self.noisyImage(width: 1280, height: 960)
+
+        let asset = try ToolImageAssetEncoder.screenshot(from: noisy)
+
+        #expect(asset.data.count <= ToolImageAssetEncoder.screenshotMaximumBytes)
+        #expect(asset.width < 1280)
+        #expect(asset.height < 960)
+        #expect(
+            abs(
+                Double(asset.width) / Double(asset.height)
+                    - Double(1280) / Double(960)
+            ) < 0.002
+        )
+        #expect(asset.width >= ToolImageAssetEncoder.screenshotMinimumDimension)
+        #expect(asset.height >= ToolImageAssetEncoder.screenshotMinimumDimension)
+    }
+
+    private static func transparentIconImage() throws -> CGImage {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        guard
+            let context = CGContext(
+                data: nil,
+                width: 1024,
+                height: 1024,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotCreateImage
+        }
+        context.clear(CGRect(x: 0, y: 0, width: 1024, height: 1024))
+        context.setFillColor(CGColor(red: 0.1, green: 0.4, blue: 0.9, alpha: 1))
+        context.fillEllipse(in: CGRect(x: 128, y: 128, width: 768, height: 768))
+        return try #require(context.makeImage())
+    }
+
+    private static func solidImage(width: Int, height: Int) throws -> CGImage {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        guard
+            let context = CGContext(
+                data: nil,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotCreateImage
+        }
+        context.setFillColor(CGColor(red: 0.2, green: 0.6, blue: 0.8, alpha: 0.5))
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        return try #require(context.makeImage())
+    }
+
+    private static func noisyImage(width: Int, height: Int) throws -> CGImage {
+        var bytes = [UInt8](repeating: 0, count: width * height * 4)
+        var state: UInt64 = 0x1234_5678_9abc_def0
+        for offset in stride(from: 0, to: bytes.count, by: 4) {
+            state = state &* 6_364_136_223_846_793_005 &+ 1
+            bytes[offset] = UInt8(truncatingIfNeeded: state >> 24)
+            bytes[offset + 1] = UInt8(truncatingIfNeeded: state >> 32)
+            bytes[offset + 2] = UInt8(truncatingIfNeeded: state >> 40)
+            bytes[offset + 3] = 255
+        }
+        let data = Data(bytes)
+        guard let provider = CGDataProvider(data: data as CFData),
+            let image = CGImage(
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bitsPerPixel: 32,
+                bytesPerRow: width * 4,
+                space: CGColorSpace(name: CGColorSpace.sRGB)!,
+                bitmapInfo: CGBitmapInfo(
+                    rawValue: CGImageAlphaInfo.last.rawValue
+                ),
+                provider: provider,
+                decode: nil,
+                shouldInterpolate: true,
+                intent: .defaultIntent
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotCreateImage
+        }
+        return image
+    }
+
+    private static func pngData(from image: CGImage) throws -> Data {
+        guard let data = NSMutableData(capacity: image.width * image.height),
+            let destination = CGImageDestinationCreateWithData(
+                data,
+                "public.png" as CFString,
+                1,
+                nil
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotEncodeJPEG
+        }
+        CGImageDestinationAddImage(destination, image, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw ToolImageAssetEncodingError.couldNotEncodeJPEG
+        }
+        return data as Data
+    }
+
+    private static func imageProperties(_ data: Data) throws -> (
+        type: String?,
+        width: Int,
+        height: Int
+    ) {
+        let source = try #require(CGImageSourceCreateWithData(data as CFData, nil))
+        let properties = try #require(
+            CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+                as? [CFString: Any]
+        )
+        return (
+            CGImageSourceGetType(source) as String?,
+            properties[kCGImagePropertyPixelWidth] as? Int ?? 0,
+            properties[kCGImagePropertyPixelHeight] as? Int ?? 0
+        )
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "ironsmith-image-asset-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true
+        )
+        return url
+    }
+}

--- a/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
@@ -10,6 +10,8 @@ import Testing
 struct ToolImageAssetEncoderTests {
     @Test
     func iconJPEGsUseRequiredDimensionsLimitsColorAndOpaqueBackground() throws {
+        #expect(ToolImageAssetEncoder.iconJPEGQuality == 0.60)
+        #expect(ToolImageAssetEncoder.screenshotJPEGQuality == 0.70)
         let source = try Self.transparentIconImage()
 
         let assets = try ToolImageAssetEncoder.iconAssets(from: source)
@@ -170,8 +172,8 @@ struct ToolImageAssetEncoderTests {
         let wideAsset = try ToolImageAssetEncoder.screenshot(from: wide)
         let smallAsset = try ToolImageAssetEncoder.screenshot(from: small)
 
-        #expect(wideAsset.width == 1280)
-        #expect(wideAsset.height == 640)
+        #expect(wideAsset.width == 1920)
+        #expect(wideAsset.height == 960)
         #expect(smallAsset.width == 400)
         #expect(smallAsset.height == 300)
         #expect(wideAsset.data.count <= ToolImageAssetEncoder.screenshotMaximumBytes)
@@ -182,17 +184,17 @@ struct ToolImageAssetEncoderTests {
 
     @Test
     func oversizedScreenshotShrinksDimensionsAtFixedQuality() throws {
-        let noisy = try Self.noisyImage(width: 1280, height: 960)
+        let noisy = try Self.noisyImage(width: 1920, height: 1440)
 
         let asset = try ToolImageAssetEncoder.screenshot(from: noisy)
 
         #expect(asset.data.count <= ToolImageAssetEncoder.screenshotMaximumBytes)
-        #expect(asset.width < 1280)
-        #expect(asset.height < 960)
+        #expect(asset.width < 1920)
+        #expect(asset.height < 1440)
         #expect(
             abs(
                 Double(asset.width) / Double(asset.height)
-                    - Double(1280) / Double(960)
+                    - Double(1920) / Double(1440)
             ) < 0.002
         )
         #expect(asset.width >= ToolImageAssetEncoder.screenshotMinimumDimension)

--- a/IronsmithTests/Features/Settings/DebugIconExportTests.swift
+++ b/IronsmithTests/Features/Settings/DebugIconExportTests.swift
@@ -1,0 +1,103 @@
+#if DEBUG
+    import CoreGraphics
+    import Foundation
+    import ImageIO
+    import Testing
+
+    @testable import Ironsmith
+
+    @Suite("Debug icon export")
+    struct DebugIconExportTests {
+        @Test(
+            "Exports master and thumbnail in every experimental format",
+            arguments: DebugIconImageFormat.allCases
+        )
+        func exportsMasterAndThumbnail(format: DebugIconImageFormat) throws {
+            guard DebugIconExportClient.supportsEncoding(format) else {
+                #expect(format == .webP)
+                return
+            }
+
+            let outputRootURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: outputRootURL) }
+
+            let result = try DebugIconExportClient.export(
+                DebugIconExportRequest(
+                    image: try testImage(pixelSize: 64),
+                    format: format,
+                    quality: 0.8,
+                    masterPixelSize: 512,
+                    thumbnailPixelSize: 256,
+                    targetMasterByteCount: nil,
+                    outputRootURL: outputRootURL,
+                    providerName: "Test Provider"
+                )
+            )
+
+            #expect(FileManager.default.fileExists(atPath: result.masterURL.path))
+            #expect(FileManager.default.fileExists(atPath: result.thumbnailURL.path))
+            #expect(try dimensions(of: result.masterData) == CGSize(width: 512, height: 512))
+            #expect(try dimensions(of: result.thumbnailData) == CGSize(width: 256, height: 256))
+            #expect(result.masterURL.pathExtension == format.fileExtension)
+            #expect(result.thumbnailURL.pathExtension == format.fileExtension)
+        }
+
+        @Test("Reports when an intentionally tiny JPEG target cannot be reached")
+        func reportsUnmetTarget() throws {
+            let outputRootURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            defer { try? FileManager.default.removeItem(at: outputRootURL) }
+
+            let result = try DebugIconExportClient.export(
+                DebugIconExportRequest(
+                    image: try testImage(pixelSize: 64),
+                    format: .jpeg,
+                    quality: 0.9,
+                    masterPixelSize: 512,
+                    thumbnailPixelSize: 256,
+                    targetMasterByteCount: 1,
+                    outputRootURL: outputRootURL,
+                    providerName: "Test Provider"
+                )
+            )
+
+            #expect(!result.metTargetMasterSize)
+            #expect((result.effectiveMasterQuality ?? 1) < 0.9)
+        }
+
+        private func testImage(pixelSize: Int) throws -> CGImage {
+            guard
+                let context = CGContext(
+                    data: nil,
+                    width: pixelSize,
+                    height: pixelSize,
+                    bitsPerComponent: 8,
+                    bytesPerRow: 0,
+                    space: CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                )
+            else {
+                throw DebugIconExportError.couldNotScaleImage
+            }
+            context.setFillColor(CGColor(red: 0.1, green: 0.5, blue: 0.9, alpha: 1))
+            context.fill(CGRect(x: 0, y: 0, width: pixelSize, height: pixelSize))
+            guard let image = context.makeImage() else {
+                throw DebugIconExportError.couldNotScaleImage
+            }
+            return image
+        }
+
+        private func dimensions(of data: Data) throws -> CGSize {
+            guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+                let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil)
+                    as? [CFString: Any],
+                let width = properties[kCGImagePropertyPixelWidth] as? NSNumber,
+                let height = properties[kCGImagePropertyPixelHeight] as? NSNumber
+            else {
+                throw DebugIconExportError.couldNotEncode(.png)
+            }
+            return CGSize(width: width.doubleValue, height: height.doubleValue)
+        }
+    }
+#endif

--- a/IronsmithTests/Features/Store/StoreCategoryTests.swift
+++ b/IronsmithTests/Features/Store/StoreCategoryTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import Ironsmith
+
+@Suite("Store Categories")
+struct StoreCategoryTests {
+    @Test
+    func categoriesMatchTheStoreSidebarTaxonomy() {
+        #expect(
+            StoreAppCategory.allCases.map(\.title) == [
+                "Business",
+                "Developer Tools",
+                "Education",
+                "Entertainment",
+                "Finance",
+                "Games",
+                "Graphics & Design",
+                "Health & Fitness",
+                "Lifestyle",
+                "Music",
+                "Productivity",
+                "Utilities",
+            ]
+        )
+        #expect(StoreAppCategory.allCases.allSatisfy { !$0.systemImage.isEmpty })
+    }
+}

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -574,15 +574,15 @@ struct StoreImportTests {
 
     @MainActor
     @Test
-    func historicalVersionInstallCreatesAttributedSeparateCopyWithoutMutatingExistingTool()
+    func historicalVersionWithSharedSourceCreatesAttributedSeparateCopyWithoutMutatingExistingTool()
         async throws
     {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
-        let historicalSource = Self.sourceCode("historical")
-        let currentSource = Self.sourceCode("current")
+        let historicalSource = Self.sourceCode("shared")
+        let currentSource = historicalSource
         let historicalMetadata = Self.versionMetadata(
             id: "00000000-0000-4000-8000-000000000201",
             versionNumber: 1,

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -216,6 +216,252 @@ struct StoreImportTests {
         }
     }
 
+    @MainActor
+    @Test
+    func historicalVersionInstallCreatesAttributedSeparateCopyWithoutMutatingExistingTool()
+        async throws
+    {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let historicalSource = Self.sourceCode("historical")
+        let currentSource = Self.sourceCode("current")
+        let historicalMetadata = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000201",
+            versionNumber: 1,
+            sourceCode: historicalSource,
+            publishedAt: "2026-06-27T00:00:00.000Z"
+        )
+        let currentMetadata = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000202",
+            versionNumber: 2,
+            sourceCode: currentSource,
+            publishedAt: "2026-06-28T00:00:00.000Z"
+        )
+        let app = Self.appListing(
+            sourceCode: currentSource,
+            versions: [currentMetadata, historicalMetadata]
+        )
+        let currentDownload = Self.versionDownload(
+            id: currentMetadata.id,
+            versionNumber: 2,
+            appId: app.id,
+            sourceCode: currentSource,
+            sourceSha256: currentMetadata.sourceSha256
+        )
+        let historicalDownload = Self.versionDownload(
+            id: historicalMetadata.id,
+            versionNumber: 1,
+            appId: app.id,
+            sourceCode: historicalSource,
+            sourceSha256: historicalMetadata.sourceSha256
+        )
+        let importer = StoreToolImportClient.live(toolsDirectoryURL: root)
+        let existing = try await importer.importTool(
+            StoreToolImportRequest(app: app, version: currentDownload, mode: .get),
+            context
+        ).tool
+        var client = IronsmithStoreClient.unconfigured
+        client.fetchVersion = { _, _, versionNumber in
+            #expect(versionNumber == 1)
+            return historicalDownload
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: importer,
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        await store.installVersion(
+            historicalMetadata,
+            of: app,
+            tools: [existing],
+            modelContext: context,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {}),
+            inferenceStore: InferenceStore()
+        )
+
+        let tools = try context.fetch(FetchDescriptor<Tool>())
+        let installed = try #require(tools.first { $0.id != existing.id })
+        let existingSource = try String(
+            contentsOf: try existing.packageLayout.packageFileURL(
+                for: existing.contentViewSourcePath),
+            encoding: .utf8
+        )
+        #expect(tools.count == 2)
+        #expect(existingSource == currentSource)
+        #expect(existing.storeVersionId == currentMetadata.id)
+        #expect(installed.name == "\(app.name) v1")
+        #expect(installed.generationState == .ready)
+        #expect(installed.storeVersionId == historicalMetadata.id)
+        #expect(installed.storeVersionNumber == 1)
+        #expect(installed.storeSourceSha256 == historicalMetadata.sourceSha256)
+        #expect(installed.storeRemixedFromVersionId == historicalMetadata.id)
+        #expect(store.workingVersionID == nil)
+
+        guard case .openExisting(let matchingTool) = store.installDisposition(
+            for: historicalMetadata,
+            of: app,
+            tools: tools
+        ) else {
+            Issue.record("Expected the exact installed historical version to open.")
+            return
+        }
+        #expect(matchingTool.id == installed.id)
+    }
+
+    @MainActor
+    @Test
+    func historicalVersionHashMismatchDoesNotCreateOrChangeTools() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let historicalSource = Self.sourceCode("historical")
+        let currentSource = Self.sourceCode("current")
+        let historicalMetadata = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000201",
+            versionNumber: 1,
+            sourceCode: historicalSource
+        )
+        let currentMetadata = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000202",
+            versionNumber: 2,
+            sourceCode: currentSource
+        )
+        let app = Self.appListing(
+            sourceCode: currentSource,
+            versions: [currentMetadata, historicalMetadata]
+        )
+        let mismatchedSource = Self.sourceCode("wrong version")
+        let mismatchedDownload = Self.versionDownload(
+            id: historicalMetadata.id,
+            versionNumber: 1,
+            appId: app.id,
+            sourceCode: mismatchedSource,
+            sourceSha256: IronsmithStoreClient.sha256Hex(for: mismatchedSource)
+        )
+        var client = IronsmithStoreClient.unconfigured
+        client.fetchVersion = { _, _, _ in mismatchedDownload }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient.live(toolsDirectoryURL: root),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        await store.installVersion(
+            historicalMetadata,
+            of: app,
+            tools: [],
+            modelContext: context,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {}),
+            inferenceStore: InferenceStore()
+        )
+
+        #expect(try context.fetch(FetchDescriptor<Tool>()).isEmpty)
+        #expect(store.errorMessage != nil)
+        #expect(store.workingVersionID == nil)
+    }
+
+    @MainActor
+    @Test
+    func historicalVersionBuildFailureLeavesFailedCopyAndNoOtherToolChanges() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let source = Self.sourceCode("historical")
+        let metadata = Self.versionMetadata(versionNumber: 1, sourceCode: source)
+        let app = Self.appListing(sourceCode: source, versions: [metadata])
+        let download = Self.versionDownload(
+            id: metadata.id,
+            versionNumber: 1,
+            appId: app.id,
+            sourceCode: source,
+            sourceSha256: metadata.sourceSha256
+        )
+        var client = IronsmithStoreClient.unconfigured
+        client.fetchVersion = { _, _, _ in download }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient.live(toolsDirectoryURL: root),
+            buildClient: ToolBuildClient(buildTool: { _ in throw TestFailure.build })
+        )
+
+        await store.installVersion(
+            metadata,
+            of: app,
+            tools: [],
+            modelContext: context,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {}),
+            inferenceStore: InferenceStore()
+        )
+
+        let failedTool = try #require(context.fetch(FetchDescriptor<Tool>()).first)
+        #expect(failedTool.generationState == .failed)
+        #expect(failedTool.storeVersionId == metadata.id)
+        #expect(failedTool.storeRemixedFromVersionId == metadata.id)
+        #expect(store.errorMessage != nil)
+    }
+
+    @Test
+    func storePermissionPresentationUsesFriendlyLabelsAndSupportsEmptyState() {
+        let source = Self.sourceCode("permissions")
+        let permissionVersion = Self.versionMetadata(
+            versionNumber: 1,
+            sourceCode: source,
+            settings: ToolGenerationSettings(
+                sandboxEnabled: true,
+                sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+                resourcePermissions: GeneratedAppResourcePermissions([.microphone])
+            )
+        )
+        let items = StorePermissionPresentation.items(for: permissionVersion)
+
+        #expect(items.map(\.title) == ["Internet", "Microphone"])
+        #expect(
+            items.map(\.explanation) == [
+                "Access to network connections",
+                "Access to audio input",
+            ]
+        )
+
+        let emptyVersion = Self.versionMetadata(
+            versionNumber: 1,
+            sourceCode: source,
+            settings: ToolGenerationSettings(
+                sandboxEnabled: false,
+                sandboxPermissions: .none,
+                resourcePermissions: .none
+            )
+        )
+        #expect(StorePermissionPresentation.items(for: emptyVersion).isEmpty)
+        #expect(StoreVersionPresentation.permissionsSummary(emptyVersion) == "None")
+    }
+
+    @Test
+    func storeVersionPresentationOrdersNewestFirstAndDesignatesCurrentVersion() {
+        let first = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000201",
+            versionNumber: 1,
+            sourceCode: Self.sourceCode("one"),
+            publishedAt: "2026-06-27T00:00:00.000Z"
+        )
+        let second = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000202",
+            versionNumber: 2,
+            sourceCode: Self.sourceCode("two"),
+            publishedAt: "2026-06-28T00:00:00.000Z"
+        )
+        let app = Self.appListing(sourceCode: Self.sourceCode("two"), versions: [first, second])
+
+        #expect(StoreVersionPresentation.newestFirst(app.versions).map(\.versionNumber) == [2, 1])
+        #expect(StoreVersionPresentation.isCurrent(second, in: app))
+        #expect(!StoreVersionPresentation.isCurrent(first, in: app))
+        #expect(StoreVersionPresentation.formattedDate(second.publishedAt).contains("2026"))
+    }
+
     private static func sourceCode(_ text: String) -> String {
         """
         import SwiftUI
@@ -228,7 +474,10 @@ struct StoreImportTests {
         """
     }
 
-    private static func appListing(sourceCode: String) -> StoreAppDetail {
+    private static func appListing(
+        sourceCode: String,
+        versions suppliedVersions: [StoreVersionMetadata]? = nil
+    ) -> StoreAppDetail {
         let storeId = "00000000-0000-4000-8000-000000000011"
         let appId = "00000000-0000-4000-8000-000000000101"
         let version = StoreVersionMetadata(
@@ -243,6 +492,8 @@ struct StoreImportTests {
             remixedFromVersionId: nil,
             publishedAt: "2026-06-27T00:00:00.000Z"
         )
+        let versions = suppliedVersions ?? [version]
+        let currentVersion = versions.max { $0.versionNumber < $1.versionNumber } ?? version
         return StoreAppDetail(
             id: appId,
             storeId: storeId,
@@ -258,23 +509,46 @@ struct StoreImportTests {
             updatedAt: "2026-06-27T00:00:00.000Z",
             icon: nil,
             screenshots: [],
-            currentVersion: version,
-            recentVersions: [version],
+            currentVersion: currentVersion,
+            versions: versions,
             remix: nil
         )
     }
 
+    private static func versionMetadata(
+        id: String = "00000000-0000-4000-8000-000000000201",
+        versionNumber: Int,
+        sourceCode: String,
+        settings: ToolGenerationSettings = .default,
+        publishedAt: String = "2026-06-27T00:00:00.000Z"
+    ) -> StoreVersionMetadata {
+        StoreVersionMetadata(
+            id: id,
+            appId: "00000000-0000-4000-8000-000000000101",
+            versionNumber: versionNumber,
+            sourceSha256: IronsmithStoreClient.sha256Hex(for: sourceCode),
+            generationSettings: StoreGenerationSettingsDTO(settings: settings),
+            runtimeVersion: "ironsmith-macos-v1",
+            license: "MIT",
+            scannerVersion: "swift-execution-blocklist-v1",
+            remixedFromVersionId: nil,
+            publishedAt: publishedAt
+        )
+    }
+
     private static func versionDownload(
+        id: String = "00000000-0000-4000-8000-000000000201",
+        versionNumber: Int = 1,
         appId: String = "00000000-0000-4000-8000-000000000101",
         sourceCode: String,
         sourceSha256: String
     ) -> StoreVersionDownload {
         StoreVersionDownload(
-            id: "00000000-0000-4000-8000-000000000201",
+            id: id,
             storeId: "00000000-0000-4000-8000-000000000011",
             storeVisibility: "public",
             appId: appId,
-            versionNumber: 1,
+            versionNumber: versionNumber,
             sourceSha256: sourceSha256,
             generationSettings: StoreGenerationSettingsDTO(settings: .default),
             runtimeVersion: "ironsmith-macos-v1",
@@ -284,6 +558,10 @@ struct StoreImportTests {
             publishedAt: "2026-06-27T00:00:00.000Z",
             sourceCode: sourceCode
         )
+    }
+
+    private enum TestFailure: Error {
+        case build
     }
 
     private static func makeTemporaryDirectory() throws -> URL {

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -218,6 +218,115 @@ struct StoreImportTests {
 
     @MainActor
     @Test
+    func storeSummaryInstallDispositionUsesVersionLinkageAndProtectsEditedTools() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let store = StoreWindowStore(
+            client: .unconfigured,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+        let oldSource = Self.sourceCode("old")
+        let currentSource = Self.sourceCode("current")
+        let oldMetadata = Self.versionMetadata(versionNumber: 1, sourceCode: oldSource)
+        let currentMetadata = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000202",
+            versionNumber: 2,
+            sourceCode: currentSource
+        )
+        let app = Self.appListing(
+            sourceCode: currentSource,
+            versions: [currentMetadata, oldMetadata]
+        )
+        let summary = StoreAppSummary(detail: app)
+        let client = StoreToolImportClient.live(toolsDirectoryURL: root)
+        let oldImport = try await client.importTool(
+            StoreToolImportRequest(
+                app: app,
+                version: Self.versionDownload(
+                    versionNumber: 1,
+                    appId: app.id,
+                    sourceCode: oldSource,
+                    sourceSha256: oldMetadata.sourceSha256
+                ),
+                mode: .get
+            ),
+            context
+        )
+
+        guard case .updateExisting(let tool) = store.installDisposition(
+            for: summary,
+            tools: [oldImport.tool]
+        ) else {
+            Issue.record("Expected the listing row to show Update for an unchanged older version.")
+            return
+        }
+        #expect(tool.id == oldImport.tool.id)
+
+        let currentImport = try await client.importTool(
+            StoreToolImportRequest(
+                app: app,
+                version: Self.versionDownload(
+                    id: currentMetadata.id,
+                    versionNumber: 2,
+                    appId: app.id,
+                    sourceCode: currentSource,
+                    sourceSha256: currentMetadata.sourceSha256
+                ),
+                mode: .get
+            ),
+            context
+        )
+        guard case .openExisting(let tool) = store.installDisposition(
+            for: summary,
+            tools: [currentImport.tool]
+        ) else {
+            Issue.record("Expected the listing row to show Open for an unchanged current version.")
+            return
+        }
+        #expect(tool.id == currentImport.tool.id)
+
+        try Self.sourceCode("edited").write(
+            to: try currentImport.tool.packageLayout.packageFileURL(
+                for: currentImport.tool.contentViewSourcePath
+            ),
+            atomically: true,
+            encoding: .utf8
+        )
+        guard case .createCopy = store.installDisposition(
+            for: summary,
+            tools: [currentImport.tool]
+        ) else {
+            Issue.record("Expected an edited current copy to show Get.")
+            return
+        }
+    }
+
+    @MainActor
+    @Test
+    func successfulStoreMutationRequestsImplicitContentRefresh() async {
+        let app = Self.appListing(sourceCode: Self.sourceCode("published"))
+        var client = IronsmithStoreClient.unconfigured
+        client.patchListing = { _, _, _ in app }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        await store.setStatus(StoreAppSummary(detail: app), status: .unlisted)
+
+        #expect(store.contentRevision == 1)
+    }
+
+    @MainActor
+    @Test
     func historicalVersionInstallCreatesAttributedSeparateCopyWithoutMutatingExistingTool()
         async throws
     {

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import CoreGraphics
 import Foundation
 import SwiftData
 import Testing
@@ -5,6 +7,43 @@ import Testing
 @testable import Ironsmith
 
 struct StoreImportTests {
+    @Test
+    func storeMultipartUsesJPEGAssetContract() throws {
+        let body = StoreMultipartBody(boundary: "JPEG-Test-Boundary")
+            .addingFile(
+                name: "iconMaster",
+                filename: "icon-master.jpg",
+                contentType: "image/jpeg",
+                data: Data("master-bytes".utf8)
+            )
+            .addingFile(
+                name: "iconThumbnail",
+                filename: "icon-thumbnail.jpg",
+                contentType: "image/jpeg",
+                data: Data("thumbnail-bytes".utf8)
+            )
+            .addingScreenshotFiles([Data("screenshot-bytes".utf8)])
+        let encoded = String(decoding: body.data, as: UTF8.self)
+
+        #expect(
+            encoded.contains(
+                #"name="iconMaster"; filename="icon-master.jpg""#
+            )
+        )
+        #expect(
+            encoded.contains(
+                #"name="iconThumbnail"; filename="icon-thumbnail.jpg""#
+            )
+        )
+        #expect(
+            encoded.contains(
+                #"name="screenshots"; filename="screenshot-1.jpg""#
+            )
+        )
+        #expect(encoded.components(separatedBy: "Content-Type: image/jpeg").count == 4)
+        #expect(encoded.hasSuffix("--JPEG-Test-Boundary--\r\n"))
+    }
+
     @MainActor
     @Test
     func storeSourceHashVerificationRejectsTamperedDownloads() throws {
@@ -59,6 +98,82 @@ struct StoreImportTests {
         #expect(tool.storeSourceSha256 == version.sourceSha256)
         #expect(tool.storeImportedAt != nil)
         #expect(tool.storeRemixedFromVersionId == version.id)
+    }
+
+    @MainActor
+    @Test
+    func storeImportPersistsJPEGsAndBuildsICNSFromMaster() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let source = Self.sourceCode("downloaded icon")
+        let iconImage = try Self.transparentIconImage()
+        let iconAssets = try ToolImageAssetEncoder.iconAssets(from: iconImage)
+        let masterURL = URL(string: "https://assets.example.test/master.jpg")!
+        let thumbnailURL = URL(string: "https://assets.example.test/thumbnail.jpg")!
+        let app = Self.appListing(
+            sourceCode: source,
+            icon: StoreAsset(
+                id: UUID().uuidString,
+                kind: .icon,
+                sortOrder: 0,
+                width: 256,
+                height: 256,
+                byteSize: iconAssets.thumbnailData.count,
+                url: thumbnailURL
+            ),
+            iconMaster: StoreAsset(
+                id: UUID().uuidString,
+                kind: .iconMaster,
+                sortOrder: 0,
+                width: 1024,
+                height: 1024,
+                byteSize: iconAssets.masterData.count,
+                url: masterURL
+            )
+        )
+        let version = Self.versionDownload(
+            appId: app.id,
+            sourceCode: source,
+            sourceSha256: IronsmithStoreClient.sha256Hex(for: source)
+        )
+        let client = StoreToolImportClient.live(
+            toolsDirectoryURL: root,
+            iconDataLoader: { url in
+                switch url {
+                case masterURL:
+                    return iconAssets.masterData
+                case thumbnailURL:
+                    return iconAssets.thumbnailData
+                default:
+                    throw IronsmithStoreClientError.invalidResponse
+                }
+            }
+        )
+
+        let result = try await client.importTool(
+            StoreToolImportRequest(app: app, version: version, mode: .get),
+            context
+        )
+        let layout = result.tool.packageLayout
+
+        #expect(
+            try Data(contentsOf: layout.cachedAppIconMasterJPEGURL)
+                == iconAssets.masterData
+        )
+        #expect(
+            try Data(contentsOf: layout.cachedAppIconThumbnailJPEGURL)
+                == iconAssets.thumbnailData
+        )
+        #expect(FileManager.default.fileExists(atPath: layout.cachedAppIconICNSURL.path))
+        let importedICNS = try ToolImageAssetEncoder.largestImage(
+            at: layout.cachedAppIconICNSURL
+        )
+        let corner = try #require(
+            NSBitmapImageRep(cgImage: importedICNS).colorAt(x: 0, y: 0)
+        )
+        #expect(corner.alphaComponent > 0.99)
     }
 
     @MainActor
@@ -258,10 +373,12 @@ struct StoreImportTests {
             context
         )
 
-        guard case .updateExisting(let tool) = store.installDisposition(
-            for: summary,
-            tools: [oldImport.tool]
-        ) else {
+        guard
+            case .updateExisting(let tool) = store.installDisposition(
+                for: summary,
+                tools: [oldImport.tool]
+            )
+        else {
             Issue.record("Expected the listing row to show Update for an unchanged older version.")
             return
         }
@@ -281,10 +398,12 @@ struct StoreImportTests {
             ),
             context
         )
-        guard case .openExisting(let tool) = store.installDisposition(
-            for: summary,
-            tools: [currentImport.tool]
-        ) else {
+        guard
+            case .openExisting(let tool) = store.installDisposition(
+                for: summary,
+                tools: [currentImport.tool]
+            )
+        else {
             Issue.record("Expected the listing row to show Open for an unchanged current version.")
             return
         }
@@ -297,10 +416,12 @@ struct StoreImportTests {
             atomically: true,
             encoding: .utf8
         )
-        guard case .createCopy = store.installDisposition(
-            for: summary,
-            tools: [currentImport.tool]
-        ) else {
+        guard
+            case .createCopy = store.installDisposition(
+                for: summary,
+                tools: [currentImport.tool]
+            )
+        else {
             Issue.record("Expected an edited current copy to show Get.")
             return
         }
@@ -535,11 +656,13 @@ struct StoreImportTests {
         #expect(installed.storeRemixedFromVersionId == historicalMetadata.id)
         #expect(store.workingVersionID == nil)
 
-        guard case .openExisting(let matchingTool) = store.installDisposition(
-            for: historicalMetadata,
-            of: app,
-            tools: tools
-        ) else {
+        guard
+            case .openExisting(let matchingTool) = store.installDisposition(
+                for: historicalMetadata,
+                of: app,
+                tools: tools
+            )
+        else {
             Issue.record("Expected the exact installed historical version to open.")
             return
         }
@@ -727,7 +850,9 @@ struct StoreImportTests {
 
     private static func appListing(
         sourceCode: String,
-        versions suppliedVersions: [StoreVersionMetadata]? = nil
+        versions suppliedVersions: [StoreVersionMetadata]? = nil,
+        icon: StoreAsset? = nil,
+        iconMaster: StoreAsset? = nil
     ) -> StoreAppDetail {
         let storeId = "00000000-0000-4000-8000-000000000011"
         let appId = "00000000-0000-4000-8000-000000000101"
@@ -758,7 +883,8 @@ struct StoreImportTests {
             publishedAt: "2026-06-27T00:00:00.000Z",
             createdAt: "2026-06-27T00:00:00.000Z",
             updatedAt: "2026-06-27T00:00:00.000Z",
-            icon: nil,
+            icon: icon,
+            iconMaster: iconMaster,
             screenshots: [],
             currentVersion: currentVersion,
             versions: versions,
@@ -785,6 +911,27 @@ struct StoreImportTests {
             remixedFromVersionId: nil,
             publishedAt: publishedAt
         )
+    }
+
+    private static func transparentIconImage() throws -> CGImage {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        guard
+            let context = CGContext(
+                data: nil,
+                width: 1024,
+                height: 1024,
+                bitsPerComponent: 8,
+                bytesPerRow: 0,
+                space: colorSpace,
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            )
+        else {
+            throw ToolImageAssetEncodingError.couldNotCreateImage
+        }
+        context.clear(CGRect(x: 0, y: 0, width: 1024, height: 1024))
+        context.setFillColor(CGColor(red: 0.8, green: 0.2, blue: 0.1, alpha: 1))
+        context.fillEllipse(in: CGRect(x: 128, y: 128, width: 768, height: 768))
+        return try #require(context.makeImage())
     }
 
     private static func versionDownload(

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -327,6 +327,132 @@ struct StoreImportTests {
 
     @MainActor
     @Test
+    func searchPaginationAppendsUniqueResultsAndAdvancesCursor() async {
+        let first = Self.appSummary(id: "app-one")
+        let second = Self.appSummary(id: "app-two")
+        let recorder = StoreListRequestRecorder()
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, scope, search, cursor, sort, category in
+            await recorder.record(
+                scope: scope,
+                search: search,
+                cursor: cursor,
+                sort: sort,
+                category: category
+            )
+            if cursor == nil {
+                return StoreAppPage(apps: [first], nextCursor: "page-two")
+            }
+            return StoreAppPage(apps: [first, second], nextCursor: nil)
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+        store.searchText = "calculator"
+
+        await store.refreshDiscover()
+        await store.loadMoreSearchResults()
+
+        #expect(store.searchResults.map(\.id) == [first.id, second.id])
+        #expect(store.searchResultsNextCursor == nil)
+        let requests = await recorder.requests
+        #expect(requests.map(\.cursor) == [nil, "page-two"])
+        #expect(requests.allSatisfy { $0.scope == .discover })
+        #expect(requests.allSatisfy { $0.search == "calculator" })
+    }
+
+    @MainActor
+    @Test
+    func sectionPaginationForwardsCategorySortAndCursor() async {
+        let app = Self.appSummary(id: "section-app")
+        let recorder = StoreListRequestRecorder()
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, scope, search, cursor, sort, category in
+            await recorder.record(
+                scope: scope,
+                search: search,
+                cursor: cursor,
+                sort: sort,
+                category: category
+            )
+            return StoreAppPage(
+                apps: [app],
+                nextCursor: cursor == nil ? "next-section-page" : nil
+            )
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        let firstPage = await store.loadSectionApps(
+            sort: .trending,
+            category: .games
+        )
+        let secondPage = await store.loadSectionApps(
+            sort: .trending,
+            category: .games,
+            cursor: firstPage?.nextCursor
+        )
+
+        #expect(firstPage?.nextCursor == "next-section-page")
+        #expect(secondPage?.nextCursor == nil)
+        let requests = await recorder.requests
+        #expect(requests.map(\.cursor) == [nil, "next-section-page"])
+        #expect(requests.allSatisfy { $0.scope == .discover })
+        #expect(requests.allSatisfy { $0.search == nil })
+        #expect(requests.allSatisfy { $0.sort == .trending })
+        #expect(requests.allSatisfy { $0.category == .games })
+    }
+
+    @MainActor
+    @Test
+    func publishedPaginationAppendsUniqueResultsAndAdvancesCursor() async {
+        let first = Self.appSummary(id: "published-one")
+        let second = Self.appSummary(id: "published-two")
+        let recorder = StoreListRequestRecorder()
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, scope, search, cursor, sort, category in
+            await recorder.record(
+                scope: scope,
+                search: search,
+                cursor: cursor,
+                sort: sort,
+                category: category
+            )
+            if cursor == nil {
+                return StoreAppPage(apps: [first], nextCursor: "published-page-two")
+            }
+            return StoreAppPage(apps: [first, second], nextCursor: nil)
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        await store.refreshPublished()
+        await store.loadMorePublishedApps()
+
+        #expect(store.publishedApps.map(\.id) == [first.id, second.id])
+        #expect(store.publishedAppsNextCursor == nil)
+        let requests = await recorder.requests
+        #expect(requests.map(\.cursor) == [nil, "published-page-two"])
+        #expect(requests.allSatisfy { $0.scope == .mine })
+        #expect(requests.allSatisfy { $0.search == nil })
+    }
+
+    @MainActor
+    @Test
     func historicalVersionInstallCreatesAttributedSeparateCopyWithoutMutatingExistingTool()
         async throws
     {
@@ -583,6 +709,22 @@ struct StoreImportTests {
         """
     }
 
+    private static func appSummary(id: String) -> StoreAppSummary {
+        StoreAppSummary(
+            id: id,
+            storeId: "00000000-0000-4000-8000-000000000011",
+            authorDisplayName: "Jade",
+            name: id,
+            shortDescription: "A Store app",
+            category: .utilities,
+            status: .published,
+            latestVersionNumber: 1,
+            publishedAt: "2026-06-27T00:00:00.000Z",
+            updatedAt: "2026-06-27T00:00:00.000Z",
+            icon: nil
+        )
+    }
+
     private static func appListing(
         sourceCode: String,
         versions suppliedVersions: [StoreVersionMetadata]? = nil
@@ -679,5 +821,35 @@ struct StoreImportTests {
                 "ironsmith-store-import-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         return root
+    }
+}
+
+private actor StoreListRequestRecorder {
+    struct Request: Sendable {
+        let scope: StoreAppListScope
+        let search: String?
+        let cursor: String?
+        let sort: StoreAppListSort
+        let category: StoreAppCategory?
+    }
+
+    private(set) var requests: [Request] = []
+
+    func record(
+        scope: StoreAppListScope,
+        search: String?,
+        cursor: String?,
+        sort: StoreAppListSort,
+        category: StoreAppCategory?
+    ) {
+        requests.append(
+            Request(
+                scope: scope,
+                search: search,
+                cursor: cursor,
+                sort: sort,
+                category: category
+            )
+        )
     }
 }

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -448,23 +448,23 @@ struct StoreImportTests {
 
     @MainActor
     @Test
-    func searchPaginationAppendsUniqueResultsAndAdvancesCursor() async {
+    func searchPaginationAppendsUniqueResultsAndAdvancesOffset() async {
         let first = Self.appSummary(id: "app-one")
         let second = Self.appSummary(id: "app-two")
         let recorder = StoreListRequestRecorder()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, scope, search, cursor, sort, category in
+        client.listApps = { _, scope, search, offset, sort, category in
             await recorder.record(
                 scope: scope,
                 search: search,
-                cursor: cursor,
+                offset: offset,
                 sort: sort,
                 category: category
             )
-            if cursor == nil {
-                return StoreAppPage(apps: [first], nextCursor: "page-two")
+            if offset == 0 {
+                return StoreAppPage(apps: [first], hasMore: true)
             }
-            return StoreAppPage(apps: [first, second], nextCursor: nil)
+            return StoreAppPage(apps: [first, second], hasMore: false)
         }
         let store = StoreWindowStore(
             client: client,
@@ -479,30 +479,68 @@ struct StoreImportTests {
         await store.loadMoreSearchResults()
 
         #expect(store.searchResults.map(\.id) == [first.id, second.id])
-        #expect(store.searchResultsNextCursor == nil)
+        #expect(store.searchResultsNextOffset == 3)
+        #expect(!store.searchResultsHasMore)
         let requests = await recorder.requests
-        #expect(requests.map(\.cursor) == [nil, "page-two"])
+        #expect(requests.map(\.offset) == [0, 1])
         #expect(requests.allSatisfy { $0.scope == .discover })
         #expect(requests.allSatisfy { $0.search == "calculator" })
     }
 
     @MainActor
     @Test
-    func sectionPaginationForwardsCategorySortAndCursor() async {
+    func staleSearchPageDoesNotReplaceNewQueryResults() async {
+        let stale = Self.appSummary(id: "stale-app")
+        let current = Self.appSummary(id: "current-app")
+        let gate = StorePageGate()
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, _, search, _, _, _ in
+            if search == "first" {
+                return await gate.waitForPage()
+            }
+            return StoreAppPage(apps: [current], hasMore: false)
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        store.searchText = "first"
+        let staleRequest = Task { @MainActor in
+            await store.refreshDiscover()
+        }
+        await gate.waitUntilRequested()
+
+        store.searchText = "second"
+        await store.refreshDiscover()
+        await gate.resume(with: StoreAppPage(apps: [stale], hasMore: true))
+        await staleRequest.value
+
+        #expect(store.searchResults.map(\.id) == [current.id])
+        #expect(store.searchResultsNextOffset == 1)
+        #expect(!store.searchResultsHasMore)
+    }
+
+    @MainActor
+    @Test
+    func sectionPaginationForwardsCategorySortAndOffset() async {
         let app = Self.appSummary(id: "section-app")
         let recorder = StoreListRequestRecorder()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, scope, search, cursor, sort, category in
+        client.listApps = { _, scope, search, offset, sort, category in
             await recorder.record(
                 scope: scope,
                 search: search,
-                cursor: cursor,
+                offset: offset,
                 sort: sort,
                 category: category
             )
             return StoreAppPage(
                 apps: [app],
-                nextCursor: cursor == nil ? "next-section-page" : nil
+                hasMore: offset == 0
             )
         }
         let store = StoreWindowStore(
@@ -520,13 +558,13 @@ struct StoreImportTests {
         let secondPage = await store.loadSectionApps(
             sort: .trending,
             category: .games,
-            cursor: firstPage?.nextCursor
+            offset: firstPage?.apps.count ?? 0
         )
 
-        #expect(firstPage?.nextCursor == "next-section-page")
-        #expect(secondPage?.nextCursor == nil)
+        #expect(firstPage?.hasMore == true)
+        #expect(secondPage?.hasMore == false)
         let requests = await recorder.requests
-        #expect(requests.map(\.cursor) == [nil, "next-section-page"])
+        #expect(requests.map(\.offset) == [0, 1])
         #expect(requests.allSatisfy { $0.scope == .discover })
         #expect(requests.allSatisfy { $0.search == nil })
         #expect(requests.allSatisfy { $0.sort == .trending })
@@ -535,23 +573,23 @@ struct StoreImportTests {
 
     @MainActor
     @Test
-    func publishedPaginationAppendsUniqueResultsAndAdvancesCursor() async {
+    func publishedPaginationAppendsUniqueResultsAndAdvancesOffset() async {
         let first = Self.appSummary(id: "published-one")
         let second = Self.appSummary(id: "published-two")
         let recorder = StoreListRequestRecorder()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, scope, search, cursor, sort, category in
+        client.listApps = { _, scope, search, offset, sort, category in
             await recorder.record(
                 scope: scope,
                 search: search,
-                cursor: cursor,
+                offset: offset,
                 sort: sort,
                 category: category
             )
-            if cursor == nil {
-                return StoreAppPage(apps: [first], nextCursor: "published-page-two")
+            if offset == 0 {
+                return StoreAppPage(apps: [first], hasMore: true)
             }
-            return StoreAppPage(apps: [first, second], nextCursor: nil)
+            return StoreAppPage(apps: [first, second], hasMore: false)
         }
         let store = StoreWindowStore(
             client: client,
@@ -565,9 +603,10 @@ struct StoreImportTests {
         await store.loadMorePublishedApps()
 
         #expect(store.publishedApps.map(\.id) == [first.id, second.id])
-        #expect(store.publishedAppsNextCursor == nil)
+        #expect(store.publishedAppsNextOffset == 3)
+        #expect(!store.publishedAppsHasMore)
         let requests = await recorder.requests
-        #expect(requests.map(\.cursor) == [nil, "published-page-two"])
+        #expect(requests.map(\.offset) == [0, 1])
         #expect(requests.allSatisfy { $0.scope == .mine })
         #expect(requests.allSatisfy { $0.search == nil })
     }
@@ -975,7 +1014,7 @@ private actor StoreListRequestRecorder {
     struct Request: Sendable {
         let scope: StoreAppListScope
         let search: String?
-        let cursor: String?
+        let offset: Int
         let sort: StoreAppListSort
         let category: StoreAppCategory?
     }
@@ -985,7 +1024,7 @@ private actor StoreListRequestRecorder {
     func record(
         scope: StoreAppListScope,
         search: String?,
-        cursor: String?,
+        offset: Int,
         sort: StoreAppListSort,
         category: StoreAppCategory?
     ) {
@@ -993,10 +1032,35 @@ private actor StoreListRequestRecorder {
             Request(
                 scope: scope,
                 search: search,
-                cursor: cursor,
+                offset: offset,
                 sort: sort,
                 category: category
             )
         )
+    }
+}
+
+private actor StorePageGate {
+    private var pageContinuation: CheckedContinuation<StoreAppPage, Never>?
+    private var requestContinuation: CheckedContinuation<Void, Never>?
+
+    func waitForPage() async -> StoreAppPage {
+        await withCheckedContinuation { continuation in
+            pageContinuation = continuation
+            requestContinuation?.resume()
+            requestContinuation = nil
+        }
+    }
+
+    func waitUntilRequested() async {
+        guard pageContinuation == nil else { return }
+        await withCheckedContinuation { continuation in
+            requestContinuation = continuation
+        }
+    }
+
+    func resume(with page: StoreAppPage) {
+        pageContinuation?.resume(returning: page)
+        pageContinuation = nil
     }
 }

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import Ironsmith
+
+extension ToolLibraryTests {
+    @MainActor
+    @Test
+    func storePublisherLeavesNewListingCopyEmpty() async {
+        let inferenceStore = InferenceStore(
+            dependencies: Self.inferenceDependencies(
+                accountClient: Self.ironsmithAccountClient(balanceCredits: 100)
+            )
+        )
+        inferenceStore.ironsmithSession = Self.ironsmithSession()
+        let publisher = ToolLibraryStorePublisher(
+            storeClient: .unconfigured,
+            iconClient: .live()
+        )
+        let tool = Tool(
+            name: "Clipboard Cleaner",
+            packageRootPath: "/tmp/ClipboardCleaner"
+        )
+
+        await publisher.beginPublishing(
+            tool,
+            inferenceStore: inferenceStore,
+            tools: [tool]
+        )
+
+        #expect(publisher.publishName == tool.name)
+        #expect(publisher.publishShortDescription.isEmpty)
+        #expect(publisher.publishDescription.isEmpty)
+        #expect(publisher.isShowingPublishSheet)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Issues and pull requests are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.
 Ironsmith is licensed under the [GNU General Public License v3.0](LICENSE).
 
 ## OpenAI Build Week instructions
+Due to this being a continuiously worked on project, I can't keep this repo frozen for the contest. Use https://github.com/Jeidoban/Ironsmith/compare/645e3d2cd21fd620737d9e9cfc529534ea3292c4...e824efac03ac786e16cb45d75e46f8866981521c to see what was worked on during the contest. Download this release to test:
+https://github.com/Jeidoban/Ironsmith/releases/tag/v0.4.1
 
 To use, make sure you are on macOS 26, preferably an Apple silicon Mac. The Xcode command line tools are needed, but Ironsmith will walk you through installing those.
 After that, I recommend logging in with your ChatGPT account, but you can also use an API key or use Claude, Gemini, or any OpenAI compatible API you want. 


### PR DESCRIPTION
## Summary

- Changes store assets to jpegs and create a 1024x1024 master icon image
- Updates the store app list, adds sidebar, and improves detail view.
- Changes cursor pagination to offset and limit for store app list.
- Add tool publishing and store browsing/import flows
- Support generated tool icons and image asset encoding
- Improve tool library, agent output, and store UI interactions
- Add debug icon export support
- Expand coverage for store imports, publishing, image encoding, and pipeline behavior
- Update README documentation

## Testing

- Added focused unit tests across agent pipeline, store, settings debug, and tool library features