### PR TITLE
Display Codex MCP calls and reasoning events

### DIFF
--- a/Ironsmith/Core/AgentPipeline/Clients/CodexAgentClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CodexAgentClient.swift
@@ -185,6 +185,8 @@ nonisolated enum CodexAgentEvent: Equatable, Sendable {
     case fileChange(id: String?, changes: [CodexAgentFileChange], status: String?)
     case webSearch(id: String?, search: CodexAgentWebSearch, status: String?)
     case todoList(id: String?, items: [CodexAgentTodoItem], status: String?)
+    case mcpToolCall(id: String?, call: CodexAgentMCPToolCall, status: String?)
+    case reasoning(String)
     case error(String)
 
     var diagnosticSummary: String? {
@@ -237,6 +239,15 @@ nonisolated enum CodexAgentEvent: Equatable, Sendable {
                 summary += " \(status)"
             }
             return "\(summary): \(completedCount)/\(items.count) completed"
+        case .mcpToolCall(_, let call, let status):
+            guard status != "in_progress" else { return nil }
+            var summary = "Codex MCP tool call"
+            if let status = CodexAgentStatusFormatter.displayText(status) {
+                summary += " \(status)"
+            }
+            return "\(summary): \(AgentDiagnosticsLog.compact(call.displayName, limit: 500))"
+        case .reasoning:
+            return nil
         case .error(let message):
             return "Codex error: \(AgentDiagnosticsLog.compact(message, limit: 500))"
         }
@@ -317,6 +328,26 @@ nonisolated enum CodexAgentEvent: Equatable, Sendable {
                 items: items,
                 status: stringValue(in: item, keys: ["status"]) ?? status(fromEnvelope: object)
             )
+        case "mcp_tool_call":
+            guard let server = stringValue(in: item, keys: ["server"]),
+                let tool = stringValue(in: item, keys: ["tool"])
+            else {
+                return nil
+            }
+            return .mcpToolCall(
+                id: stringValue(in: item, keys: ["id"]),
+                call: CodexAgentMCPToolCall(
+                    server: server,
+                    tool: tool,
+                    arguments: jsonText(item["arguments"])
+                ),
+                status: stringValue(in: item, keys: ["status"]) ?? status(fromEnvelope: object)
+            )
+        case "reasoning":
+            guard let text = stringValue(in: item, keys: ["text"]) else { return nil }
+            return .reasoning(text)
+        case "error":
+            return .error(message(in: item) ?? "Codex reported an error.")
         default:
             return nil
         }
@@ -391,11 +422,30 @@ nonisolated enum CodexAgentEvent: Equatable, Sendable {
             return nil
         }
     }
+
+    private static func jsonText(_ value: Any?) -> String? {
+        guard let value, JSONSerialization.isValidJSONObject(value),
+            let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys])
+        else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
 }
 
 nonisolated struct CodexAgentTodoItem: Equatable, Sendable {
     let text: String
     let completed: Bool
+}
+
+nonisolated struct CodexAgentMCPToolCall: Equatable, Sendable {
+    let server: String
+    let tool: String
+    let arguments: String?
+
+    var displayName: String {
+        "\(server).\(tool)"
+    }
 }
 
 nonisolated struct CodexAgentFileChange: Equatable, Sendable {

--- a/Ironsmith/Core/AgentPipeline/Clients/CodexAgentTranscriptReader.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CodexAgentTranscriptReader.swift
@@ -63,6 +63,8 @@ nonisolated struct CodexAgentTranscriptEntry: Equatable, Identifiable, Sendable 
         case fileChange(changes: [CodexAgentFileChange], status: String?)
         case webSearch(search: CodexAgentWebSearch, status: String?)
         case todoList(items: [CodexAgentTodoItem], status: String?)
+        case mcpToolCall(call: CodexAgentMCPToolCall, status: String?)
+        case reasoning(String)
         case error(String)
     }
 
@@ -250,7 +252,9 @@ private extension CodexAgentEvent {
         case .todoList(let id, let items, _):
             let fallbackKey = items.map(\.text).joined(separator: "|")
             return id.map { "todo-list:\($0)" } ?? "todo-list:\(fallbackKey)"
-        case .threadStarted, .turnStarted, .turnCompleted, .agentMessage, .error:
+        case .mcpToolCall(let id, let call, _):
+            return id.map { "mcp-tool-call:\($0)" } ?? "mcp-tool-call:\(call.displayName)"
+        case .threadStarted, .turnStarted, .turnCompleted, .agentMessage, .reasoning, .error:
             return nil
         }
     }
