### PR TITLE
Add creator store pages and extensible sorting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Config/*.local.xcconfig
 Config/*.env
 !Config/.env.example
 script/*.local.sh
+
+ironsmith-backend/
+.codex/environments/environment.toml

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -30,9 +30,18 @@ nonisolated enum StoreAssetKind: String, Codable, Equatable, Sendable {
     case screenshot
 }
 
-nonisolated enum StoreAppListSort: String, Codable, Hashable, Sendable {
+nonisolated enum StoreAppListSort: String, Codable, CaseIterable, Hashable, Identifiable, Sendable {
     case recent
     case trending
+
+    var id: Self { self }
+
+    var title: String {
+        switch self {
+        case .recent: "Recent"
+        case .trending: "Trending"
+        }
+    }
 }
 
 nonisolated struct AppStoreDescriptor: Decodable, Identifiable, Equatable, Sendable {
@@ -318,7 +327,8 @@ nonisolated struct IronsmithStoreClient {
             _ search: String?,
             _ offset: Int,
             _ sort: StoreAppListSort,
-            _ category: StoreAppCategory?
+            _ category: StoreAppCategory?,
+            _ creatorHandle: String?
         ) async throws
             -> StoreAppPage
     var fetchApp: @Sendable (_ storeId: String, _ appId: String) async throws -> StoreAppDetail
@@ -362,7 +372,7 @@ extension IronsmithStoreClient {
                 )
                 return response.data
             },
-            listApps: { storeId, scope, search, offset, sort, category in
+            listApps: { storeId, scope, search, offset, sort, category, creatorHandle in
                 var queryItems = [
                     URLQueryItem(name: "scope", value: scope.rawValue),
                     URLQueryItem(name: "sort", value: sort.rawValue),
@@ -377,6 +387,9 @@ extension IronsmithStoreClient {
                 }
                 if let category {
                     queryItems.append(URLQueryItem(name: "category", value: category.rawValue))
+                }
+                if let creatorHandle, !creatorHandle.isEmpty {
+                    queryItems.append(URLQueryItem(name: "creator", value: creatorHandle))
                 }
                 let response: StorePageEnvelope<StoreAppSummary> = try await api.request(
                     "api/v1/stores/\(storeId)/apps",
@@ -510,7 +523,7 @@ extension IronsmithStoreClient {
         Self(
             listStores: { throw IronsmithStoreClientError.notConfigured },
             listHomeSections: { _ in throw IronsmithStoreClientError.notConfigured },
-            listApps: { _, _, _, _, _, _ in throw IronsmithStoreClientError.notConfigured },
+            listApps: { _, _, _, _, _, _, _ in throw IronsmithStoreClientError.notConfigured },
             fetchApp: { _, _ in throw IronsmithStoreClientError.notConfigured },
             fetchVersion: { _, _, _ in throw IronsmithStoreClientError.notConfigured },
             publishApp: { _ in throw IronsmithStoreClientError.notConfigured },

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -10,6 +10,7 @@ struct StoreAppDetailView: View {
     let versionInstallDisposition: (StoreAppDetail, StoreVersionMetadata) -> StoreAppInstallDisposition
     let onGet: (StoreAppDetail) -> Void
     let onRemix: (StoreAppDetail) -> Void
+    let onOpenCreator: (String, String) -> Void
     let onInstallVersion: (StoreAppDetail, StoreVersionMetadata) -> Void
 
     @State private var expandedVersionID: String?
@@ -28,7 +29,7 @@ struct StoreAppDetailView: View {
                             onRemix: { onRemix(app) }
                         )
 
-                        StoreDetailMetadataStrip(app: app)
+                        StoreDetailMetadataStrip(app: app, onOpenCreator: onOpenCreator)
 
                         if let screenshot = app.screenshots.first {
                             StoreDetailScreenshot(asset: screenshot)
@@ -114,6 +115,7 @@ private struct StoreDetailHeroView: View {
 
 private struct StoreDetailMetadataStrip: View {
     let app: StoreAppDetail
+    let onOpenCreator: (String, String) -> Void
 
     private var columns: [GridItem] {
         [GridItem(.adaptive(minimum: 140), spacing: 16, alignment: .top)]
@@ -121,7 +123,15 @@ private struct StoreDetailMetadataStrip: View {
 
     var body: some View {
         LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
-            StoreDetailMetadataItem(title: "Creator", value: app.creatorDisplayText)
+            if let handle = app.authorHandle, !handle.isEmpty {
+                StoreDetailCreatorMetadataItem(
+                    displayName: app.authorDisplayName,
+                    handle: handle,
+                    action: { onOpenCreator(app.authorDisplayName, handle) }
+                )
+            } else {
+                StoreDetailMetadataItem(title: "Creator", value: app.creatorDisplayText)
+            }
             StoreDetailMetadataItem(
                 title: "Version",
                 value: String(app.currentVersion.versionNumber)
@@ -134,6 +144,38 @@ private struct StoreDetailMetadataStrip: View {
         .overlay(alignment: .bottom) { Divider() }
     }
 
+}
+
+private struct StoreDetailCreatorMetadataItem: View {
+    let displayName: String
+    let handle: String
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("CREATOR")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.tertiary)
+            Button(action: action) {
+                Text("\(Text(displayName).bold()) · @\(handle)")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background {
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(isHovering ? Color.primary.opacity(0.08) : Color.clear)
+                    }
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovering = $0 }
+            .animation(.easeOut(duration: 0.12), value: isHovering)
+        }
+    }
 }
 
 private struct StoreDetailMetadataItem: View {

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -165,6 +165,7 @@ final class StoreWindowStore {
                 trimmedSearch,
                 0,
                 .recent,
+                nil,
                 nil
             )
             guard searchPaginationRevision == revision,
@@ -203,6 +204,7 @@ final class StoreWindowStore {
                 trimmedSearch,
                 offset,
                 .recent,
+                nil,
                 nil
             )
             guard searchPaginationRevision == revision,
@@ -226,6 +228,7 @@ final class StoreWindowStore {
     func loadSectionApps(
         sort: StoreAppListSort,
         category: StoreAppCategory?,
+        creatorHandle: String? = nil,
         offset: Int = 0
     ) async -> StoreAppPage? {
         do {
@@ -235,9 +238,13 @@ final class StoreWindowStore {
                 nil,
                 offset,
                 sort,
-                category
+                category,
+                creatorHandle
             )
         } catch {
+            guard !IronsmithErrorPresentation.isCancellation(error), !Task.isCancelled else {
+                return nil
+            }
             present(error)
             return nil
         }
@@ -296,6 +303,7 @@ final class StoreWindowStore {
                 nil,
                 0,
                 .recent,
+                nil,
                 nil
             )
             guard publishedPaginationRevision == revision, selectedStoreId == storeId else {
@@ -327,6 +335,7 @@ final class StoreWindowStore {
                 nil,
                 offset,
                 .recent,
+                nil,
                 nil
             )
             guard publishedPaginationRevision == revision,
@@ -345,10 +354,19 @@ final class StoreWindowStore {
     }
 
     func select(_ app: StoreAppSummary) {
-        selectedAppID = app.id
+        select(storeID: app.storeId, appID: app.id)
+    }
+
+    func select(storeID: String, appID: String) {
+        if selectedAppID == appID,
+            selectedAppDetail?.id == appID || isLoadingDetail
+        {
+            return
+        }
+        selectedAppID = appID
         selectedAppDetail = nil
         Task {
-            await loadDetail(for: app)
+            await loadDetail(storeID: storeID, appID: appID)
         }
     }
 
@@ -705,19 +723,19 @@ final class StoreWindowStore {
         )
     }
 
-    private func loadDetail(for app: StoreAppSummary) async {
+    private func loadDetail(storeID: String, appID: String) async {
         isLoadingDetail = true
         defer {
-            if selectedAppID == app.id {
+            if selectedAppID == appID {
                 isLoadingDetail = false
             }
         }
         do {
-            let detail = try await client.fetchApp(app.storeId, app.id)
-            guard selectedAppID == app.id else { return }
+            let detail = try await client.fetchApp(storeID, appID)
+            guard selectedAppID == appID else { return }
             selectedAppDetail = detail
         } catch {
-            guard selectedAppID == app.id else { return }
+            guard selectedAppID == appID else { return }
             present(error)
         }
     }

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -63,14 +63,16 @@ struct StoreWindowView: View {
                 .navigationTitle(navigationTitle)
                 .navigationDestination(for: StoreNavigationDestination.self) { destination in
                     switch destination {
-                    case .app(let appID):
+                    case .app(let appRoute):
                         StoreAppDetailDestinationView(
-                            appID: appID,
+                            appID: appRoute.appID,
+                            storeID: appRoute.storeID,
                             store: store,
                             tools: tools,
                             modelContext: modelContext,
                             routeStore: routeStore,
-                            inferenceStore: inferenceStore
+                            inferenceStore: inferenceStore,
+                            onOpenCreator: openCreator
                         )
                     case .section(let section):
                         StoreSectionAppsView(
@@ -147,11 +149,17 @@ struct StoreWindowView: View {
 
     private func openApp(_ app: StoreAppSummary) {
         store.select(app)
-        path.append(.app(app.id))
+        path.append(.app(StoreAppRoute(app: app)))
     }
 
     private func openSection(_ section: StoreHomeSection) {
         path.append(.section(StoreSectionRoute(section: section)))
+    }
+
+    private func openCreator(displayName: String, handle: String) {
+        path.append(
+            .section(StoreSectionRoute(creatorDisplayName: displayName, handle: handle))
+        )
     }
 
     private func install(_ app: StoreAppSummary, mode: StoreToolImportMode = .get) {
@@ -208,7 +216,7 @@ struct StoreWindowView: View {
                 categoryRefreshToken += 1
                 if let app = store.publishedApps.first(where: { $0.id == appID }) {
                     store.select(app)
-                    path = [.app(app.id)]
+                    path = [.app(StoreAppRoute(app: app))]
                 }
             }
         }
@@ -216,8 +224,18 @@ struct StoreWindowView: View {
 }
 
 private enum StoreNavigationDestination: Hashable {
-    case app(String)
+    case app(StoreAppRoute)
     case section(StoreSectionRoute)
+}
+
+private struct StoreAppRoute: Hashable {
+    let appID: String
+    let storeID: String
+
+    init(app: StoreAppSummary) {
+        appID = app.id
+        storeID = app.storeId
+    }
 }
 
 private enum StoreSidebarSelection: Hashable {
@@ -253,12 +271,20 @@ private struct StoreSectionRoute: Hashable, Identifiable {
     let title: String
     let sort: StoreAppListSort
     let category: StoreAppCategory?
+    let creatorDisplayName: String?
+    let creatorHandle: String?
+
+    var showsSortControl: Bool {
+        category != nil || creatorHandle != nil
+    }
 
     init(section: StoreHomeSection) {
         id = section.id
         title = section.title
         sort = section.sort
         category = section.category
+        creatorDisplayName = nil
+        creatorHandle = nil
     }
 
     init(category: StoreAppCategory) {
@@ -266,6 +292,17 @@ private struct StoreSectionRoute: Hashable, Identifiable {
         title = category.title
         sort = .recent
         self.category = category
+        creatorDisplayName = nil
+        creatorHandle = nil
+    }
+
+    init(creatorDisplayName: String, handle: String) {
+        id = "creator-\(handle)"
+        title = creatorDisplayName
+        sort = .recent
+        category = nil
+        self.creatorDisplayName = creatorDisplayName
+        creatorHandle = handle
     }
 }
 
@@ -427,13 +464,43 @@ private struct StoreSectionAppsView: View {
     @State private var isLoading = true
     @State private var isLoadingMore = false
     @State private var paginationRevision = 0
+    @State private var selectedSort: StoreAppListSort?
+
+    private var activeSort: StoreAppListSort {
+        selectedSort ?? section.sort
+    }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 18) {
-                Text(section.title)
-                    .font(.largeTitle.weight(.semibold))
-                    .padding(.horizontal, 28)
+                HStack(alignment: .center, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(section.title)
+                            .font(.largeTitle.weight(.semibold))
+                        if let creatorHandle = section.creatorHandle {
+                            Text("@\(creatorHandle)")
+                                .font(.title3)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    if section.showsSortControl {
+                        HStack(spacing: 6) {
+                            Text("Sort by")
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                            Picker("Sort by", selection: sortBinding) {
+                                ForEach(StoreAppListSort.allCases) { sort in
+                                    Text(sort.title).tag(sort)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .labelsHidden()
+                        }
+                        .fixedSize()
+                    }
+                }
+                .padding(.horizontal, 28)
 
                 if isLoading {
                     ProgressView()
@@ -464,9 +531,20 @@ private struct StoreSectionAppsView: View {
             .padding(.bottom, 24)
         }
         .navigationTitle(section.title)
-        .task(id: "\(section.id)-\(refreshToken)") {
+        .task(id: "\(section.id)-\(refreshToken)-\(activeSort.rawValue)") {
             await reload()
         }
+    }
+
+    private var sortBinding: Binding<StoreAppListSort> {
+        Binding(
+            get: { activeSort },
+            set: { sort in
+                guard sort != activeSort else { return }
+                paginationRevision += 1
+                selectedSort = sort
+            }
+        )
     }
 
     private func reload() async {
@@ -477,14 +555,15 @@ private struct StoreSectionAppsView: View {
             isLoading = true
         }
         defer {
-            if showsLoadingIndicator {
+            if showsLoadingIndicator, paginationRevision == revision {
                 isLoading = false
             }
         }
         guard
             let page = await store.loadSectionApps(
-                sort: section.sort,
-                category: section.category
+                sort: activeSort,
+                category: section.category,
+                creatorHandle: section.creatorHandle
             )
         else {
             return
@@ -507,8 +586,9 @@ private struct StoreSectionAppsView: View {
         defer { isLoadingMore = false }
         guard
             let page = await store.loadSectionApps(
-                sort: section.sort,
+                sort: activeSort,
                 category: section.category,
+                creatorHandle: section.creatorHandle,
                 offset: offset
             )
         else {
@@ -753,11 +833,13 @@ private struct StorePublishedRowView: View {
 
 private struct StoreAppDetailDestinationView: View {
     let appID: String
+    let storeID: String
     @Bindable var store: StoreWindowStore
     let tools: [Tool]
     let modelContext: ModelContext
     let routeStore: IronsmithRouteStore
     let inferenceStore: InferenceStore
+    let onOpenCreator: (String, String) -> Void
 
     var body: some View {
         StoreAppDetailView(
@@ -796,6 +878,7 @@ private struct StoreAppDetailDestinationView: View {
                     )
                 }
             },
+            onOpenCreator: onOpenCreator,
             onInstallVersion: { app, version in
                 Task {
                     await store.installVersion(
@@ -810,13 +893,8 @@ private struct StoreAppDetailDestinationView: View {
             }
         )
         .navigationTitle(detail?.name ?? "App")
-        .task(id: appID) {
-            guard store.selectedAppDetail?.id != appID,
-                let summary = store.appSummary(id: appID)
-            else {
-                return
-            }
-            store.select(summary)
+        .onAppear {
+            store.select(storeID: storeID, appID: appID)
         }
     }
 

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -84,6 +84,7 @@ final class ToolLibraryStorePublisher {
                         nil,
                         offset,
                         .recent,
+                        nil,
                         nil
                     )
                     for app in page.apps {

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -455,13 +455,14 @@ struct StoreImportTests {
         let second = Self.appSummary(id: "app-two")
         let recorder = StoreListRequestRecorder()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, scope, search, offset, sort, category in
+        client.listApps = { _, scope, search, offset, sort, category, creatorHandle in
             await recorder.record(
                 scope: scope,
                 search: search,
                 offset: offset,
                 sort: sort,
-                category: category
+                category: category,
+                creatorHandle: creatorHandle
             )
             if offset == 0 {
                 return StoreAppPage(apps: [first], hasMore: true)
@@ -496,7 +497,7 @@ struct StoreImportTests {
         let current = Self.appSummary(id: "current-app")
         let gate = StorePageGate()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, _, search, _, _, _ in
+        client.listApps = { _, _, search, _, _, _, _ in
             if search == "first" {
                 return await gate.waitForPage()
             }
@@ -532,13 +533,14 @@ struct StoreImportTests {
         let app = Self.appSummary(id: "section-app")
         let recorder = StoreListRequestRecorder()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, scope, search, offset, sort, category in
+        client.listApps = { _, scope, search, offset, sort, category, creatorHandle in
             await recorder.record(
                 scope: scope,
                 search: search,
                 offset: offset,
                 sort: sort,
-                category: category
+                category: category,
+                creatorHandle: creatorHandle
             )
             return StoreAppPage(
                 apps: [app],
@@ -571,6 +573,68 @@ struct StoreImportTests {
         #expect(requests.allSatisfy { $0.search == nil })
         #expect(requests.allSatisfy { $0.sort == .trending })
         #expect(requests.allSatisfy { $0.category == .games })
+        #expect(requests.allSatisfy { $0.creatorHandle == nil })
+    }
+
+    @MainActor
+    @Test
+    func creatorListForwardsExactHandleSortAndOffset() async {
+        let recorder = StoreListRequestRecorder()
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, scope, search, offset, sort, category, creatorHandle in
+            await recorder.record(
+                scope: scope,
+                search: search,
+                offset: offset,
+                sort: sort,
+                category: category,
+                creatorHandle: creatorHandle
+            )
+            return StoreAppPage(apps: [], hasMore: false)
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        _ = await store.loadSectionApps(
+            sort: .trending,
+            category: nil,
+            creatorHandle: "jadew",
+            offset: 30
+        )
+
+        let request = await recorder.requests.first
+        #expect(request?.scope == .discover)
+        #expect(request?.search == nil)
+        #expect(request?.offset == 30)
+        #expect(request?.sort == .trending)
+        #expect(request?.category == nil)
+        #expect(request?.creatorHandle == "jadew")
+    }
+
+    @MainActor
+    @Test
+    func cancelledSectionLoadDoesNotPresentAnError() async {
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, _, _, _, _, _, _ in
+            throw CancellationError()
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        let page = await store.loadSectionApps(sort: .trending, category: .utilities)
+
+        #expect(page == nil)
+        #expect(store.errorMessage == nil)
     }
 
     @MainActor
@@ -580,13 +644,14 @@ struct StoreImportTests {
         let second = Self.appSummary(id: "published-two")
         let recorder = StoreListRequestRecorder()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, scope, search, offset, sort, category in
+        client.listApps = { _, scope, search, offset, sort, category, creatorHandle in
             await recorder.record(
                 scope: scope,
                 search: search,
                 offset: offset,
                 sort: sort,
-                category: category
+                category: category,
+                creatorHandle: creatorHandle
             )
             if offset == 0 {
                 return StoreAppPage(apps: [first], hasMore: true)
@@ -1034,6 +1099,7 @@ private actor StoreListRequestRecorder {
         let offset: Int
         let sort: StoreAppListSort
         let category: StoreAppCategory?
+        let creatorHandle: String?
     }
 
     private(set) var requests: [Request] = []
@@ -1043,7 +1109,8 @@ private actor StoreListRequestRecorder {
         search: String?,
         offset: Int,
         sort: StoreAppListSort,
-        category: StoreAppCategory?
+        category: StoreAppCategory?,
+        creatorHandle: String?
     ) {
         requests.append(
             Request(
@@ -1051,7 +1118,8 @@ private actor StoreListRequestRecorder {
                 search: search,
                 offset: offset,
                 sort: sort,
-                category: category
+                category: category,
+                creatorHandle: creatorHandle
             )
         )
     }

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -70,7 +70,7 @@ extension ToolLibraryTests {
 
         let detail = Self.publisherAppDetail()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, _, _, _, _, _ in
+        client.listApps = { _, _, _, _, _, _, _ in
             StoreAppPage(apps: [StoreAppSummary(detail: detail)], hasMore: false)
         }
         client.fetchApp = { _, _ in detail }
@@ -115,7 +115,7 @@ extension ToolLibraryTests {
 
         let detail = Self.publisherAppDetail()
         var client = IronsmithStoreClient.unconfigured
-        client.listApps = { _, _, _, _, _, _ in
+        client.listApps = { _, _, _, _, _, _, _ in
             StoreAppPage(apps: [StoreAppSummary(detail: detail)], hasMore: false)
         }
         client.fetchApp = { _, _ in detail }


### PR DESCRIPTION
## Summary

- make creator names and handles searchable in the store
- open a creator page that lists all apps for the selected handle
- present creator identity as a neutral, hover-highlighted link with a bold display name
- add a labeled sort dropdown to category and creator listings
- omit redundant sorting from Discover's Recent and Trending pages
- preserve exact app navigation when moving between creator listings and details

## Impact

Users can discover apps by creator, navigate a creator's complete catalog, and change ordering on filtered store pages through a control that can accommodate additional sort options later.

## Validation

- `script/test.sh --filter StoreImportTests` — 22 passed
- `script/test.sh` — 539 passed
- `git diff --check`
