### PR TITLE
Add Ironsmith account handles across settings and store flows

### DIFF
--- a/Ironsmith/Core/Inference/InferenceStore/IronsmithAccount.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/IronsmithAccount.swift
@@ -34,6 +34,14 @@ extension InferenceStore {
         return profile
     }
 
+    func checkIronsmithHandleAvailability(_ handle: String) async throws -> IronsmithHandleAvailability {
+        refreshIronsmithSession()
+        guard ironsmithSession != nil else {
+            throw IronsmithAccountClientError.missingSession
+        }
+        return try await dependencies.accountClient.checkHandleAvailability(handle)
+    }
+
     func refreshIronsmithCreditPacks() async {
         refreshIronsmithSession()
         guard ironsmithSession != nil else {
@@ -90,6 +98,16 @@ extension InferenceStore {
     }
 
     func signOutIronsmithProvider(_ provider: ProviderConfig) async -> Bool {
+        await signOutIronsmithAccount(provider: provider)
+    }
+
+    func signOutIronsmithAccount() async -> Bool {
+        await signOutIronsmithAccount(
+            provider: providers.first(where: { $0.kind == .ironsmith })
+        )
+    }
+
+    private func signOutIronsmithAccount(provider: ProviderConfig?) async -> Bool {
         do {
             try await dependencies.accountClient.signOut()
             ironsmithSession = nil
@@ -97,7 +115,9 @@ extension InferenceStore {
             ironsmithAccountSummary = nil
             ironsmithCreditPacks = []
             pendingIronsmithAccountRefreshAfterCheckout = false
-            await removeProvider(provider)
+            if let provider {
+                await removeProvider(provider)
+            }
             return true
         } catch {
             presentError(error)
@@ -106,6 +126,16 @@ extension InferenceStore {
     }
 
     func deleteIronsmithAccount(provider: ProviderConfig) async -> Bool {
+        await deleteIronsmithAccount(provider: Optional(provider))
+    }
+
+    func deleteIronsmithAccount() async -> Bool {
+        await deleteIronsmithAccount(
+            provider: providers.first(where: { $0.kind == .ironsmith })
+        )
+    }
+
+    private func deleteIronsmithAccount(provider: ProviderConfig?) async -> Bool {
         do {
             try await dependencies.accountClient.deleteAccount()
             try? await dependencies.accountClient.signOut()
@@ -114,7 +144,9 @@ extension InferenceStore {
             ironsmithAccountSummary = nil
             ironsmithCreditPacks = []
             pendingIronsmithAccountRefreshAfterCheckout = false
-            await removeProvider(provider)
+            if let provider {
+                await removeProvider(provider)
+            }
             return true
         } catch {
             presentError(error)

--- a/Ironsmith/Core/Inference/InferenceStore/IronsmithAccount.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/IronsmithAccount.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Supabase
 
 extension InferenceStore {
     func refreshIronsmithSession() {
@@ -83,11 +84,8 @@ extension InferenceStore {
         launchFlow: @escaping IronsmithOAuthLaunchFlow
     ) async -> Bool {
         do {
-            ironsmithSession = try await dependencies.accountClient.signInWithAppleOAuth(launchFlow)
-            reconcileImageGenerationProvider()
-            let didEnsureProvider = await ensureIronsmithProviderExists()
-            await refreshIronsmithAccountSummary()
-            return didEnsureProvider
+            let session = try await dependencies.accountClient.signInWithAppleOAuth(launchFlow)
+            return await finishIronsmithAuthentication(session)
         } catch {
             guard !IronsmithErrorPresentation.isCancellation(error) else {
                 return false
@@ -95,6 +93,50 @@ extension InferenceStore {
             presentError(error)
             return false
         }
+    }
+
+    func signInToIronsmithWithEmailPassword(email: String, password: String) async -> Bool {
+        do {
+            let session = try await dependencies.accountClient.signInWithEmailPassword(
+                email,
+                password
+            )
+            return await finishIronsmithAuthentication(session)
+        } catch {
+            presentError(error)
+            return false
+        }
+    }
+
+    func createIronsmithAccountWithEmailPassword(email: String, password: String) async -> Bool {
+        do {
+            let session = try await dependencies.accountClient.signUpWithEmailPassword(
+                email,
+                password
+            )
+            return await finishIronsmithAuthentication(session)
+        } catch {
+            presentError(error)
+            return false
+        }
+    }
+
+    private func finishIronsmithAuthentication(_ session: Session) async -> Bool {
+        ironsmithSession = session
+        reconcileImageGenerationProvider()
+
+        guard await ensureIronsmithProviderExists() else {
+            try? await dependencies.accountClient.signOut()
+            ironsmithSession = nil
+            ironsmithAccountSummary = nil
+            ironsmithCreditPacks = []
+            pendingIronsmithAccountRefreshAfterCheckout = false
+            reconcileImageGenerationProvider()
+            return false
+        }
+
+        await refreshIronsmithAccountSummary()
+        return true
     }
 
     func signOutIronsmithProvider(_ provider: ProviderConfig) async -> Bool {

--- a/Ironsmith/Core/Inference/InferenceStore/Providers.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/Providers.swift
@@ -62,7 +62,11 @@ extension InferenceStore {
             try refreshData()
 
             if provider.kind == .ironsmith {
-                await refreshDiscoveredModels(for: provider)
+                let didDiscoverModels = await refreshDiscoveredModels(for: provider)
+                guard didDiscoverModels else {
+                    await removeProvider(provider)
+                    return false
+                }
                 if selectedModelID == nil {
                     selectModel(
                         remoteModels.first(where: { $0.providerIdentifier == provider.identifier })?

--- a/Ironsmith/Core/Inference/IronsmithAccount/IronsmithAccountClient.swift
+++ b/Ironsmith/Core/Inference/IronsmithAccount/IronsmithAccountClient.swift
@@ -165,6 +165,7 @@ nonisolated enum IronsmithAPIRequestMethod: String, Sendable {
 nonisolated enum IronsmithAccountClientError: LocalizedError, Equatable {
     case notConfigured
     case missingSession
+    case emailConfirmationRequired
     case invalidResponse
     case requestFailed(statusCode: Int, message: String)
     case refundRequired(balanceCredits: Int)
@@ -182,6 +183,9 @@ nonisolated enum IronsmithAccountClientError: LocalizedError, Equatable {
                 "Ironsmith service is not configured. Missing configuration keys: \(Self.requiredConfigurationKeyNames.joined(separator: ", "))."
         case .missingSession:
             return "Sign in with Ironsmith before using Ironsmith credits."
+        case .emailConfirmationRequired:
+            return
+                "Account created, but Supabase requires email confirmation. Disable Confirm email in the Supabase Auth settings for debug sign-in."
         case .invalidResponse:
             return "The Ironsmith service returned an invalid response."
         case .requestFailed(let statusCode, let message):
@@ -202,6 +206,10 @@ nonisolated struct IronsmithAccountClient {
     var generationAccessToken: @Sendable () async throws -> String
     var signInWithAppleOAuth:
         @Sendable (_ launchFlow: @escaping IronsmithOAuthLaunchFlow) async throws -> Session
+    var signInWithEmailPassword:
+        @Sendable (_ email: String, _ password: String) async throws -> Session
+    var signUpWithEmailPassword:
+        @Sendable (_ email: String, _ password: String) async throws -> Session
     var signOut: @Sendable () async throws -> Void
     var fetchAccountSummary: @Sendable () async throws -> IronsmithAccountSummary
     var updateProfile: @Sendable (_ update: IronsmithAccountProfileUpdate) async throws -> IronsmithAccountProfile
@@ -250,6 +258,16 @@ extension IronsmithAccountClient {
                     scopes: "email",
                     launchFlow: launchFlow,
                 )
+            },
+            signInWithEmailPassword: { email, password in
+                try await supabase.auth.signIn(email: email, password: password)
+            },
+            signUpWithEmailPassword: { email, password in
+                let response = try await supabase.auth.signUp(email: email, password: password)
+                guard let session = response.session else {
+                    throw IronsmithAccountClientError.emailConfirmationRequired
+                }
+                return session
             },
             signOut: {
                 try await supabase.auth.signOut()
@@ -325,6 +343,8 @@ extension IronsmithAccountClient {
             validAccessToken: { throw IronsmithAccountClientError.notConfigured },
             generationAccessToken: { throw IronsmithAccountClientError.notConfigured },
             signInWithAppleOAuth: { _ in throw IronsmithAccountClientError.notConfigured },
+            signInWithEmailPassword: { _, _ in throw IronsmithAccountClientError.notConfigured },
+            signUpWithEmailPassword: { _, _ in throw IronsmithAccountClientError.notConfigured },
             signOut: {},
             fetchAccountSummary: { throw IronsmithAccountClientError.notConfigured },
             updateProfile: { _ in throw IronsmithAccountClientError.notConfigured },

--- a/Ironsmith/Core/Inference/IronsmithAccount/IronsmithAccountClient.swift
+++ b/Ironsmith/Core/Inference/IronsmithAccount/IronsmithAccountClient.swift
@@ -88,13 +88,34 @@ nonisolated struct IronsmithAccountProfile: Decodable, Equatable, Sendable {
     let id: String
     let email: String?
     let displayName: String?
+    let handle: String?
 }
 
 nonisolated struct IronsmithAccountProfileUpdate: Encodable, Equatable, Sendable {
     var displayName: String?
+    var handle: String?
 
-    init(displayName: String? = nil) {
+    init(displayName: String? = nil, handle: String? = nil) {
         self.displayName = displayName
+        self.handle = handle
+    }
+}
+
+nonisolated struct IronsmithHandleAvailability: Decodable, Equatable, Sendable {
+    let handle: String
+    let available: Bool
+}
+
+nonisolated enum IronsmithCreatorHandle {
+    static func normalized(_ value: String) -> String {
+        value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    static func isValid(_ value: String) -> Bool {
+        normalized(value).range(
+            of: "^[a-z0-9][a-z0-9_]{1,28}[a-z0-9]$",
+            options: .regularExpression
+        ) != nil
     }
 }
 
@@ -184,6 +205,7 @@ nonisolated struct IronsmithAccountClient {
     var signOut: @Sendable () async throws -> Void
     var fetchAccountSummary: @Sendable () async throws -> IronsmithAccountSummary
     var updateProfile: @Sendable (_ update: IronsmithAccountProfileUpdate) async throws -> IronsmithAccountProfile
+    var checkHandleAvailability: @Sendable (_ handle: String) async throws -> IronsmithHandleAvailability
     var fetchCreditPacks: @Sendable () async throws -> [IronsmithCreditPack]
     var createCheckoutSession:
         @Sendable (_ creditPackID: String) async throws -> IronsmithCheckoutSession
@@ -250,6 +272,15 @@ extension IronsmithAccountClient {
                 )
                 return response.profile
             },
+            checkHandleAvailability: { handle in
+                let encoded = handle.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? handle
+                return try await Self.invokeAPI(
+                    configuration,
+                    accessTokenProvider: validAccessToken,
+                    path: "api/v1/account/handle-availability?handle=\(encoded)",
+                    method: .get
+                )
+            },
             fetchCreditPacks: {
                 let response: IronsmithCreditPacksResponse = try await Self.invokeAPI(
                     configuration,
@@ -297,6 +328,7 @@ extension IronsmithAccountClient {
             signOut: {},
             fetchAccountSummary: { throw IronsmithAccountClientError.notConfigured },
             updateProfile: { _ in throw IronsmithAccountClientError.notConfigured },
+            checkHandleAvailability: { _ in throw IronsmithAccountClientError.notConfigured },
             fetchCreditPacks: { throw IronsmithAccountClientError.notConfigured },
             createCheckoutSession: { _ in throw IronsmithAccountClientError.notConfigured },
             deleteAccount: { throw IronsmithAccountClientError.notConfigured },
@@ -311,9 +343,14 @@ extension IronsmithAccountClient {
         accessToken: String,
         body: Data? = nil
     ) -> URLRequest {
+        let pathAndQuery = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
         var url = baseURL
-        for component in path.split(separator: "/") {
+        for component in pathAndQuery[0].split(separator: "/") {
             url.appendPathComponent(String(component))
+        }
+        if pathAndQuery.count == 2, var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            components.percentEncodedQuery = String(pathAndQuery[1])
+            url = components.url ?? url
         }
 
         var request = URLRequest(url: url)

--- a/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
@@ -6,9 +6,13 @@ struct SettingsAccountSectionView: View {
     @Environment(\.webAuthenticationSession) private var webAuthenticationSession
     let onManageAccount: () -> Void
     @State private var isSigningIn = false
+    #if DEBUG
+    @State private var email = ""
+    @State private var password = ""
+    #endif
 
     var body: some View {
-        Section("Account") {
+        Section("Ironsmith Account") {
             if inferenceStore.ironsmithSession == nil {
                 LabeledContent("Ironsmith Account") {
                     Button(isSigningIn ? "Signing In…" : "Sign In") {
@@ -16,6 +20,27 @@ struct SettingsAccountSectionView: View {
                     }
                     .disabled(isSigningIn)
                 }
+                #if DEBUG
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Debug email/password sign-in")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Email", text: $email)
+                        .textFieldStyle(.roundedBorder)
+                    SecureField("Password", text: $password)
+                        .textFieldStyle(.roundedBorder)
+                    HStack {
+                        Button("Create Account") {
+                            authenticateWithEmailPassword(createAccount: true)
+                        }
+                        Button("Sign In") {
+                            authenticateWithEmailPassword(createAccount: false)
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .disabled(isEmailPasswordAuthenticationDisabled)
+                }
+                #endif
                 Text("Sign in to publish apps, manage your creator identity, and use Ironsmith credits.")
                     .foregroundStyle(.secondary)
             } else {
@@ -66,4 +91,36 @@ struct SettingsAccountSectionView: View {
             isSigningIn = false
         }
     }
+
+    #if DEBUG
+    private var isEmailPasswordAuthenticationDisabled: Bool {
+        isSigningIn
+            || email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || password.isEmpty
+    }
+
+    private func authenticateWithEmailPassword(createAccount: Bool) {
+        guard !isEmailPasswordAuthenticationDisabled else { return }
+        isSigningIn = true
+        let email = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let password = password
+        Task {
+            defer {
+                isSigningIn = false
+                self.password = ""
+            }
+            if createAccount {
+                _ = await inferenceStore.createIronsmithAccountWithEmailPassword(
+                    email: email,
+                    password: password
+                )
+            } else {
+                _ = await inferenceStore.signInToIronsmithWithEmailPassword(
+                    email: email,
+                    password: password
+                )
+            }
+        }
+    }
+    #endif
 }

--- a/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
@@ -22,6 +22,10 @@ struct SettingsAccountSectionView: View {
                 if let email = inferenceStore.ironsmithAccountSummary?.user.email {
                     LabeledContent("Email", value: email)
                 }
+                LabeledContent("Display Name") {
+                    Text(displayName ?? "Not set")
+                        .foregroundStyle(displayName == nil ? .secondary : .primary)
+                }
                 LabeledContent("Creator Handle") {
                     Text(handleText)
                         .foregroundStyle(handle == nil ? .secondary : .primary)
@@ -33,6 +37,16 @@ struct SettingsAccountSectionView: View {
 
     private var handle: String? {
         inferenceStore.ironsmithAccountSummary?.profile?.handle
+    }
+
+    private var displayName: String? {
+        guard let displayName = inferenceStore.ironsmithAccountSummary?.profile?.displayName?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !displayName.isEmpty
+        else {
+            return nil
+        }
+        return displayName
     }
 
     private var handleText: String {

--- a/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
@@ -1,0 +1,55 @@
+import AuthenticationServices
+import SwiftUI
+
+struct SettingsAccountSectionView: View {
+    @Environment(InferenceStore.self) private var inferenceStore
+    @Environment(\.webAuthenticationSession) private var webAuthenticationSession
+    let onManageAccount: () -> Void
+    @State private var isSigningIn = false
+
+    var body: some View {
+        Section("Account") {
+            if inferenceStore.ironsmithSession == nil {
+                LabeledContent("Ironsmith Account") {
+                    Button(isSigningIn ? "Signing In…" : "Sign In") {
+                        signIn()
+                    }
+                    .disabled(isSigningIn)
+                }
+                Text("Sign in to publish apps, manage your creator identity, and use Ironsmith credits.")
+                    .foregroundStyle(.secondary)
+            } else {
+                if let email = inferenceStore.ironsmithAccountSummary?.user.email {
+                    LabeledContent("Email", value: email)
+                }
+                LabeledContent("Creator Handle") {
+                    Text(handleText)
+                        .foregroundStyle(handle == nil ? .secondary : .primary)
+                }
+                Button("Manage Account…", action: onManageAccount)
+            }
+        }
+    }
+
+    private var handle: String? {
+        inferenceStore.ironsmithAccountSummary?.profile?.handle
+    }
+
+    private var handleText: String {
+        handle.map { "@\($0)" } ?? "Not set"
+    }
+
+    private func signIn() {
+        guard !isSigningIn else { return }
+        isSigningIn = true
+        Task {
+            _ = await inferenceStore.signInToIronsmithWithAppleOAuth { @MainActor url in
+                try await webAuthenticationSession.authenticate(
+                    using: url,
+                    callbackURLScheme: IronsmithOAuthRedirect.appCallbackScheme
+                )
+            }
+            isSigningIn = false
+        }
+    }
+}

--- a/Ironsmith/Features/Settings/SettingsWindowView.swift
+++ b/Ironsmith/Features/Settings/SettingsWindowView.swift
@@ -17,6 +17,9 @@ struct SettingsWindowView: View {
 
     var body: some View {
         Form {
+            SettingsAccountSectionView(
+                onManageAccount: { presentedSheet = .manageAccount }
+            )
             SettingsProvidersSectionView(
                 onAddProvider: { presentedSheet = .addProvider(initialKind: nil) },
                 onEditProvider: { presentedSheet = .editProvider($0, showsCreditPacks: false) }
@@ -31,6 +34,7 @@ struct SettingsWindowView: View {
         .frame(minWidth: 680, minHeight: 720)
         .task {
             await inferenceStore.prepareSettings(modelContext: modelContext)
+            await inferenceStore.refreshIronsmithAccountSummary()
             hasPreparedSettings = true
             consumePendingSettingsRoute()
         }
@@ -52,6 +56,14 @@ struct SettingsWindowView: View {
                 ProviderEditorSheetView(
                     provider: provider,
                     showsCreditPacksOnAppear: showsCreditPacks
+                )
+            case .manageAccount:
+                ManageIronsmithAccountSheetView(
+                    onBuyCredits: {
+                        presentedSheet = inferenceStore.providers
+                            .first { $0.kind == .ironsmith }
+                            .map { .editProvider($0, showsCreditPacks: true) }
+                    }
                 )
             }
         }
@@ -128,6 +140,7 @@ struct SettingsWindowView: View {
 private enum SettingsPresentedSheet: Identifiable {
     case addProvider(initialKind: ProviderKind?)
     case editProvider(ProviderConfig, showsCreditPacks: Bool)
+    case manageAccount
 
     var id: String {
         switch self {
@@ -135,6 +148,8 @@ private enum SettingsPresentedSheet: Identifiable {
             "addProvider.\(initialKind?.rawValue ?? "default")"
         case .editProvider(let provider, let showsCreditPacks):
             "editProvider.\(provider.id.uuidString).credits.\(showsCreditPacks)"
+        case .manageAccount:
+            "manageAccount"
         }
     }
 }

--- a/Ironsmith/Features/Settings/SettingsWindowView.swift
+++ b/Ironsmith/Features/Settings/SettingsWindowView.swift
@@ -17,12 +17,12 @@ struct SettingsWindowView: View {
 
     var body: some View {
         Form {
-            SettingsAccountSectionView(
-                onManageAccount: { presentedSheet = .manageAccount }
-            )
             SettingsProvidersSectionView(
                 onAddProvider: { presentedSheet = .addProvider(initialKind: nil) },
                 onEditProvider: { presentedSheet = .editProvider($0, showsCreditPacks: false) }
+            )
+            SettingsAccountSectionView(
+                onManageAccount: { presentedSheet = .manageAccount }
             )
             SettingsPreferencesSectionView()
             #if DEBUG

--- a/Ironsmith/Features/Settings/Sheets/ManageIronsmithAccountSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/ManageIronsmithAccountSheetView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+
+struct ManageIronsmithAccountSheetView: View {
+    @Environment(InferenceStore.self) private var inferenceStore
+    @Environment(\.dismiss) private var dismiss
+    let onBuyCredits: () -> Void
+
+    @State private var displayName = ""
+    @State private var handle = ""
+    @State private var isSaving = false
+    @State private var isSigningOut = false
+    @State private var isDeleting = false
+    @State private var isConfirmingDeletion = false
+    @State private var isConfirmingDeletionWithCredits = false
+    @State private var isConfirmingHandleClaim = false
+    @State private var handleAvailability: Bool?
+    @State private var handleAvailabilityCheckFailed = false
+    @State private var showsHandleRequirements = false
+
+    var body: some View {
+        Form {
+            Section("Creator Profile") {
+                TextField("Display Name", text: $displayName)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 12) {
+                        Text("Handle")
+                        Spacer(minLength: 12)
+                        if existingHandle != nil {
+                            Text("@\(normalizedHandle)")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            TextField(
+                                "",
+                                text: handleText,
+                                prompt: Text("@your_handle")
+                            )
+                            .labelsHidden()
+                            .multilineTextAlignment(.trailing)
+                            .frame(width: 220)
+                        }
+                    }
+                    if let handleSupportingText {
+                        Text(handleSupportingText)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+            }
+
+            Section("Account") {
+                LabeledContent("Email", value: accountEmail)
+                LabeledContent("Available Credits", value: creditsText)
+                Button("Buy Credits…", action: onBuyCredits)
+            }
+
+        }
+        .formStyle(.grouped)
+        .padding(20)
+        .safeAreaInset(edge: .bottom) {
+            HStack {
+                Button(isSigningOut ? "Signing Out…" : "Sign Out") {
+                    signOut()
+                }
+                .disabled(isSigningOut || isDeleting)
+
+                Button("Delete Account", role: .destructive) {
+                    isConfirmingDeletion = true
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.red)
+                .disabled(isSigningOut || isDeleting)
+
+                Spacer()
+                Button("Cancel") { dismiss() }
+                Button(isSaving ? "Saving…" : "Save") { save() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!canSave || isSaving)
+            }
+            .padding(20)
+            .background(.bar)
+        }
+        .frame(width: 540, height: 500)
+        .task {
+            await loadThenRefreshProfile()
+        }
+        .task(id: normalizedHandle) {
+            await refreshHandleAvailability()
+        }
+        .task(id: handle) {
+            await refreshHandleRequirementsVisibility()
+        }
+        .confirmationDialog("Delete Ironsmith Account?", isPresented: $isConfirmingDeletion) {
+            Button("Delete Account", role: .destructive) {
+                if (remainingCreditBalance ?? 0) > 0 {
+                    isConfirmingDeletionWithCredits = true
+                } else {
+                    deleteAccount()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "This permanently deletes your Ironsmith account, removes its provider, and forfeits any remaining credits."
+            )
+        }
+        .confirmationDialog(
+            "Delete Account With Credits?",
+            isPresented: $isConfirmingDeletionWithCredits
+        ) {
+            Button("Delete Anyway", role: .destructive) { deleteAccount() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "You still have \(creditsText). Deleting your account removes access to these credits. If you purchased credits less than 30 days ago, you can get a refund by contacting support@ironsmith.app."
+            )
+        }
+        .alert("Set Creator Handle?", isPresented: $isConfirmingHandleClaim) {
+            Button("Cancel", role: .cancel) {}
+            Button("Set Handle") { saveProfile() }
+        } message: {
+            Text("@\(normalizedHandle) cannot be changed after it is claimed.")
+        }
+    }
+
+    private var profile: IronsmithAccountProfile? {
+        inferenceStore.ironsmithAccountSummary?.profile
+    }
+
+    private var existingHandle: String? { profile?.handle }
+    private var normalizedHandle: String {
+        IronsmithCreatorHandle.normalized(handle)
+    }
+    private var normalizedDisplayName: String {
+        displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+    private var handleIsValid: Bool {
+        normalizedHandle.isEmpty || IronsmithCreatorHandle.isValid(normalizedHandle)
+    }
+    private var canSave: Bool {
+        (1...80).contains(normalizedDisplayName.count)
+            && (existingHandle != nil
+                || handleIsValid
+                    && !normalizedHandle.isEmpty
+                    && (handleAvailability == true || handleAvailabilityCheckFailed))
+    }
+    private var accountEmail: String {
+        inferenceStore.ironsmithAccountSummary?.user.email ?? "Hidden"
+    }
+    private var creditsText: String {
+        guard let credits = remainingCreditBalance else {
+            return "Unknown"
+        }
+        return credits == 1 ? "1 credit" : "\(credits) credits"
+    }
+    private var remainingCreditBalance: Int? {
+        inferenceStore.ironsmithAccountSummary?.credits.balanceCredits
+    }
+    private var handleStatusText: String {
+        guard handleIsValid else {
+            return
+                "Use 3–30 letters, numbers, or underscores; begin and end with a letter or number."
+        }
+        if handleAvailabilityCheckFailed {
+            return "Couldn’t check availability. Ironsmith will verify this handle when you save."
+        }
+        switch handleAvailability {
+        case true: return "This handle is available."
+        case false: return "This handle is unavailable."
+        case nil: return "Checking availability…"
+        }
+    }
+    private var handleSupportingText: String? {
+        guard existingHandle == nil else { return nil }
+        guard !normalizedHandle.isEmpty else { return nil }
+        if handleIsValid {
+            return handleStatusText
+        }
+        return showsHandleRequirements
+            ? "Use 3–30 letters, numbers, or underscores; begin and end with a letter or number."
+            : nil
+    }
+    private var handleText: Binding<String> {
+        Binding(
+            get: { handle.isEmpty ? "" : "@\(handle)" },
+            set: { value in
+                handle = value.hasPrefix("@") ? String(value.dropFirst()) : value
+            }
+        )
+    }
+
+    private func loadProfile() {
+        displayName = profile?.displayName ?? ""
+        handle = profile?.handle ?? ""
+    }
+
+    private func loadThenRefreshProfile() async {
+        loadProfile()
+        let initialDisplayName = displayName
+        let initialHandle = handle
+        await inferenceStore.refreshIronsmithAccountSummary()
+        if displayName == initialDisplayName {
+            displayName = profile?.displayName ?? ""
+        }
+        if handle == initialHandle {
+            handle = profile?.handle ?? ""
+        }
+    }
+
+    private func refreshHandleAvailability() async {
+        guard existingHandle == nil, !normalizedHandle.isEmpty, handleIsValid else {
+            handleAvailability = existingHandle == nil && normalizedHandle.isEmpty ? true : nil
+            handleAvailabilityCheckFailed = false
+            return
+        }
+        let requestedHandle = normalizedHandle
+        handleAvailability = nil
+        handleAvailabilityCheckFailed = false
+        try? await Task.sleep(for: .milliseconds(350))
+        guard !Task.isCancelled else { return }
+        do {
+            let availability = try await inferenceStore
+                .checkIronsmithHandleAvailability(requestedHandle)
+            guard !Task.isCancelled, normalizedHandle == requestedHandle else { return }
+            handleAvailability = availability.available
+        } catch {
+            guard !Task.isCancelled, normalizedHandle == requestedHandle else { return }
+            handleAvailability = nil
+            handleAvailabilityCheckFailed = true
+        }
+    }
+
+    private func refreshHandleRequirementsVisibility() async {
+        showsHandleRequirements = false
+        guard existingHandle == nil, !normalizedHandle.isEmpty, !handleIsValid else {
+            return
+        }
+        try? await Task.sleep(for: .seconds(1))
+        guard !Task.isCancelled else { return }
+        showsHandleRequirements = true
+    }
+
+    private func save() {
+        guard canSave else { return }
+        if existingHandle == nil {
+            isConfirmingHandleClaim = true
+            return
+        }
+        saveProfile()
+    }
+
+    private func saveProfile() {
+        isSaving = true
+        Task {
+            do {
+                _ = try await inferenceStore.updateIronsmithAccountProfile(
+                    IronsmithAccountProfileUpdate(
+                        displayName: normalizedDisplayName,
+                        handle: existingHandle == nil && !normalizedHandle.isEmpty
+                            ? normalizedHandle
+                            : nil
+                    )
+                )
+                dismiss()
+            } catch {
+                inferenceStore.presentError(error)
+            }
+            isSaving = false
+        }
+    }
+
+    private func signOut() {
+        isSigningOut = true
+        Task {
+            if await inferenceStore.signOutIronsmithAccount() { dismiss() }
+            isSigningOut = false
+        }
+    }
+
+    private func deleteAccount() {
+        isDeleting = true
+        Task {
+            if await inferenceStore.deleteIronsmithAccount() { dismiss() }
+            isDeleting = false
+        }
+    }
+}

--- a/Ironsmith/Features/Settings/Sheets/ManageIronsmithAccountSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/ManageIronsmithAccountSheetView.swift
@@ -20,7 +20,11 @@ struct ManageIronsmithAccountSheetView: View {
     var body: some View {
         Form {
             Section("Creator Profile") {
-                TextField("Display Name", text: $displayName)
+                TextField(
+                    "Display Name",
+                    text: $displayName,
+                    prompt: Text("Your public creator name")
+                )
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 12) {
                         Text("Handle")

--- a/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
@@ -12,13 +12,10 @@ struct ProviderEditorSheetView: View {
     @State private var baseURLString = ""
     @State private var openAICompatibleAPIVariant: OpenAICompatibleAPIVariant = .chatCompletions
     @State private var isConfirmingDelete = false
-    @State private var isConfirmingAccountDeletion = false
-    @State private var isConfirmingAccountDeletionWithCredits = false
     @State private var isShowingCreditPacks = false
     @State private var isSigningOut = false
     @State private var isSigningInToChatGPT = false
     @State private var isSigningOutOfChatGPT = false
-    @State private var isDeletingAccount = false
 
     private var isCustomOpenAICompatible: Bool {
         provider.kind == .customOpenAICompatible
@@ -61,12 +58,6 @@ struct ProviderEditorSheetView: View {
                         Text("AI Models")
                     }
                 } else if isIronsmith {
-                    Section {
-                        ironsmithAccountRows
-                    } header: {
-                        Text("Account")
-                    }
-
                     Section {
                         LabeledContent("Available Credits") {
                             Text(ironsmithBalanceText)
@@ -129,18 +120,11 @@ struct ProviderEditorSheetView: View {
         .safeAreaInset(edge: .bottom) {
             HStack {
                 if isIronsmith {
-                    Button("Delete Account", role: .destructive) {
-                        isConfirmingAccountDeletion = true
-                    }
-                    .buttonStyle(.bordered)
-                    .tint(.red)
-                    .disabled(isDeletingAccount || isSigningOut)
-
                     Button(isSigningOut ? "Signing Out..." : "Sign Out") {
                         signOut()
                     }
                     .buttonStyle(.bordered)
-                    .disabled(isSigningOut || isDeletingAccount)
+                    .disabled(isSigningOut)
                 } else if provider.isRemovable {
                     Button("Delete Provider", role: .destructive) {
                         isConfirmingDelete = true
@@ -230,34 +214,6 @@ struct ProviderEditorSheetView: View {
         } message: {
             Text("This removes \(provider.displayName) and all of its AI models from Ironsmith.")
         }
-        .confirmationDialog(
-            "Delete Ironsmith Account?",
-            isPresented: $isConfirmingAccountDeletion
-        ) {
-            Button("Delete Account", role: .destructive) {
-                if (remainingIronsmithCreditBalance ?? 0) > 0 {
-                    isConfirmingAccountDeletionWithCredits = true
-                } else {
-                    deleteAccount()
-                }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This permanently deletes your Ironsmith account and removes this provider from the app.")
-        }
-        .confirmationDialog(
-            "Delete Account With Credits?",
-            isPresented: $isConfirmingAccountDeletionWithCredits
-        ) {
-            Button("Delete Anyway", role: .destructive) {
-                deleteAccount()
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text(
-                "You still have \(ironsmithBalanceText). Deleting your account removes access to these credits. If you purchased credits less than 30 days ago, you can get a refund by contacting support@ironsmith.app"
-            )
-        }
     }
 
     private var providerSummaryRow: some View {
@@ -299,24 +255,6 @@ struct ProviderEditorSheetView: View {
         }
     }
 
-    @ViewBuilder
-    private var ironsmithAccountRows: some View {
-        if let summary = inferenceStore.ironsmithAccountSummary {
-            LabeledContent("Email") {
-                Text(summary.user.email ?? "Hidden")
-                    .textSelection(.enabled)
-            }
-        } else if let session = inferenceStore.ironsmithSession {
-            LabeledContent("Email") {
-                Text(session.user.email ?? "Hidden")
-                    .textSelection(.enabled)
-            }
-        } else {
-            Text("Not Signed In")
-                .foregroundStyle(.secondary)
-        }
-    }
-
     private var ironsmithBalanceText: String {
         guard let credits = remainingIronsmithCreditBalance else {
             return "Unknown"
@@ -350,21 +288,6 @@ struct ProviderEditorSheetView: View {
             await MainActor.run {
                 isSigningOut = false
                 if didSignOut {
-                    dismiss()
-                }
-            }
-        }
-    }
-
-    private func deleteAccount() {
-        guard !isDeletingAccount else { return }
-
-        isDeletingAccount = true
-        Task {
-            let didDelete = await inferenceStore.deleteIronsmithAccount(provider: provider)
-            await MainActor.run {
-                isDeletingAccount = false
-                if didDelete {
                     dismiss()
                 }
             }

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -143,6 +143,7 @@ nonisolated struct StoreAppSummary: Decodable, Identifiable, Equatable, Sendable
     let id: String
     let storeId: String
     let authorDisplayName: String
+    let authorHandle: String?
     let name: String
     let shortDescription: String
     let category: StoreAppCategory
@@ -156,6 +157,7 @@ nonisolated struct StoreAppSummary: Decodable, Identifiable, Equatable, Sendable
         id: String,
         storeId: String,
         authorDisplayName: String,
+        authorHandle: String?,
         name: String,
         shortDescription: String,
         category: StoreAppCategory,
@@ -168,6 +170,7 @@ nonisolated struct StoreAppSummary: Decodable, Identifiable, Equatable, Sendable
         self.id = id
         self.storeId = storeId
         self.authorDisplayName = authorDisplayName
+        self.authorHandle = authorHandle
         self.name = name
         self.shortDescription = shortDescription
         self.category = category
@@ -183,6 +186,7 @@ nonisolated struct StoreAppSummary: Decodable, Identifiable, Equatable, Sendable
             id: detail.id,
             storeId: detail.storeId,
             authorDisplayName: detail.authorDisplayName,
+            authorHandle: detail.authorHandle,
             name: detail.name,
             shortDescription: detail.shortDescription,
             category: detail.category,
@@ -201,6 +205,7 @@ nonisolated struct StoreAppDetail: Decodable, Identifiable, Equatable, Sendable 
     let storeId: String
     let storeVisibility: String
     let authorDisplayName: String
+    let authorHandle: String?
     let name: String
     let shortDescription: String
     let description: String
@@ -218,6 +223,13 @@ nonisolated struct StoreAppDetail: Decodable, Identifiable, Equatable, Sendable 
 
     var iconAsset: StoreAsset? {
         icon
+    }
+
+    var creatorDisplayText: String {
+        guard let authorHandle, !authorHandle.isEmpty else {
+            return authorDisplayName
+        }
+        return "\(authorDisplayName) · @\(authorHandle)"
     }
 }
 

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -121,7 +121,7 @@ private struct StoreDetailMetadataStrip: View {
 
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
-            StoreDetailMetadataItem(title: "Creator", value: app.authorDisplayName)
+            StoreDetailMetadataItem(title: "Creator", value: app.creatorDisplayText)
             StoreDetailMetadataItem(
                 title: "Version",
                 value: String(app.currentVersion.versionNumber)
@@ -133,6 +133,7 @@ private struct StoreDetailMetadataStrip: View {
         .overlay(alignment: .top) { Divider() }
         .overlay(alignment: .bottom) { Divider() }
     }
+
 }
 
 private struct StoreDetailMetadataItem: View {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryCreatorProfileSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryCreatorProfileSheetView.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct ToolLibraryCreatorProfileSheetView: View {
+    @Binding var displayName: String
+    @Binding var handle: String
+    let isSaving: Bool
+    let isClaimingHandle: Bool
+    let onCancel: () -> Void
+    let onSave: () -> Void
+    @State private var isConfirmingHandleClaim = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Complete Your Creator Profile")
+                .font(.headline)
+            Text("Your display name and unique handle appear with apps you publish.")
+                .foregroundStyle(.secondary)
+
+            field("Display Name") {
+                TextField("Your public creator name", text: $displayName)
+            }
+            field("Handle") {
+                HStack(spacing: 2) {
+                    Text("@")
+                        .foregroundStyle(.secondary)
+                    TextField("your_handle", text: $handle)
+                        .textFieldStyle(.plain)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(.background, in: RoundedRectangle(cornerRadius: 6))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(.separator)
+                }
+            }
+            Text("Handles are permanent and use 3–30 letters, numbers, or underscores.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button(isSaving ? "Saving…" : "Continue") {
+                    if isClaimingHandle {
+                        isConfirmingHandleClaim = true
+                    } else {
+                        onSave()
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(!canSave || isSaving)
+            }
+        }
+        .padding(18)
+        .frame(width: 390)
+        .alert("Set Creator Handle?", isPresented: $isConfirmingHandleClaim) {
+            Button("Cancel", role: .cancel) {}
+            Button("Set Handle", action: onSave)
+        } message: {
+            Text(
+                "@\(IronsmithCreatorHandle.normalized(handle)) cannot be changed after it is claimed."
+            )
+        }
+    }
+
+    static func isValidHandle(_ handle: String) -> Bool {
+        IronsmithCreatorHandle.isValid(handle)
+    }
+
+    private var canSave: Bool {
+        let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedHandle = IronsmithCreatorHandle.normalized(handle)
+        return (1...80).contains(name.count) && Self.isValidHandle(normalizedHandle)
+    }
+
+    private func field<Content: View>(
+        _ label: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.subheadline.weight(.medium))
+            content()
+        }
+    }
+}

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -225,6 +225,27 @@ struct ToolLibraryPopoverView: View {
         .sheet(isPresented: $storePublisher.isShowingPublishSheet) {
             storePublishSheet
         }
+        .sheet(isPresented: $storePublisher.isShowingCreatorProfileSheet) {
+            ToolLibraryCreatorProfileSheetView(
+                displayName: $storePublisher.creatorDisplayName,
+                handle: $storePublisher.creatorHandle,
+                isSaving: storePublisher.isSavingCreatorProfile,
+                isClaimingHandle:
+                    inferenceStore.ironsmithAccountSummary?.profile?.handle == nil,
+                onCancel: {
+                    storePublisher.isShowingCreatorProfileSheet = false
+                    storePublisher.pendingCreatorProfileToolID = nil
+                },
+                onSave: {
+                    Task {
+                        await storePublisher.saveCreatorProfile(
+                            inferenceStore: inferenceStore,
+                            tools: tools
+                        )
+                    }
+                }
+            )
+        }
         .sheet(isPresented: $detailsEditor.isShowingSheet) {
             detailsEditorSheet
         }
@@ -565,9 +586,7 @@ struct ToolLibraryPopoverView: View {
                 publishShortDescription: $storePublisher.publishShortDescription,
                 publishDescription: $storePublisher.publishDescription,
                 publishCategory: $storePublisher.publishCategory,
-                publishDisplayName: $storePublisher.publishDisplayName,
                 publishScreenshotName: storePublisher.publishScreenshotName,
-                needsDisplayName: storePublisher.needsDisplayName(inferenceStore: inferenceStore),
                 isPublishing: storePublisher.isPublishing,
                 onChooseScreenshot: { url in
                     storePublisher.importScreenshot(from: url)

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -7,9 +7,7 @@ struct ToolLibraryStorePublishSheetView: View {
     @Binding var publishShortDescription: String
     @Binding var publishDescription: String
     @Binding var publishCategory: StoreAppCategory
-    @Binding var publishDisplayName: String
     let publishScreenshotName: String?
-    let needsDisplayName: Bool
     let isPublishing: Bool
     let onChooseScreenshot: (URL) -> Void
     let onCancel: () -> Void
@@ -24,20 +22,6 @@ struct ToolLibraryStorePublishSheetView: View {
                     : "Publish \(tool.name) to Ironsmith Store"
             )
                 .font(.headline)
-
-            if needsDisplayName {
-                field("Creator Name") {
-                    TextField(
-                        "The public name shown next to your apps",
-                        text: $publishDisplayName
-                    )
-                        .onChange(of: publishDisplayName) { _, value in
-                            if value.count > 80 {
-                                publishDisplayName = String(value.prefix(80))
-                            }
-                        }
-                }
-            }
 
             field("Short Description") {
                 TextField(
@@ -118,13 +102,7 @@ struct ToolLibraryStorePublishSheetView: View {
 
     private var canPublish: Bool {
         listingFieldsAreValid
-            && (!needsDisplayName || displayNameIsValid)
             && !tool.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-    }
-
-    private var displayNameIsValid: Bool {
-        let trimmed = publishDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return (1...80).contains(trimmed.count)
     }
 
     private var listingFieldsAreValid: Bool {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -10,13 +10,17 @@ final class ToolLibraryStorePublisher {
     var publishShortDescription = ""
     var publishDescription = ""
     var publishCategory: StoreAppCategory = .utilities
-    var publishDisplayName = ""
     var publishScreenshotData: Data?
     var publishScreenshotName: String?
     var isShowingPublishSheet = false
     var isPublishing = false
     var errorMessage: String?
     var pendingSignInToolID: UUID?
+    var pendingCreatorProfileToolID: UUID?
+    var creatorDisplayName = ""
+    var creatorHandle = ""
+    var isShowingCreatorProfileSheet = false
+    var isSavingCreatorProfile = false
 
     @ObservationIgnored private let storeClient: IronsmithStoreClient
     @ObservationIgnored private let iconClient: ToolIconClient
@@ -96,10 +100,12 @@ final class ToolLibraryStorePublisher {
         }
     }
 
-    func needsDisplayName(inferenceStore: InferenceStore) -> Bool {
-        (inferenceStore.ironsmithAccountSummary?.profile?.displayName ?? "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .isEmpty
+    func hasCompleteCreatorProfile(inferenceStore: InferenceStore) -> Bool {
+        let profile = inferenceStore.ironsmithAccountSummary?.profile
+        return !(profile?.displayName ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !(profile?.handle ?? "")
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     func beginPublishing(
@@ -114,6 +120,14 @@ final class ToolLibraryStorePublisher {
             return
         }
         pendingSignInToolID = nil
+        guard hasCompleteCreatorProfile(inferenceStore: inferenceStore) else {
+            pendingCreatorProfileToolID = tool.id
+            creatorDisplayName = inferenceStore.ironsmithAccountSummary?.profile?.displayName ?? ""
+            creatorHandle = inferenceStore.ironsmithAccountSummary?.profile?.handle ?? ""
+            isShowingCreatorProfileSheet = true
+            return
+        }
+        pendingCreatorProfileToolID = nil
         await refreshPublishedStoreApps(
             isSignedIn: true,
             tools: tools
@@ -144,7 +158,6 @@ final class ToolLibraryStorePublisher {
             currentPublishedSourceSha256 = nil
         }
         publishingToolID = tool.id
-        publishDisplayName = inferenceStore.ironsmithAccountSummary?.profile?.displayName ?? ""
         publishScreenshotData = nil
         publishScreenshotName = nil
         isShowingPublishSheet = true
@@ -162,20 +175,6 @@ final class ToolLibraryStorePublisher {
         defer { isPublishing = false }
 
         do {
-            if needsDisplayName(inferenceStore: inferenceStore) {
-                let displayName = publishDisplayName.trimmingCharacters(
-                    in: .whitespacesAndNewlines
-                )
-                guard (1...80).contains(displayName.count) else {
-                    throw ToolLibraryStorePublishingError.invalidDisplayName
-                }
-                _ = try await inferenceStore.updateIronsmithAccountProfile(
-                    IronsmithAccountProfileUpdate(
-                        displayName: displayName
-                    )
-                )
-            }
-
             let source = try sourceCode(for: tool)
             if linkedPublishedApp(for: tool) != nil,
                 let currentPublishedSourceSha256,
@@ -240,6 +239,38 @@ final class ToolLibraryStorePublisher {
             )
         } catch {
             modelContext.rollback()
+            present(error)
+        }
+    }
+
+    func saveCreatorProfile(
+        inferenceStore: InferenceStore,
+        tools: [Tool]
+    ) async {
+        guard !isSavingCreatorProfile else { return }
+        let displayName = creatorDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let handle = IronsmithCreatorHandle.normalized(creatorHandle)
+        guard (1...80).contains(displayName.count) else {
+            present(ToolLibraryStorePublishingError.invalidDisplayName)
+            return
+        }
+        guard ToolLibraryCreatorProfileSheetView.isValidHandle(handle) else {
+            present(ToolLibraryStorePublishingError.invalidHandle)
+            return
+        }
+        isSavingCreatorProfile = true
+        defer { isSavingCreatorProfile = false }
+        do {
+            _ = try await inferenceStore.updateIronsmithAccountProfile(
+                IronsmithAccountProfileUpdate(displayName: displayName, handle: handle)
+            )
+            isShowingCreatorProfileSheet = false
+            guard let toolID = pendingCreatorProfileToolID,
+                let tool = tools.first(where: { $0.id == toolID })
+            else { return }
+            pendingCreatorProfileToolID = nil
+            await beginPublishing(tool, inferenceStore: inferenceStore, tools: tools)
+        } catch {
             present(error)
         }
     }
@@ -331,6 +362,7 @@ final class ToolLibraryStorePublisher {
 
 private enum ToolLibraryStorePublishingError: LocalizedError {
     case invalidDisplayName
+    case invalidHandle
     case localFinalizationFailed(String)
 
     static func localFinalizationWarning(
@@ -356,6 +388,8 @@ private enum ToolLibraryStorePublishingError: LocalizedError {
         switch self {
         case .invalidDisplayName:
             "Enter a display name between 1 and 80 characters."
+        case .invalidHandle:
+            "Enter a handle using 3–30 letters, numbers, or underscores that begins and ends with a letter or number."
         case .localFinalizationFailed(let detail):
             """
             This app was published successfully, but Ironsmith could not finish updating its \

--- a/IronsmithTests/Core/Inference/InferenceIronsmithAccountTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceIronsmithAccountTests.swift
@@ -165,6 +165,148 @@ extension InferenceTests {
 
     @MainActor
     @Test
+    func emailPasswordSignInAddsIronsmithProviderAndRefreshesAccount() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let authBox = EmailPasswordAuthBox()
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteModelIDs: ["anthropic.claude-test"],
+                accountClient: Self.accountClient(emailPasswordBox: authBox)
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+        let didSignIn = await inferenceStore.signInToIronsmithWithEmailPassword(
+            email: " test@example.com ",
+            password: "password"
+        )
+
+        #expect(didSignIn)
+        #expect(authBox.email == " test@example.com ")
+        #expect(authBox.password == "password")
+        #expect(authBox.operation == .signIn)
+        #expect(inferenceStore.providers.contains { $0.kind == .ironsmith })
+        #expect(inferenceStore.ironsmithAccountSummary?.credits.balanceCredits == 42)
+        #expect(inferenceStore.remoteModels.map(\.identifier) == ["anthropic.claude-test"])
+    }
+
+    @MainActor
+    @Test
+    func emailPasswordSignUpCreatesSessionAndAddsIronsmithProvider() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let authBox = EmailPasswordAuthBox()
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteModelIDs: ["openai.gpt-5"],
+                accountClient: Self.accountClient(emailPasswordBox: authBox)
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+        let didCreateAccount = await inferenceStore.createIronsmithAccountWithEmailPassword(
+            email: "new@example.com",
+            password: "password"
+        )
+
+        #expect(didCreateAccount)
+        #expect(authBox.email == "new@example.com")
+        #expect(authBox.password == "password")
+        #expect(authBox.operation == .signUp)
+        #expect(inferenceStore.ironsmithSession != nil)
+        #expect(inferenceStore.providers.contains { $0.kind == .ironsmith })
+    }
+
+    @MainActor
+    @Test
+    func emailPasswordSignUpPresentsEmailConfirmationConfigurationError() async {
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                accountClient: Self.accountClient(
+                    emailPasswordError: IronsmithAccountClientError.emailConfirmationRequired
+                )
+            )
+        )
+
+        let didCreateAccount = await inferenceStore.createIronsmithAccountWithEmailPassword(
+            email: "new@example.com",
+            password: "password"
+        )
+
+        #expect(!didCreateAccount)
+        #expect(
+            inferenceStore.presentedErrorMessage
+                == "Account created, but Supabase requires email confirmation. Disable Confirm email in the Supabase Auth settings for debug sign-in."
+        )
+    }
+
+    @MainActor
+    @Test
+    func authenticationRollsBackWhenExistingIronsmithProviderSetupFails() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let signOutBox = SignOutBox()
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteDiscoveryError: NSError(
+                    domain: "IronsmithTests.ModelDiscovery",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Model discovery failed."]
+                ),
+                accountClient: Self.accountClient(signOutBox: signOutBox)
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+        let provider = try #require(ProviderCatalog.makeProvider(for: .ironsmith))
+        context.insert(provider)
+        try context.save()
+        try inferenceStore.refreshData()
+
+        let didSignIn = await inferenceStore.signInToIronsmithWithEmailPassword(
+            email: "jade@example.com",
+            password: "password"
+        )
+
+        #expect(!didSignIn)
+        #expect(signOutBox.didSignOut)
+        #expect(inferenceStore.ironsmithSession == nil)
+        #expect(inferenceStore.ironsmithAccountSummary == nil)
+    }
+
+    @MainActor
+    @Test
+    func authenticationRollsBackWhenNewIronsmithProviderDiscoveryFails() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let signOutBox = SignOutBox()
+        let inferenceStore = InferenceStore(
+            dependencies: Self.dependencies(
+                remoteDiscoveryError: NSError(
+                    domain: "IronsmithTests.ModelDiscovery",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Model discovery failed."]
+                ),
+                accountClient: Self.accountClient(signOutBox: signOutBox)
+            )
+        )
+
+        await inferenceStore.loadIfNeeded(modelContext: context)
+        let didSignIn = await inferenceStore.signInToIronsmithWithEmailPassword(
+            email: "jade@example.com",
+            password: "password"
+        )
+
+        #expect(!didSignIn)
+        #expect(signOutBox.didSignOut)
+        #expect(inferenceStore.ironsmithSession == nil)
+        #expect(inferenceStore.ironsmithAccountSummary == nil)
+        #expect(!(inferenceStore.providers.contains { $0.kind == .ironsmith }))
+    }
+
+    @MainActor
+    @Test
     func signOutRemovesIronsmithProvider() async throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)

--- a/IronsmithTests/Core/Inference/InferenceIronsmithAccountTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceIronsmithAccountTests.swift
@@ -14,7 +14,8 @@ extension InferenceTests {
               "profile": {
                 "id": "user-123",
                 "email": "jade@example.com",
-                "displayName": "Jade Westover"
+                "displayName": "Jade Westover",
+                "handle": "jadew"
               }
             }
             """.utf8
@@ -28,6 +29,7 @@ extension InferenceTests {
         #expect(response.profile.id == "user-123")
         #expect(response.profile.email == "jade@example.com")
         #expect(response.profile.displayName == "Jade Westover")
+        #expect(response.profile.handle == "jadew")
     }
 
     @MainActor
@@ -179,7 +181,7 @@ extension InferenceTests {
         try context.save()
         try inferenceStore.refreshData()
 
-        let didSignOut = await inferenceStore.signOutIronsmithProvider(provider)
+        let didSignOut = await inferenceStore.signOutIronsmithAccount()
 
         #expect(didSignOut)
         #expect(signOutBox.didSignOut)
@@ -205,7 +207,7 @@ extension InferenceTests {
         try context.save()
         try inferenceStore.refreshData()
 
-        let didDelete = await inferenceStore.deleteIronsmithAccount(provider: provider)
+        let didDelete = await inferenceStore.deleteIronsmithAccount()
 
         #expect(didDelete)
         #expect(signOutBox.didSignOut)

--- a/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceProviderCatalogTests.swift
@@ -341,6 +341,21 @@ extension InferenceTests {
     }
 
     @Test
+    func ironsmithAPIRequestsPreserveQueryItems() throws {
+        let request = IronsmithAccountClient.makeAuthenticatedAPIRequest(
+            baseURL: try #require(URL(string: "http://localhost:8000")),
+            path: "api/v1/account/handle-availability?handle=jade_w",
+            method: .get,
+            accessToken: "access-token"
+        )
+
+        #expect(
+            request.url?.absoluteString
+                == "http://localhost:8000/api/v1/account/handle-availability?handle=jade_w"
+        )
+    }
+
+    @Test
     func ollamaModelManagementRequestsAppendAPIPathAndAuthorization() throws {
         let pullRequest = try OllamaClient.makePullRequest(
             baseURLString: "http://localhost:11434",

--- a/IronsmithTests/Core/Inference/InferenceTestSupport.swift
+++ b/IronsmithTests/Core/Inference/InferenceTestSupport.swift
@@ -154,6 +154,8 @@ extension InferenceTests {
     static func accountClient(
         signInBox: AppleOAuthSignInBox? = nil,
         signInError: Error? = nil,
+        emailPasswordBox: EmailPasswordAuthBox? = nil,
+        emailPasswordError: Error? = nil,
         signOutBox: SignOutBox? = nil,
         deleteError: IronsmithAccountClientError? = nil,
         fetchError: Error? = nil,
@@ -176,6 +178,24 @@ extension InferenceTests {
                 signInBox?.callbackURL = try await launchFlow(authorizationURL)
                 if let signInError {
                     throw signInError
+                }
+                return Self.ironsmithSession()
+            },
+            signInWithEmailPassword: { email, password in
+                emailPasswordBox?.email = email
+                emailPasswordBox?.password = password
+                emailPasswordBox?.operation = .signIn
+                if let emailPasswordError {
+                    throw emailPasswordError
+                }
+                return Self.ironsmithSession()
+            },
+            signUpWithEmailPassword: { email, password in
+                emailPasswordBox?.email = email
+                emailPasswordBox?.password = password
+                emailPasswordBox?.operation = .signUp
+                if let emailPasswordError {
+                    throw emailPasswordError
                 }
                 return Self.ironsmithSession()
             },
@@ -298,6 +318,17 @@ final class CredentialBox {
 nonisolated final class AppleOAuthSignInBox: @unchecked Sendable {
     var authorizationURL: URL?
     var callbackURL: URL?
+}
+
+nonisolated final class EmailPasswordAuthBox: @unchecked Sendable {
+    enum Operation: Equatable {
+        case signIn
+        case signUp
+    }
+
+    var email: String?
+    var password: String?
+    var operation: Operation?
 }
 
 final class SignOutBox: @unchecked Sendable {

--- a/IronsmithTests/Core/Inference/InferenceTestSupport.swift
+++ b/IronsmithTests/Core/Inference/InferenceTestSupport.swift
@@ -192,8 +192,12 @@ extension InferenceTests {
                 IronsmithAccountProfile(
                     id: "00000000-0000-4000-8000-000000000001",
                     email: "jade@example.com",
-                    displayName: nil
+                    displayName: nil,
+                    handle: nil
                 )
+            },
+            checkHandleAvailability: {
+                IronsmithHandleAvailability(handle: $0, available: true)
             },
             fetchCreditPacks: {
                 [

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -861,6 +861,18 @@ struct StoreImportTests {
         #expect(StoreVersionPresentation.formattedDate(second.publishedAt).contains("2026"))
     }
 
+    @Test
+    func storeCreatorPresentationIncludesHandleWithLegacyFallback() {
+        let legacy = Self.appListing(sourceCode: Self.sourceCode("legacy"))
+        let attributed = Self.appListing(
+            sourceCode: Self.sourceCode("attributed"),
+            authorHandle: "jadew"
+        )
+
+        #expect(legacy.creatorDisplayText == "Jade")
+        #expect(attributed.creatorDisplayText == "Jade · @jadew")
+    }
+
     private static func sourceCode(_ text: String) -> String {
         """
         import SwiftUI
@@ -878,6 +890,7 @@ struct StoreImportTests {
             id: id,
             storeId: "00000000-0000-4000-8000-000000000011",
             authorDisplayName: "Jade",
+            authorHandle: nil,
             name: id,
             shortDescription: "A Store app",
             category: .utilities,
@@ -893,7 +906,8 @@ struct StoreImportTests {
         sourceCode: String,
         versions suppliedVersions: [StoreVersionMetadata]? = nil,
         icon: StoreAsset? = nil,
-        iconMaster: StoreAsset? = nil
+        iconMaster: StoreAsset? = nil,
+        authorHandle: String? = nil
     ) -> StoreAppDetail {
         let storeId = "00000000-0000-4000-8000-000000000011"
         let appId = "00000000-0000-4000-8000-000000000101"
@@ -916,6 +930,7 @@ struct StoreImportTests {
             storeId: storeId,
             storeVisibility: "public",
             authorDisplayName: "Jade",
+            authorHandle: authorHandle,
             name: "Clipboard Cleaner",
             shortDescription: "Clipboard cleanup",
             description: "Cleans clipboard text.",

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -163,6 +163,8 @@ extension ToolLibraryTests {
             validAccessToken: { "access-token" },
             generationAccessToken: { "access-token" },
             signInWithAppleOAuth: { _ in session },
+            signInWithEmailPassword: { _, _ in session },
+            signUpWithEmailPassword: { _, _ in session },
             signOut: {},
             fetchAccountSummary: {
                 await profileCapture.summary()

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -152,7 +152,7 @@ extension ToolLibraryTests {
 
     @MainActor
     @Test
-    func storePublisherSavesMissingDisplayNameOnceBeforePublishing() async throws {
+    func storePublisherCompletesCreatorProfileBeforePublishing() async throws {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let profileCapture = PublisherProfileCapture()
@@ -169,6 +169,9 @@ extension ToolLibraryTests {
             },
             updateProfile: { update in
                 await profileCapture.update(update)
+            },
+            checkHandleAvailability: {
+                IronsmithHandleAvailability(handle: $0, available: true)
             },
             fetchCreditPacks: { [] },
             createCheckoutSession: { _ in
@@ -202,9 +205,6 @@ extension ToolLibraryTests {
                 )
             }
         )
-        publisher.publishShortDescription = "Clean copied text"
-        publisher.publishDescription = "Cleans and reformats text."
-        publisher.publishDisplayName = "  Jade Westover  "
         let tool = Tool(
             name: "Clipboard Cleaner",
             executableName: "ClipboardCleaner",
@@ -221,6 +221,14 @@ extension ToolLibraryTests {
         let context = container.mainContext
         context.insert(tool)
         try context.save()
+
+        await publisher.beginPublishing(tool, inferenceStore: inferenceStore, tools: [tool])
+        #expect(publisher.isShowingCreatorProfileSheet)
+        publisher.creatorDisplayName = "  Jade Westover  "
+        publisher.creatorHandle = "jade_w"
+        await publisher.saveCreatorProfile(inferenceStore: inferenceStore, tools: [tool])
+        publisher.publishShortDescription = "Clean copied text"
+        publisher.publishDescription = "Cleans and reformats text."
 
         await publisher.publish(
             tool,
@@ -262,7 +270,6 @@ extension ToolLibraryTests {
             iconClient: .cachedOnly(),
             buildClient: ToolBuildClient { _ in }
         )
-        publisher.publishDisplayName = "Jade Westover"
         publisher.publishShortDescription = "Clean copied text"
         publisher.publishDescription = "Cleans and reformats text."
         let tool = Tool(
@@ -356,7 +363,6 @@ extension ToolLibraryTests {
         publisher.publishedStoreAppsByID[previousDetail.id] = StoreAppSummary(
             detail: previousDetail
         )
-        publisher.publishDisplayName = "Jade Westover"
         publisher.publishShortDescription = "Clean copied text"
         publisher.publishDescription = "Cleans and reformats text."
         let tool = Tool(
@@ -426,7 +432,6 @@ extension ToolLibraryTests {
                 throw PublisherPersistenceError.failed
             }
         )
-        publisher.publishDisplayName = "Jade Westover"
         publisher.publishShortDescription = "Clean copied text"
         publisher.publishDescription = "Cleans and reformats text."
         publisher.isShowingPublishSheet = true
@@ -499,7 +504,6 @@ extension ToolLibraryTests {
         publisher.publishedStoreAppsByID[previousDetail.id] = StoreAppSummary(
             detail: previousDetail
         )
-        publisher.publishDisplayName = "Jade Westover"
         publisher.publishShortDescription = "Clean copied text"
         publisher.publishDescription = "Cleans and reformats text."
         publisher.isShowingPublishSheet = true
@@ -614,6 +618,7 @@ extension ToolLibraryTests {
             storeId: IronsmithStoreConstants.communityStoreId,
             storeVisibility: "public",
             authorDisplayName: "Jade",
+            authorHandle: "jade",
             name: "Clipboard Cleaner",
             shortDescription: "Clean copied text",
             description: "Cleans and reformats text from the clipboard.",
@@ -635,6 +640,7 @@ extension ToolLibraryTests {
 private actor PublisherProfileCapture {
     private(set) var updatedNames: [String] = []
     private var displayName: String?
+    private var handle: String?
 
     func summary() -> IronsmithAccountSummary {
         IronsmithAccountSummary(
@@ -646,7 +652,8 @@ private actor PublisherProfileCapture {
                 IronsmithAccountProfile(
                     id: "00000000-0000-4000-8000-000000000001",
                     email: "jade@example.com",
-                    displayName: $0
+                    displayName: $0,
+                    handle: handle
                 )
             },
             credits: IronsmithCreditSummary(
@@ -663,10 +670,14 @@ private actor PublisherProfileCapture {
             updatedNames.append(name)
         }
         displayName = name
+        if let updatedHandle = update.handle {
+            handle = updatedHandle
+        }
         return IronsmithAccountProfile(
             id: "00000000-0000-4000-8000-000000000001",
             email: "jade@example.com",
-            displayName: name
+            displayName: name,
+            handle: handle
         )
     }
 }

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryTestSupport.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryTestSupport.swift
@@ -48,6 +48,12 @@ extension ToolLibraryTests {
             signInWithAppleOAuth: { _ in
                 Self.ironsmithSession()
             },
+            signInWithEmailPassword: { _, _ in
+                Self.ironsmithSession()
+            },
+            signUpWithEmailPassword: { _, _ in
+                Self.ironsmithSession()
+            },
             signOut: {},
             fetchAccountSummary: {
                 IronsmithAccountSummary(
@@ -103,6 +109,12 @@ extension ToolLibraryTests {
                 "access-token"
             },
             signInWithAppleOAuth: { _ in
+                Self.ironsmithSession()
+            },
+            signInWithEmailPassword: { _, _ in
+                Self.ironsmithSession()
+            },
+            signUpWithEmailPassword: { _, _ in
                 Self.ironsmithSession()
             },
             signOut: {},

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryTestSupport.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryTestSupport.swift
@@ -55,7 +55,12 @@ extension ToolLibraryTests {
                         id: "00000000-0000-4000-8000-000000000001",
                         email: "jade@example.com"
                     ),
-                    profile: nil,
+                    profile: IronsmithAccountProfile(
+                        id: "00000000-0000-4000-8000-000000000001",
+                        email: "jade@example.com",
+                        displayName: "Jade",
+                        handle: "jade"
+                    ),
                     credits: IronsmithCreditSummary(
                         userId: "00000000-0000-4000-8000-000000000001",
                         balanceCredits: balanceCredits
@@ -67,8 +72,12 @@ extension ToolLibraryTests {
                 IronsmithAccountProfile(
                     id: "00000000-0000-4000-8000-000000000001",
                     email: "jade@example.com",
-                    displayName: nil
+                    displayName: nil,
+                    handle: nil
                 )
+            },
+            checkHandleAvailability: {
+                IronsmithHandleAvailability(handle: $0, available: true)
             },
             fetchCreditPacks: { [] },
             createCheckoutSession: { _ in
@@ -104,8 +113,12 @@ extension ToolLibraryTests {
                 IronsmithAccountProfile(
                     id: "00000000-0000-4000-8000-000000000001",
                     email: "jade@example.com",
-                    displayName: nil
+                    displayName: nil,
+                    handle: nil
                 )
+            },
+            checkHandleAvailability: {
+                IronsmithHandleAvailability(handle: $0, available: true)
             },
             fetchCreditPacks: { [] },
             createCheckoutSession: { _ in


### PR DESCRIPTION
## Summary

- Add account handle support to Ironsmith account and provider models.
- Update account, settings, store, and publishing interfaces to display and use handles.
- Extend account, provider, store import, and tool publishing test coverage.

## Testing

- Added and updated focused Swift Testing coverage for account handles, provider behavior, store imports, and tool publishing.