@@ -275,6 +279,10 @@ private extension CodexAgentTranscriptEntry.Kind {
             self = .webSearch(search: search, status: status)
         case .todoList(_, let items, let status):
             self = .todoList(items: items, status: status)
+        case .mcpToolCall(_, let call, let status):
+            self = .mcpToolCall(call: call, status: status)
+        case .reasoning(let text):
+            self = .reasoning(text)
         case .error(let message):
             self = .error(message)
         }

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -700,7 +700,7 @@ struct SingleFileToolGenerationRuntime {
 
         do {
             switch event {
-            case .commandExecution, .fileChange, .webSearch, .todoList:
+            case .commandExecution, .fileChange, .webSearch, .todoList, .mcpToolCall:
                 try await lifecycle.updatePhase(.generating, .repairing, nil)
             case .agentMessage:
                 try await lifecycle.updatePhase(.generating, .generatingSource, nil)
@@ -708,7 +708,7 @@ struct SingleFileToolGenerationRuntime {
                 try await lifecycle.updatePhase(.generating, .repairing, nil)
             case .error(let message):
                 try await lifecycle.updatePhase(.generating, .generatingSource, message)
-            case .threadStarted, .turnStarted:
+            case .threadStarted, .turnStarted, .reasoning:
                 break
             }
         } catch {

--- a/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
+++ b/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
@@ -297,6 +297,15 @@ private struct AgentOutputEventRow: View {
                     webSearchRow(search: search, status: status)
                 case .todoList(let items, let status):
                     todoListRow(items: items, status: status)
+                case .mcpToolCall(let call, let status):
+                    mcpToolCallRow(call: call, status: status)
+                case .reasoning(let text):
+                    Text(text)
+                        .font(.callout)
+                        .italic()
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 case .error(let message):
                     Text(message)
                         .font(.callout)
@@ -331,6 +340,10 @@ private struct AgentOutputEventRow: View {
             return "magnifyingglass"
         case .todoList:
             return "checklist"
+        case .mcpToolCall:
+            return "wrench.and.screwdriver"
+        case .reasoning:
+            return "brain.head.profile"
         case .error:
             return "exclamationmark.triangle.fill"
         case .threadStarted, .turnStarted, .turnCompleted:
@@ -358,6 +371,12 @@ private struct AgentOutputEventRow: View {
         case .todoList(_, let status):
             if status == "failed" { return .red }
             if status == "completed" { return .green }
+            return .secondary
+        case .mcpToolCall(_, let status):
+            if status == "failed" { return .red }
+            if status == "completed" { return .green }
+            return .secondary
+        case .reasoning:
             return .secondary
         case .error:
             return .red
@@ -506,6 +525,41 @@ private struct AgentOutputEventRow: View {
                             .textSelection(.enabled)
                     }
                 }
+            }
+        }
+    }
+
+    private func mcpToolCallRow(call: CodexAgentMCPToolCall, status: String?) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text("MCP tool call")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                if let statusText = CodexAgentStatusFormatter.displayText(status) {
+                    Text(statusText)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(statusStyle(status: status, exitCode: nil))
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(
+                            statusStyle(status: status, exitCode: nil).opacity(0.12),
+                            in: Capsule()
+                        )
+                }
+            }
+
+            Text(call.displayName)
+                .font(.callout.weight(.medium))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+
+            if let arguments = call.arguments {
+                Text(arguments)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+                    .lineLimit(5)
             }
         }
     }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineCodexAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineCodexAgentTests.swift
