### PR TITLE
Add account requirement for store downloads

### DIFF
--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -411,7 +411,7 @@ extension IronsmithStoreClient {
                 let response: StoreDataEnvelope<StoreVersionDownload> = try await api.request(
                     "api/v1/stores/\(storeId)/apps/\(appId)/versions/\(versionNumber)",
                     method: "GET",
-                    authentication: .optional
+                    authentication: .required
                 )
                 return response.data
             },

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -24,6 +24,12 @@ enum StoreAppInstallDisposition {
     }
 }
 
+enum StorePendingDownloadRequest {
+    case appSummary(StoreAppSummary, mode: StoreToolImportMode)
+    case appDetail(StoreAppDetail, mode: StoreToolImportMode)
+    case version(StoreVersionMetadata, app: StoreAppDetail)
+}
+
 @MainActor
 @Observable
 final class StoreWindowStore {
@@ -49,6 +55,8 @@ final class StoreWindowStore {
     var workingVersionID: String?
     var contentRevision = 0
     var errorMessage: String?
+    var isDownloadSignInRequired = false
+    var pendingDownloadRequest: StorePendingDownloadRequest?
 
     @ObservationIgnored private let client: IronsmithStoreClient
     @ObservationIgnored private let importClient: StoreToolImportClient
@@ -259,6 +267,18 @@ final class StoreWindowStore {
         inferenceStore: InferenceStore
     ) async {
         selectedAppID = app.id
+        if mode == .get,
+            case .openExisting(let tool) = installDisposition(for: app, tools: tools)
+        {
+            routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
+            return
+        }
+        guard
+            requireAccountForDownload(
+                .appSummary(app, mode: mode),
+                inferenceStore: inferenceStore
+            )
+        else { return }
         do {
             let detail: StoreAppDetail
             if let selectedAppDetail, selectedAppDetail.id == app.id {
@@ -444,6 +464,18 @@ final class StoreWindowStore {
         inferenceStore: InferenceStore
     ) async {
         guard workingAppID == nil else { return }
+        if mode == .get,
+            case .openExisting(let tool) = installDisposition(for: app, tools: tools)
+        {
+            routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
+            return
+        }
+        guard
+            requireAccountForDownload(
+                .appDetail(app, mode: mode),
+                inferenceStore: inferenceStore
+            )
+        else { return }
         workingAppID = app.id
         workingVersionID = app.currentVersion.id
         defer {
@@ -504,6 +536,20 @@ final class StoreWindowStore {
         inferenceStore: InferenceStore
     ) async {
         guard workingAppID == nil else { return }
+        if case .openExisting(let tool) = installDisposition(
+            for: version,
+            of: app,
+            tools: tools
+        ) {
+            routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
+            return
+        }
+        guard
+            requireAccountForDownload(
+                .version(version, app: app),
+                inferenceStore: inferenceStore
+            )
+        else { return }
         workingAppID = app.id
         workingVersionID = version.id
         defer {
@@ -643,6 +689,61 @@ final class StoreWindowStore {
             try? modelContext.save()
             throw error
         }
+    }
+
+    func takePendingDownloadRequest() -> StorePendingDownloadRequest? {
+        defer { pendingDownloadRequest = nil }
+        return pendingDownloadRequest
+    }
+
+    func resumeDownload(
+        _ request: StorePendingDownloadRequest,
+        tools: [Tool],
+        modelContext: ModelContext,
+        routeStore: IronsmithRouteStore,
+        inferenceStore: InferenceStore
+    ) async {
+        switch request {
+        case .appSummary(let app, let mode):
+            await install(
+                app,
+                mode: mode,
+                tools: tools,
+                modelContext: modelContext,
+                routeStore: routeStore,
+                inferenceStore: inferenceStore
+            )
+        case .appDetail(let app, let mode):
+            await install(
+                app,
+                mode: mode,
+                tools: tools,
+                modelContext: modelContext,
+                routeStore: routeStore,
+                inferenceStore: inferenceStore
+            )
+        case .version(let version, let app):
+            await installVersion(
+                version,
+                of: app,
+                tools: tools,
+                modelContext: modelContext,
+                routeStore: routeStore,
+                inferenceStore: inferenceStore
+            )
+        }
+    }
+
+    private func requireAccountForDownload(
+        _ request: StorePendingDownloadRequest,
+        inferenceStore: InferenceStore
+    ) -> Bool {
+        guard inferenceStore.ironsmithSession != nil else {
+            pendingDownloadRequest = request
+            isDownloadSignInRequired = true
+            return false
+        }
+        return true
     }
 
     private func importAndBuild(

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import SwiftData
 import SwiftUI
 
@@ -9,12 +10,14 @@ struct StoreWindowView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(InferenceStore.self) private var inferenceStore
     @Environment(IronsmithRouteStore.self) private var routeStore
+    @Environment(\.webAuthenticationSession) private var webAuthenticationSession
     @Query(sort: \Tool.updatedAt, order: .reverse) private var tools: [Tool]
     @State private var store = StoreWindowStore()
     @State private var path: [StoreNavigationDestination] = []
     @State private var sidebarSelection: StoreSidebarSelection? = .discover
     @State private var categoryRefreshToken = 0
     @State private var searchTask: Task<Void, Never>?
+    @State private var isSigningInToIronsmith = false
 
     var body: some View {
         @Bindable var store = store
@@ -145,6 +148,42 @@ struct StoreWindowView: View {
         } message: {
             Text(store.errorMessage ?? "")
         }
+        .alert(
+            "Sign in to Download",
+            isPresented: Binding(
+                get: { store.isDownloadSignInRequired },
+                set: { isPresented in
+                    store.isDownloadSignInRequired = isPresented
+                    if !isPresented, !isSigningInToIronsmith {
+                        store.pendingDownloadRequest = nil
+                    }
+                }
+            )
+        ) {
+            Button("Cancel", role: .cancel) {
+                store.pendingDownloadRequest = nil
+            }
+            Button("Sign In") {
+                signInToIronsmith(resumeDownload: store.takePendingDownloadRequest())
+            }
+        } message: {
+            Text("Sign in with Ironsmith to download this app from the Ironsmith Store.")
+        }
+        .alert(
+            "Sign In Failed",
+            isPresented: Binding(
+                get: { inferenceStore.presentedErrorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        inferenceStore.presentedErrorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(inferenceStore.presentedErrorMessage ?? "")
+        }
     }
 
     private func openApp(_ app: StoreAppSummary) {
@@ -167,6 +206,31 @@ struct StoreWindowView: View {
             await store.install(
                 app,
                 mode: mode,
+                tools: tools,
+                modelContext: modelContext,
+                routeStore: routeStore,
+                inferenceStore: inferenceStore
+            )
+        }
+    }
+
+    private func signInToIronsmith(resumeDownload request: StorePendingDownloadRequest?) {
+        guard !isSigningInToIronsmith else { return }
+        isSigningInToIronsmith = true
+        Task {
+            let didSignIn = await inferenceStore.signInToIronsmithWithAppleOAuth { @MainActor url in
+                try await webAuthenticationSession.authenticate(
+                    using: url,
+                    callbackURLScheme: IronsmithOAuthRedirect.appCallbackScheme
+                )
+            }
+            isSigningInToIronsmith = false
+            guard didSignIn,
+                inferenceStore.ironsmithSession != nil,
+                let request
+            else { return }
+            await store.resumeDownload(
+                request,
                 tools: tools,
                 modelContext: modelContext,
                 routeStore: routeStore,

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -1,12 +1,169 @@
 import AppKit
 import CoreGraphics
 import Foundation
+import Supabase
 import SwiftData
 import Testing
 
 @testable import Ironsmith
 
 struct StoreImportTests {
+    @MainActor
+    @Test
+    func unsignedStoreDownloadRequiresAnAccountBeforeFetchingAppDetails() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let app = Self.appSummary(id: "account-required")
+        var client = IronsmithStoreClient.unconfigured
+        client.fetchApp = { _, _ in
+            Issue.record("An unsigned download must not fetch app details.")
+            throw IronsmithStoreClientError.notConfigured
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                Issue.record("An unsigned download must not import an app.")
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in
+                Issue.record("An unsigned download must not build an app.")
+            })
+        )
+
+        await store.install(
+            app,
+            mode: .get,
+            tools: [],
+            modelContext: context,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {}),
+            inferenceStore: InferenceStore()
+        )
+
+        #expect(store.isDownloadSignInRequired)
+        #expect(store.workingAppID == nil)
+        #expect(store.errorMessage == nil)
+        #expect(try context.fetch(FetchDescriptor<Tool>()).isEmpty)
+        guard case .appSummary(let pendingApp, mode: .get) = store.pendingDownloadRequest else {
+            Issue.record("Expected the Get request to remain pending for sign-in.")
+            return
+        }
+        #expect(pendingApp.id == app.id)
+    }
+
+    @MainActor
+    @Test
+    func unsignedHistoricalVersionDownloadRequiresAnAccountBeforeFetchingSource() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let source = Self.sourceCode("historical")
+        let version = Self.versionMetadata(versionNumber: 1, sourceCode: source)
+        let app = Self.appListing(sourceCode: source, versions: [version])
+        var client = IronsmithStoreClient.unconfigured
+        client.fetchVersion = { _, _, _ in
+            Issue.record("An unsigned version download must not fetch source.")
+            throw IronsmithStoreClientError.notConfigured
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                Issue.record("An unsigned version download must not import an app.")
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        await store.installVersion(
+            version,
+            of: app,
+            tools: [],
+            modelContext: context,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {}),
+            inferenceStore: InferenceStore()
+        )
+
+        #expect(store.isDownloadSignInRequired)
+        #expect(store.workingAppID == nil)
+        #expect(store.workingVersionID == nil)
+        #expect(store.errorMessage == nil)
+        guard case .version(let pendingVersion, let pendingApp) = store.pendingDownloadRequest else {
+            Issue.record("Expected the historical version request to remain pending for sign-in.")
+            return
+        }
+        #expect(pendingVersion.id == version.id)
+        #expect(pendingApp.id == app.id)
+    }
+
+    @MainActor
+    @Test
+    func unsignedRemixRequiresAnAccountAndPreservesThePendingAction() async throws {
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let app = Self.appListing(sourceCode: Self.sourceCode("remix"))
+        let store = StoreWindowStore(
+            client: .unconfigured,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                Issue.record("An unsigned remix must not import an app.")
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        await store.install(
+            app,
+            mode: .remix,
+            tools: [],
+            modelContext: context,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {}),
+            inferenceStore: InferenceStore()
+        )
+
+        #expect(store.isDownloadSignInRequired)
+        guard case .appDetail(let pendingApp, mode: .remix) = store.pendingDownloadRequest else {
+            Issue.record("Expected the Remix request to remain pending for sign-in.")
+            return
+        }
+        #expect(pendingApp.id == app.id)
+    }
+
+    @MainActor
+    @Test
+    func unsignedUserCanOpenAnAlreadyInstalledCurrentVersion() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let source = Self.sourceCode("installed")
+        let app = Self.appListing(sourceCode: source)
+        let version = Self.versionDownload(
+            appId: app.id,
+            sourceCode: source,
+            sourceSha256: IronsmithStoreClient.sha256Hex(for: source)
+        )
+        let importer = StoreToolImportClient.live(toolsDirectoryURL: root)
+        let installed = try await importer.importTool(
+            StoreToolImportRequest(app: app, version: version, mode: .get),
+            context
+        ).tool
+        let store = StoreWindowStore(
+            client: .unconfigured,
+            importClient: importer,
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        await store.install(
+            app,
+            mode: .get,
+            tools: [installed],
+            modelContext: context,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {}),
+            inferenceStore: InferenceStore()
+        )
+
+        #expect(!store.isDownloadSignInRequired)
+        #expect(store.pendingDownloadRequest == nil)
+        #expect(store.errorMessage == nil)
+    }
+
     @Test
     func storeMultipartUsesJPEGAssetContract() throws {
         let body = StoreMultipartBody(boundary: "JPEG-Test-Boundary")
@@ -741,7 +898,7 @@ struct StoreImportTests {
             tools: [existing],
             modelContext: context,
             routeStore: IronsmithRouteStore(openSettingsWindow: {}),
-            inferenceStore: InferenceStore()
+            inferenceStore: Self.signedInInferenceStore()
         )
 
         let tools = try context.fetch(FetchDescriptor<Tool>())
@@ -820,7 +977,7 @@ struct StoreImportTests {
             tools: [],
             modelContext: context,
             routeStore: IronsmithRouteStore(openSettingsWindow: {}),
-            inferenceStore: InferenceStore()
+            inferenceStore: Self.signedInInferenceStore()
         )
 
         #expect(try context.fetch(FetchDescriptor<Tool>()).isEmpty)
@@ -859,7 +1016,7 @@ struct StoreImportTests {
             tools: [],
             modelContext: context,
             routeStore: IronsmithRouteStore(openSettingsWindow: {}),
-            inferenceStore: InferenceStore()
+            inferenceStore: Self.signedInInferenceStore()
         )
 
         let failedTool = try #require(context.fetch(FetchDescriptor<Tool>()).first)
@@ -948,6 +1105,30 @@ struct StoreImportTests {
             }
         }
         """
+    }
+
+    @MainActor
+    private static func signedInInferenceStore() -> InferenceStore {
+        let store = InferenceStore()
+        let userID = UUID(uuidString: "00000000-0000-4000-8000-000000000001")!
+        store.ironsmithSession = Session(
+            accessToken: "access-token",
+            tokenType: "bearer",
+            expiresIn: 3_600,
+            expiresAt: Date().addingTimeInterval(3_600).timeIntervalSince1970,
+            refreshToken: "refresh-token",
+            user: User(
+                id: userID,
+                appMetadata: [:],
+                userMetadata: [:],
+                aud: "authenticated",
+                email: "jade@example.com",
+                createdAt: Date(),
+                role: "authenticated",
+                updatedAt: Date()
+            )
+        )
+        return store
     }
 
     private static func appSummary(id: String) -> StoreAppSummary {


### PR DESCRIPTION
## Summary

- require an Ironsmith account before Get, Update, Remix, or historical-version downloads
- keep Store browsing and opening already-installed apps available without signing in
- show a publishing-style sign-in alert, resume the pending download after authentication, and surface sign-in failures
- require authenticated version-source requests from the macOS client
- add focused regression coverage for unsigned download paths

## Validation

- `script/test.sh --filter StoreImportTests` — 26 tests passed
- `script/test.sh` — 543 tests passed
- `git diff --check`