@@ -678,6 +678,11 @@ extension AgentPipelineTests {
         {"type":"item.started","item":{"id":"item_4","type":"todo_list","items":[{"text":"Create ContentView.swift","completed":false},{"text":"Build and verify","completed":false}]}}
         {"type":"item.updated","item":{"id":"item_4","type":"todo_list","items":[{"text":"Create ContentView.swift","completed":true},{"text":"Build and verify","completed":false}]}}
         {"type":"item.completed","item":{"id":"item_4","type":"todo_list","items":[{"text":"Create ContentView.swift","completed":true},{"text":"Build and verify","completed":true}]}}
+        {"type":"item.started","item":{"id":"item_5","type":"mcp_tool_call","server":"codex_apps","tool":"github.search","arguments":{"topn":5,"query":"SwiftUI"},"result":null,"error":null,"status":"in_progress"}}
+        {"type":"item.completed","item":{"id":"item_5","type":"mcp_tool_call","server":"codex_apps","tool":"github.search","arguments":{"topn":5,"query":"SwiftUI"},"result":{"content":[]},"error":null,"status":"completed"}}
+        {"type":"item.completed","item":{"id":"item_6","type":"reasoning","text":"I should verify the generated source."}}
+        {"type":"item.completed","item":{"id":"item_7","type":"reasoning","encrypted_content":"encrypted-payload"}}
+        {"type":"item.completed","item":{"id":"item_8","type":"error","message":"MCP request failed"}}
         {"type":"error","message":"apply_patch failed"}
         {"type":"turn.completed"}
         """
@@ -723,6 +728,16 @@ extension AgentPipelineTests {
                 ],
                 status: "completed"
             ),
+            .mcpToolCall(
+                call: CodexAgentMCPToolCall(
+                    server: "codex_apps",
+                    tool: "github.search",
+                    arguments: #"{"query":"SwiftUI","topn":5}"#
+                ),
+                status: "completed"
+            ),
+            .reasoning("I should verify the generated source."),
+            .error("MCP request failed"),
             .error("apply_patch failed"),
             .turnCompleted,
         ])
@@ -838,6 +853,29 @@ extension AgentPipelineTests {
                 status: "completed"
             ).diagnosticSummary == "Codex todo list Completed: 2/2 completed"
         )
+        #expect(
+            CodexAgentEvent.mcpToolCall(
+                id: "item_5",
+                call: CodexAgentMCPToolCall(
+                    server: "codex_apps",
+                    tool: "github.search",
+                    arguments: #"{"query":"SwiftUI"}"#
+                ),
+                status: "in_progress"
+            ).diagnosticSummary == nil
+        )
+        #expect(
+            CodexAgentEvent.mcpToolCall(
+                id: "item_5",
+                call: CodexAgentMCPToolCall(
+                    server: "codex_apps",
+                    tool: "github.search",
+                    arguments: #"{"query":"SwiftUI"}"#
+                ),
+                status: "completed"
+            ).diagnosticSummary == "Codex MCP tool call Completed: codex_apps.github.search"
+        )
+        #expect(CodexAgentEvent.reasoning("private thought").diagnosticSummary == nil)
     }
 
     @Test
@@ -1039,6 +1077,7 @@ extension AgentPipelineTests {
         let invocationCapture = LanguageModelInvocationCapture()
         let attachmentID = UUID()
         let persistedAttachmentCapture = PersistedAttachmentCapture()
+        let phaseCapture = ToolGenerationPhaseCapture()
         let generatedSource = """
         import SwiftUI
 
@@ -1065,6 +1104,7 @@ extension AgentPipelineTests {
                 encoding: .utf8
             )
             await request.onEvent(.commandExecution(id: nil, command: "swift build", status: "completed", exitCode: 0))
+            await request.onEvent(.reasoning("The build passed, so I should finish."))
             return CodexAgentResult(
                 stdout: "",
                 stderr: "",
@@ -1118,6 +1158,9 @@ extension AgentPipelineTests {
             lifecycle: ToolGenerationLifecycle(
                 didPersistAttachments: { ids in
                     await persistedAttachmentCapture.record(ids)
+                },
+                updatePhase: { _, phase, _ in
+                    await phaseCapture.record(phase)
                 }
             )
         )
@@ -1130,6 +1173,9 @@ extension AgentPipelineTests {
         #expect(contentView == generatedSource)
         #expect(await invocationCapture.count == 1)
         #expect(await persistedAttachmentCapture.ids == [attachmentID])
+        let phases = await phaseCapture.phases
+        let firstRepairIndex = try #require(phases.firstIndex(of: .repairing))
+        #expect(!phases[phases.index(after: firstRepairIndex)...].contains(.generatingSource))
         #expect(result.packageRootURL.lastPathComponent == "codex-demo")
         #expect(!FileManager.default.fileExists(
             atPath: toolsDirectory.appendingPathComponent("new-app").path
@@ -1356,6 +1402,15 @@ private actor PersistedAttachmentCapture {
 
     func record(_ ids: [UUID]) {
         self.ids = ids
+    }
+}
+
+private actor ToolGenerationPhaseCapture {
+    private(set) var phases: [ToolGenerationPhase] = []
+
+    func record(_ phase: ToolGenerationPhase?) {
+        guard let phase else { return }
+        phases.append(phase)
     }
 }
 


### PR DESCRIPTION
## Summary

- Parse and persist Codex MCP tool-call and reasoning events
- Show MCP calls, arguments, statuses, and reasoning in Agent Output
- Keep MCP activity in the repairing generation phase
- Add unit coverage for event parsing, diagnostics, and phase handling

## Testing

- Added and updated Swift Testing unit tests for Codex event handling and generation lifecycle behavior