### PR TITLE
Expand generated app sandbox permissions and prompt refinement

### DIFF
--- a/Ironsmith/Core/AgentPipeline/AppBundle/GeneratedAppResourcePermission.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/GeneratedAppResourcePermission.swift
@@ -148,15 +148,25 @@ nonisolated struct GeneratedAppResourcePermissions: Equatable, Sendable {
 }
 
 nonisolated enum GeneratedAppSandboxPermission: String, CaseIterable, Identifiable, Sendable {
-    case internet
+    case incomingConnections
+    case outgoingConnections = "internet"
     case userSelectedFiles
+    case downloadsFolder
+    case picturesFolder
+    case musicFolder
+    case moviesFolder
 
     var id: String { rawValue }
 
     var displayName: String {
         switch self {
-        case .internet: return "Internet"
+        case .incomingConnections: return "Incoming connections (server)"
+        case .outgoingConnections: return "Internet access"
         case .userSelectedFiles: return "User-selected files"
+        case .downloadsFolder: return "Downloads folder"
+        case .picturesFolder: return "Pictures folder"
+        case .musicFolder: return "Music folder"
+        case .moviesFolder: return "Movies folder"
         }
     }
 
@@ -166,8 +176,13 @@ nonisolated enum GeneratedAppSandboxPermission: String, CaseIterable, Identifiab
 
     var entitlementKey: String {
         switch self {
-        case .internet: return "com.apple.security.network.client"
+        case .incomingConnections: return "com.apple.security.network.server"
+        case .outgoingConnections: return "com.apple.security.network.client"
         case .userSelectedFiles: return "com.apple.security.files.user-selected.read-write"
+        case .downloadsFolder: return "com.apple.security.files.downloads.read-write"
+        case .picturesFolder: return "com.apple.security.assets.pictures.read-write"
+        case .musicFolder: return "com.apple.security.assets.music.read-write"
+        case .moviesFolder: return "com.apple.security.assets.movies.read-write"
         }
     }
 }
@@ -175,12 +190,16 @@ nonisolated enum GeneratedAppSandboxPermission: String, CaseIterable, Identifiab
 nonisolated struct GeneratedAppSandboxPermissions: Equatable, Sendable {
     var enabled: Set<GeneratedAppSandboxPermission>
 
-    init(_ enabled: some Sequence<GeneratedAppSandboxPermission> = GeneratedAppSandboxPermission.allCases) {
+    init(
+        _ enabled: some Sequence<GeneratedAppSandboxPermission> = [
+            .outgoingConnections, .userSelectedFiles,
+        ]
+    ) {
         self.enabled = Set(enabled)
     }
 
     nonisolated static var `default`: GeneratedAppSandboxPermissions {
-        GeneratedAppSandboxPermissions()
+        GeneratedAppSandboxPermissions([.outgoingConnections, .userSelectedFiles])
     }
 
     nonisolated static var none: GeneratedAppSandboxPermissions {

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -390,7 +390,8 @@ struct SingleFileToolGenerationRuntime {
             userPrompt: prompt,
             invoker: context.languageModelInvoker,
             appKind: appKind,
-            sandboxEnabled: sandboxEnabled
+            sandboxEnabled: sandboxEnabled,
+            codingAgent: context.pipelineConfiguration.codingAgent
         )
         try Task.checkCancellation()
         guard let refinedPrompt else {

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -260,19 +260,19 @@ struct ToolMetadataClient: Sendable {
         switch provider {
         case .gemini, .openAI, .ironsmith:
             return """
-            - Write one concise visual concept of 8 to 20 words.
-            - Describe only the concrete subject, any meaningful secondary object, and how they relate or are arranged.
-            - Choose a concept specific to the requested app instead of repeating the app name.
-            - Do not specify icon shape, canvas, background, palette, materials, lighting, depth, style, rendering quality, legibility, macOS conventions, or generation instructions.
-            - Good examples: A small house sheltering a calculator, with one coin orbiting the roofline. A calendar page whose date square becomes a checkmark.
-            """
+                - Write one concise visual concept of 8 to 20 words.
+                - Describe only the concrete subject, any meaningful secondary object, and how they relate or are arranged.
+                - Choose a concept specific to the requested app instead of repeating the app name.
+                - Do not specify icon shape, canvas, background, palette, materials, lighting, depth, style, rendering quality, legibility, macOS conventions, or generation instructions.
+                - Good examples: A small house sheltering a calculator, with one coin orbiting the roofline. A calendar page whose date square becomes a checkmark.
+                """
         case .automatic, .imagePlayground, .disabled:
             return """
-            - Must be a tiny object phrase, not a sentence or description.
-            - Must be 2 to 5 words.
-            - Good examples: Calculator in front of house. Gamepad with buttons.
-            - Do not mention app icon, macOS, style, text, letters, screenshots, UI, logos, or backgrounds.
-            """
+                - Must be a tiny object phrase, not a sentence or description.
+                - Must be 2 to 5 words.
+                - Good examples: Calculator in front of house. Gamepad with buttons.
+                - Do not mention app icon, macOS, style, text, letters, screenshots, UI, logos, or backgrounds.
+                """
         }
     }
 
@@ -301,6 +301,7 @@ struct ToolPromptRefinementRequest: Sendable {
     let userPrompt: String
     let appKind: ToolAppKind
     let sandboxEnabled: Bool
+    let codingAgent: ToolCodingAgent
     let invoker: ToolLanguageModelInvoker
 }
 
@@ -326,13 +327,15 @@ struct ToolPromptRefinementClient: Sendable {
         userPrompt: String,
         invoker: ToolLanguageModelInvoker,
         appKind: ToolAppKind = .window,
-        sandboxEnabled: Bool = true
+        sandboxEnabled: Bool = true,
+        codingAgent: ToolCodingAgent = .ironsmithSpark
     ) async -> String? {
         await refinePromptForRequest(
             ToolPromptRefinementRequest(
                 userPrompt: userPrompt,
                 appKind: appKind,
                 sandboxEnabled: sandboxEnabled,
+                codingAgent: codingAgent,
                 invoker: invoker
             )
         )
@@ -349,7 +352,7 @@ struct ToolPromptRefinementClient: Sendable {
                 do {
                     let session = request.invoker.makeSession(
                         for: .promptRefinement,
-                        instructions: promptRefinementInstructions
+                        instructions: promptRefinementInstructions(for: request.codingAgent)
                     )
                     let response = try await request.invoker.respond(
                         stage: .promptRefinement,
@@ -412,7 +415,37 @@ struct ToolPromptRefinementClient: Sendable {
         """
     }
 
-    nonisolated private static let promptRefinementInstructions = """
+    nonisolated static func promptRefinementInstructions(
+        for codingAgent: ToolCodingAgent
+    ) -> String {
+        switch codingAgent {
+        case .ironsmithSpark:
+            return sparkPromptRefinementInstructions
+        case .ironsmithFlame, .codex:
+            return additivePromptRefinementInstructions
+        }
+    }
+
+    nonisolated private static let additivePromptRefinementInstructions = """
+        You lightly refine a user's app request for a macOS SwiftUI AI coding agent.
+        Return only the refined prompt as one concise plain-text paragraph, without markdown, labels, commentary, code, or file names.
+
+        The refined prompt:
+        - Must be additive only: preserve every requested feature and constraint without removing, simplifying, replacing, or reprioritizing any part of the request. The user's explicit request takes priority over the defaults below.
+        - Should expand the user's request with specific product intent, core features, expected interactions, layout and visual design direction, and useful states such as empty, loading, complete, or error states when relevant.
+        - Must preserve whether the generated app is a window app or menu bar app.
+        - For menu bar apps, describe a compact menu bar popover utility with concise controls, short labels, bounded size, and a focused quick workflow. Do not expand the request into a full-size desktop app, dashboard, sidebar layout, multi-pane workflow, or large complicated UI unless explicitly requested.
+        - For window apps, describe a normal native macOS window app layout when appropriate.
+        - Prefer one polished primary workflow over many secondary workflows while preserving all requested features.
+        - If a requested feature can be implemented with a native Apple framework such as Vision for OCR, PDFKit for PDFs, or AVFoundation for media, explicitly call it out.
+        - Must describe a self-contained Mac app unless the user explicitly requests external services.
+        - May include local persistence, local files, import/export, and open/save flows when they make sense.
+        - Must not add or imply a separate backend service, custom server component, account system, iCloud, CloudKit, push notifications, analytics, subscriptions, or cross-device sync unless explicitly requested.
+        - Should emphasize a native macOS feel using appropriate SwiftUI macOS patterns and system controls.
+        - For games, drawing canvases, and highly visual toys, the refined prompt may describe custom graphics and game-like UI, but it should keep the app local-only unless the user requests network features and remain sensible for macOS pointer, keyboard, and window behavior.
+        """
+
+    nonisolated private static let sparkPromptRefinementInstructions = """
         You refine a user's app request into a compact build prompt for a macOS SwiftUI AI coding agent.
         Return only the refined prompt as plain text.
         Do not return JSON, code, markdown, bullets, labels, commentary, code, or file names.
@@ -429,7 +462,6 @@ struct ToolPromptRefinementClient: Sendable {
         - If the user lists many features, preserve the most important ones and explicitly simplify or omit the rest.
         - Prefer one polished primary workflow over many secondary workflows.
         - If a requested feature can be implemented with a native Apple framework such as Vision for OCR, PDFKit for PDFs, AVFoundation for media etc., explicitly call it out.
-        - The request states whether the generated app uses the app sandbox. Treat that as runtime context, not a reason to reduce useful scope. If sandboxed, preserve the useful workflow and phrase it with sandbox-compatible macOS patterns. If not sandboxed, the app may use what it needs to complete the user's ask, but must not make changes to the user's system unless the user asks for them or the request requires them.
         - Must describe a self-contained Mac app, with direct internet requests allowed only when the user's request requires them.
         - May include local persistence, local files, import/export, and open/save flows when they make sense.
         - Must not mention or imply a separate backend service, custom server component, account system, iCloud, CloudKit, push notifications, analytics, subscriptions, or cross-device sync.

--- a/Ironsmith/Core/Inference/ModelSelection/GenerationPreferencesStore.swift
+++ b/Ironsmith/Core/Inference/ModelSelection/GenerationPreferencesStore.swift
@@ -87,11 +87,19 @@ final class GenerationPreferencesStore {
             )
         }
     }
-    var generatedAppInternetAccessEnabled: Bool {
+    var generatedAppIncomingConnectionsEnabled: Bool {
         didSet {
             userDefaults.set(
-                generatedAppInternetAccessEnabled,
-                forKey: GeneratedAppSandboxPermission.internet.userDefaultsKey
+                generatedAppIncomingConnectionsEnabled,
+                forKey: GeneratedAppSandboxPermission.incomingConnections.userDefaultsKey
+            )
+        }
+    }
+    var generatedAppOutgoingConnectionsEnabled: Bool {
+        didSet {
+            userDefaults.set(
+                generatedAppOutgoingConnectionsEnabled,
+                forKey: GeneratedAppSandboxPermission.outgoingConnections.userDefaultsKey
             )
         }
     }
@@ -100,6 +108,38 @@ final class GenerationPreferencesStore {
             userDefaults.set(
                 generatedAppUserSelectedFileAccessEnabled,
                 forKey: GeneratedAppSandboxPermission.userSelectedFiles.userDefaultsKey
+            )
+        }
+    }
+    var generatedAppDownloadsFolderAccessEnabled: Bool {
+        didSet {
+            userDefaults.set(
+                generatedAppDownloadsFolderAccessEnabled,
+                forKey: GeneratedAppSandboxPermission.downloadsFolder.userDefaultsKey
+            )
+        }
+    }
+    var generatedAppPicturesFolderAccessEnabled: Bool {
+        didSet {
+            userDefaults.set(
+                generatedAppPicturesFolderAccessEnabled,
+                forKey: GeneratedAppSandboxPermission.picturesFolder.userDefaultsKey
+            )
+        }
+    }
+    var generatedAppMusicFolderAccessEnabled: Bool {
+        didSet {
+            userDefaults.set(
+                generatedAppMusicFolderAccessEnabled,
+                forKey: GeneratedAppSandboxPermission.musicFolder.userDefaultsKey
+            )
+        }
+    }
+    var generatedAppMoviesFolderAccessEnabled: Bool {
+        didSet {
+            userDefaults.set(
+                generatedAppMoviesFolderAccessEnabled,
+                forKey: GeneratedAppSandboxPermission.moviesFolder.userDefaultsKey
             )
         }
     }
@@ -155,16 +195,32 @@ final class GenerationPreferencesStore {
         self.generatedAppAppleEventsAccessEnabled = userDefaults.bool(
             forKey: GeneratedAppResourcePermission.appleEvents.userDefaultsKey
         )
-        self.generatedAppInternetAccessEnabled = userDefaults.object(
-            forKey: GeneratedAppSandboxPermission.internet.userDefaultsKey
+        self.generatedAppIncomingConnectionsEnabled = userDefaults.bool(
+            forKey: GeneratedAppSandboxPermission.incomingConnections.userDefaultsKey
+        )
+        self.generatedAppOutgoingConnectionsEnabled = userDefaults.object(
+            forKey: GeneratedAppSandboxPermission.outgoingConnections.userDefaultsKey
         ) == nil
             ? true
-            : userDefaults.bool(forKey: GeneratedAppSandboxPermission.internet.userDefaultsKey)
+            : userDefaults.bool(
+                forKey: GeneratedAppSandboxPermission.outgoingConnections.userDefaultsKey)
         self.generatedAppUserSelectedFileAccessEnabled = userDefaults.object(
             forKey: GeneratedAppSandboxPermission.userSelectedFiles.userDefaultsKey
         ) == nil
             ? true
             : userDefaults.bool(forKey: GeneratedAppSandboxPermission.userSelectedFiles.userDefaultsKey)
+        self.generatedAppDownloadsFolderAccessEnabled = userDefaults.bool(
+            forKey: GeneratedAppSandboxPermission.downloadsFolder.userDefaultsKey
+        )
+        self.generatedAppPicturesFolderAccessEnabled = userDefaults.bool(
+            forKey: GeneratedAppSandboxPermission.picturesFolder.userDefaultsKey
+        )
+        self.generatedAppMusicFolderAccessEnabled = userDefaults.bool(
+            forKey: GeneratedAppSandboxPermission.musicFolder.userDefaultsKey
+        )
+        self.generatedAppMoviesFolderAccessEnabled = userDefaults.bool(
+            forKey: GeneratedAppSandboxPermission.moviesFolder.userDefaultsKey
+        )
     }
 
     func isGeneratedAppResourcePermissionEnabled(_ permission: GeneratedAppResourcePermission) -> Bool {
@@ -207,19 +263,39 @@ final class GenerationPreferencesStore {
 
     func isGeneratedAppSandboxPermissionEnabled(_ permission: GeneratedAppSandboxPermission) -> Bool {
         switch permission {
-        case .internet:
-            return generatedAppInternetAccessEnabled
+        case .incomingConnections:
+            return generatedAppIncomingConnectionsEnabled
+        case .outgoingConnections:
+            return generatedAppOutgoingConnectionsEnabled
         case .userSelectedFiles:
             return generatedAppUserSelectedFileAccessEnabled
+        case .downloadsFolder:
+            return generatedAppDownloadsFolderAccessEnabled
+        case .picturesFolder:
+            return generatedAppPicturesFolderAccessEnabled
+        case .musicFolder:
+            return generatedAppMusicFolderAccessEnabled
+        case .moviesFolder:
+            return generatedAppMoviesFolderAccessEnabled
         }
     }
 
     func setGeneratedAppSandboxPermission(_ permission: GeneratedAppSandboxPermission, enabled: Bool) {
         switch permission {
-        case .internet:
-            generatedAppInternetAccessEnabled = enabled
+        case .incomingConnections:
+            generatedAppIncomingConnectionsEnabled = enabled
+        case .outgoingConnections:
+            generatedAppOutgoingConnectionsEnabled = enabled
         case .userSelectedFiles:
             generatedAppUserSelectedFileAccessEnabled = enabled
+        case .downloadsFolder:
+            generatedAppDownloadsFolderAccessEnabled = enabled
+        case .picturesFolder:
+            generatedAppPicturesFolderAccessEnabled = enabled
+        case .musicFolder:
+            generatedAppMusicFolderAccessEnabled = enabled
+        case .moviesFolder:
+            generatedAppMoviesFolderAccessEnabled = enabled
         }
     }
 }

--- a/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
@@ -128,14 +128,27 @@ struct SettingsPreferencesSectionView: View {
 private struct GeneratedAppSandboxAccessPreferencesGrid: View {
     let preferences: GenerationPreferencesStore
 
+    private static let rows: [(GeneratedAppSandboxPermission, GeneratedAppSandboxPermission?)] = [
+        (.incomingConnections, .outgoingConnections),
+        (.userSelectedFiles, .downloadsFolder),
+        (.picturesFolder, .musicFolder),
+        (.moviesFolder, nil),
+    ]
+
     var body: some View {
         Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 6) {
-            GridRow {
-                ForEach(GeneratedAppSandboxPermission.allCases) { permission in
-                    Toggle(permission.displayName, isOn: binding(for: permission))
+            ForEach(Self.rows, id: \.0) { leftPermission, rightPermission in
+                GridRow {
+                    Toggle(leftPermission.displayName, isOn: binding(for: leftPermission))
                         .toggleStyle(.checkbox)
                         .controlSize(.small)
                         .frame(width: 150, alignment: .leading)
+                    if let rightPermission {
+                        Toggle(rightPermission.displayName, isOn: binding(for: rightPermission))
+                            .toggleStyle(.checkbox)
+                            .controlSize(.small)
+                            .frame(width: 150, alignment: .leading)
+                    }
                 }
             }
         }

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -321,9 +321,9 @@ nonisolated struct StorePermissionPresentation: Identifiable, Equatable, Sendabl
         let sandbox: [Self] = settings.sandboxEnabled
             ? settings.sandboxPermissions.enabledPermissions.map { permission in
                 switch permission {
-                case .internet:
+                case .incomingConnections, .outgoingConnections:
                     Self(
-                        id: "sandbox.internet",
+                        id: "sandbox.\(permission.rawValue)",
                         title: permission.displayName,
                         explanation: "Access to network connections",
                         systemImage: "network"
@@ -334,6 +334,13 @@ nonisolated struct StorePermissionPresentation: Identifiable, Equatable, Sendabl
                         title: permission.displayName,
                         explanation: "Access to files you choose",
                         systemImage: "folder.badge.plus"
+                    )
+                case .downloadsFolder, .picturesFolder, .musicFolder, .moviesFolder:
+                    Self(
+                        id: "sandbox.\(permission.rawValue)",
+                        title: permission.displayName,
+                        explanation: "Read and write access to this folder",
+                        systemImage: "folder"
                     )
                 }
             }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
@@ -54,7 +54,7 @@ extension AgentPipelineTests {
         #expect(!(tools.first?.sandboxEnabled ?? false))
         #expect(await capture.existingToolID == existingTool.id)
         #expect(await capture.settings?.sandboxEnabled == false)
-        #expect(await capture.settings?.sandboxPermissions.enabled == [.internet, .userSelectedFiles])
+        #expect(await capture.settings?.sandboxPermissions == .default)
         #expect(await capture.settings?.resourcePermissions.enabled == [.location, .calendar])
         #expect(await capture.repairStrategy == .deterministicOnly)
         #expect(await runCapture.ranToolIDs.isEmpty)

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
@@ -244,7 +244,6 @@ extension AgentPipelineTests {
             #expect(instructions.contains("For window apps, describe a normal native macOS window app layout"))
             #expect(instructions.contains("Prefer one polished primary workflow over many secondary workflows"))
             #expect(instructions.contains("native Apple framework such as Vision for OCR, PDFKit for PDFs, or AVFoundation"))
-            #expect(instructions.contains("Treat that as runtime context, not a reason to reduce useful scope."))
             #expect(instructions.contains("Must describe a self-contained Mac app"))
             #expect(instructions.contains("May include local persistence, local files, import/export"))
             #expect(instructions.contains("Must not add or imply a separate backend service"))

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
@@ -224,6 +224,38 @@ extension AgentPipelineTests {
         )
     }
 
+    @Test
+    func promptRefinementScopeMatchesCodingAgentCapacity() {
+        let spark = ToolPromptRefinementClient.promptRefinementInstructions(
+            for: .ironsmithSpark)
+        let flame = ToolPromptRefinementClient.promptRefinementInstructions(
+            for: .ironsmithFlame)
+        let codex = ToolPromptRefinementClient.promptRefinementInstructions(for: .codex)
+
+        #expect(spark.contains("Choose at most 3 core user-facing features."))
+        #expect(spark.contains("explicitly simplify or omit the rest."))
+        #expect(spark.contains("Must be under 750 characters."))
+        for instructions in [flame, codex] {
+            #expect(instructions.contains("Must be additive only: preserve every requested feature and constraint"))
+            #expect(instructions.contains("without removing, simplifying, replacing, or reprioritizing"))
+            #expect(instructions.contains("specific product intent, core features, expected interactions"))
+            #expect(instructions.contains("Must preserve whether the generated app is a window app or menu bar app."))
+            #expect(instructions.contains("For menu bar apps, describe a compact menu bar popover utility"))
+            #expect(instructions.contains("For window apps, describe a normal native macOS window app layout"))
+            #expect(instructions.contains("Prefer one polished primary workflow over many secondary workflows"))
+            #expect(instructions.contains("native Apple framework such as Vision for OCR, PDFKit for PDFs, or AVFoundation"))
+            #expect(instructions.contains("Treat that as runtime context, not a reason to reduce useful scope."))
+            #expect(instructions.contains("Must describe a self-contained Mac app"))
+            #expect(instructions.contains("May include local persistence, local files, import/export"))
+            #expect(instructions.contains("Must not add or imply a separate backend service"))
+            #expect(instructions.contains("Should emphasize a native macOS feel"))
+            #expect(instructions.contains("games, drawing canvases, and highly visual toys"))
+            #expect(!instructions.contains("Choose at most 3 core user-facing features."))
+            #expect(!instructions.contains("explicitly simplify or omit the rest."))
+            #expect(!instructions.contains("Must be under 750 characters."))
+        }
+    }
+
     @MainActor
     @Test
     func livePromptRefinementClientStreamsPlainTextResponse() async throws {

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -144,14 +144,14 @@ extension AgentPipelineTests {
             sandboxEnabled: false,
             appKind: .menuBar,
             menuBarSystemImage: "timer",
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
             resourcePermissions: GeneratedAppResourcePermissions([.camera, .microphone]),
             packageRootPath: "/tmp/timer"
         )
 
         #expect(tool.appKind == .menuBar)
         #expect(tool.validatedMenuBarSystemImage == "timer")
-        #expect(tool.storedSandboxPermissions?.enabled == [.internet])
+        #expect(tool.storedSandboxPermissions?.enabled == [.outgoingConnections])
         #expect(tool.storedResourcePermissions?.enabled == [.camera, .microphone])
 
         tool.storedSandboxPermissions = GeneratedAppSandboxPermissions.none
@@ -201,7 +201,7 @@ extension AgentPipelineTests {
             appKind: .menuBar,
             menuBarSystemImage: "timer",
             sandboxEnabled: true,
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet, .userSelectedFiles]),
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections, .userSelectedFiles]),
             resourcePermissions: GeneratedAppResourcePermissions([.camera])
         )
         let backup = try ToolVersionBackupClient.live.stageCurrentVersion(
@@ -259,7 +259,7 @@ extension AgentPipelineTests {
         #expect(restored.appKind == .menuBar)
         #expect(restored.menuBarSystemImage == "timer")
         #expect(restored.sandboxEnabled)
-        #expect(restored.sandboxPermissions.enabled == [.internet])
+        #expect(restored.sandboxPermissions.enabled == [.outgoingConnections])
         #expect(restored.resourcePermissions.enabled == [.microphone, .camera])
     }
 
@@ -671,12 +671,30 @@ extension AgentPipelineTests {
 
         let withoutUserSelectedFiles = try await buildEntitlements(
             executableName: "NoFilesTool",
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet])
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections])
         )
         #expect(withoutUserSelectedFiles["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(withoutUserSelectedFiles["com.apple.security.network.client"] as? Bool == true)
         #expect(
             withoutUserSelectedFiles["com.apple.security.files.user-selected.read-write"] == nil)
+
+        let expandedAccess = try await buildEntitlements(
+            executableName: "ExpandedAccessTool",
+            sandboxPermissions: GeneratedAppSandboxPermissions(
+                GeneratedAppSandboxPermission.allCases)
+        )
+        let expectedEntitlements = [
+            "com.apple.security.network.server",
+            "com.apple.security.network.client",
+            "com.apple.security.files.user-selected.read-write",
+            "com.apple.security.files.downloads.read-write",
+            "com.apple.security.assets.pictures.read-write",
+            "com.apple.security.assets.music.read-write",
+            "com.apple.security.assets.movies.read-write",
+        ]
+        for entitlement in expectedEntitlements {
+            #expect(expandedAccess[entitlement] as? Bool == true)
+        }
     }
 
     @MainActor
@@ -705,7 +723,7 @@ extension AgentPipelineTests {
 
         let request = ToolAppBundleRequest.forToolPreservingExistingBundlePermissions(tool)
 
-        #expect(request.sandboxPermissions.contains(.internet))
+        #expect(request.sandboxPermissions.contains(.outgoingConnections))
         #expect(!(request.sandboxPermissions.contains(.userSelectedFiles)))
         #expect(request.category == .music)
         #expect(request.versionNumber == 3)

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
@@ -61,7 +61,7 @@ extension AgentPipelineTests {
         )
 
         let resourcePermissions = GeneratedAppResourcePermissions([.location, .calendar])
-        let sandboxPermissions = GeneratedAppSandboxPermissions([.internet])
+        let sandboxPermissions = GeneratedAppSandboxPermissions([.outgoingConnections])
         let settings = ToolGenerationSettings(
             appKind: .menuBar,
             sandboxPermissions: sandboxPermissions,

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineToolLibraryStoreTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineToolLibraryStoreTests.swift
@@ -54,7 +54,7 @@ extension AgentPipelineTests {
         #expect(tools.first?.packageRootPath == packageRoot.path)
         #expect(store.prompt == "Make a mortgage calculator")
         #expect(!(store.isGenerating))
-        #expect(await generationCapture.settings?.sandboxPermissions.enabled == [.internet, .userSelectedFiles])
+        #expect(await generationCapture.settings?.sandboxPermissions == .default)
         #expect(await generationCapture.settings?.resourcePermissions.enabled == [.microphone, .camera])
         #expect(await runCapture.ranToolIDs.isEmpty)
 

--- a/IronsmithTests/Core/Inference/InferenceGenerationPreferenceTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceGenerationPreferenceTests.swift
@@ -404,23 +404,28 @@ extension InferenceTests {
 
     @MainActor
     @Test
-    func generatedAppSandboxPermissionPreferencesDefaultOnAndPersist() {
+    func generatedAppSandboxPermissionPreferencesPreserveLegacyDefaultsAndPersist() {
         let suiteName = "IronsmithTests.GeneratedAppSandboxPermissions.\(UUID().uuidString)"
         let userDefaults = UserDefaults(suiteName: suiteName)!
         userDefaults.removePersistentDomain(forName: suiteName)
 
         let preferences = GenerationPreferencesStore(userDefaults: userDefaults)
-        for permission in GeneratedAppSandboxPermission.allCases {
-            #expect(preferences.isGeneratedAppSandboxPermissionEnabled(permission))
-        }
         #expect(preferences.generatedAppSandboxPermissions == .default)
+        #expect(
+            preferences.generatedAppSandboxPermissions.enabled
+                == [.outgoingConnections, .userSelectedFiles]
+        )
 
-        preferences.setGeneratedAppSandboxPermission(.internet, enabled: false)
+        preferences.setGeneratedAppSandboxPermission(.downloadsFolder, enabled: true)
 
         let reloadedPreferences = GenerationPreferencesStore(userDefaults: userDefaults)
-        #expect(!(reloadedPreferences.isGeneratedAppSandboxPermissionEnabled(.internet)))
+        #expect(reloadedPreferences.isGeneratedAppSandboxPermissionEnabled(.outgoingConnections))
         #expect(reloadedPreferences.isGeneratedAppSandboxPermissionEnabled(.userSelectedFiles))
-        #expect(reloadedPreferences.generatedAppSandboxPermissions.enabled == [.userSelectedFiles])
+        #expect(reloadedPreferences.isGeneratedAppSandboxPermissionEnabled(.downloadsFolder))
+        #expect(
+            reloadedPreferences.generatedAppSandboxPermissions.enabled
+                == [.outgoingConnections, .userSelectedFiles, .downloadsFolder]
+        )
     }
 
     @Test

--- a/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
@@ -725,7 +725,7 @@ extension InferenceTests {
 
         inferenceStore.pullOllamaRecommendedModel(entry, provider: provider)
 
-        await Self.eventually(timeoutNanoseconds: 5_000_000_000) {
+        await Self.eventually(timeoutNanoseconds: 15_000_000_000) {
             inferenceStore.ollamaPullStates.isEmpty &&
                 inferenceStore.remoteModels.contains { $0.identifier == entry.identifier }
         }

--- a/IronsmithTests/Core/Persistence/PersistenceTests.swift
+++ b/IronsmithTests/Core/Persistence/PersistenceTests.swift
@@ -190,7 +190,7 @@ struct PersistenceTests {
                 sandboxEnabled: false,
                 appKind: .menuBar,
                 menuBarSystemImage: "timer",
-                sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+                sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
                 resourcePermissions: GeneratedAppResourcePermissions([.camera, .microphone]),
                 packageRootPath: "/tmp/menu-timer",
                 generationState: .stopped,
@@ -224,7 +224,7 @@ struct PersistenceTests {
         #expect(tool.generationPhase == .generatingSource)
         #expect(tool.generationMode == .edit)
         #expect(tool.pendingPrompt == "Make it better")
-        #expect(tool.storedSandboxPermissions?.enabled == [.internet])
+        #expect(tool.storedSandboxPermissions?.enabled == [.outgoingConnections])
         #expect(tool.storedResourcePermissions?.enabled == [.camera, .microphone])
         #expect(tool.storeId == nil)
         #expect(tool.storeAppId == nil)

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -877,13 +877,13 @@ struct StoreImportTests {
             sourceCode: source,
             settings: ToolGenerationSettings(
                 sandboxEnabled: true,
-                sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+                sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
                 resourcePermissions: GeneratedAppResourcePermissions([.microphone])
             )
         )
         let items = StorePermissionPresentation.items(for: permissionVersion)
 
-        #expect(items.map(\.title) == ["Internet", "Microphone"])
+        #expect(items.map(\.title) == ["Internet access", "Microphone"])
         #expect(
             items.map(\.explanation) == [
                 "Access to network connections",

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -112,7 +112,7 @@ extension ToolLibraryTests {
         toolLibraryState.initializeNextGenerationSettingsIfNeeded(defaults)
         toolLibraryState.appKind = .menuBar
         toolLibraryState.sandboxEnabled = false
-        toolLibraryState.sandboxPermissions = GeneratedAppSandboxPermissions([.internet])
+        toolLibraryState.sandboxPermissions = GeneratedAppSandboxPermissions([.outgoingConnections])
         toolLibraryState.resourcePermissions = GeneratedAppResourcePermissions([.camera])
         toolLibraryState.rememberCurrentGenerationSettingsForNextGeneration()
 
@@ -129,7 +129,7 @@ extension ToolLibraryTests {
         #expect(!(toolLibraryState.isSelected(tool)))
         #expect(toolLibraryState.appKind == .menuBar)
         #expect(!(toolLibraryState.sandboxEnabled))
-        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.outgoingConnections])
         #expect(toolLibraryState.resourcePermissions.enabled == [.camera])
     }
 
@@ -142,7 +142,7 @@ extension ToolLibraryTests {
             sandboxEnabled: false,
             appKind: .menuBar,
             menuBarSystemImage: "timer",
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
             resourcePermissions: GeneratedAppResourcePermissions([.camera]),
             packageRootPath: "/tmp/menu-tool"
         )
@@ -162,7 +162,7 @@ extension ToolLibraryTests {
         #expect(toolLibraryState.appKind == .menuBar)
         #expect(toolLibraryState.menuBarSystemImage == "timer")
         #expect(toolLibraryState.sandboxEnabled)
-        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.outgoingConnections])
         #expect(toolLibraryState.resourcePermissions.enabled == [.microphone])
     }
 
@@ -175,7 +175,7 @@ extension ToolLibraryTests {
             resourcePermissions: GeneratedAppResourcePermissions([.location])
         )
         let updatedDefaults = ToolGenerationSettings(
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
             resourcePermissions: GeneratedAppResourcePermissions([.camera])
         )
 
@@ -184,14 +184,14 @@ extension ToolLibraryTests {
         #expect(toolLibraryState.resourcePermissions.enabled == [.location])
 
         toolLibraryState.initializeNextGenerationSettingsIfNeeded(updatedDefaults)
-        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.outgoingConnections])
         #expect(toolLibraryState.resourcePermissions.enabled == [.camera])
 
         toolLibraryState.resourcePermissions = GeneratedAppResourcePermissions([.microphone])
         toolLibraryState.rememberCurrentGenerationSettingsForNextGeneration()
         toolLibraryState.initializeNextGenerationSettingsIfNeeded(initialDefaults)
 
-        #expect(toolLibraryState.sandboxPermissions.enabled == [.internet])
+        #expect(toolLibraryState.sandboxPermissions.enabled == [.outgoingConnections])
         #expect(toolLibraryState.resourcePermissions.enabled == [.microphone])
     }
 
@@ -222,7 +222,7 @@ extension ToolLibraryTests {
             packageRootPath: "/tmp/menu-timer"
         )
         let defaults = ToolGenerationSettings(
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet, .userSelectedFiles]),
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections, .userSelectedFiles]),
             resourcePermissions: GeneratedAppResourcePermissions([.location])
         )
 
@@ -249,7 +249,7 @@ extension ToolLibraryTests {
         )
         let entitlementsData = try PropertyListSerialization.data(
             fromPropertyList: [
-                GeneratedAppSandboxPermission.internet.entitlementKey: true
+                GeneratedAppSandboxPermission.outgoingConnections.entitlementKey: true
             ],
             format: .xml,
             options: 0
@@ -484,7 +484,7 @@ extension ToolLibraryTests {
             appKind: .menuBar,
             menuBarSystemImage: "timer",
             sandboxEnabled: false,
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
             resourcePermissions: GeneratedAppResourcePermissions([.microphone])
         )
         try #"Text("previous")"#.write(to: contentViewURL, atomically: true, encoding: .utf8)
@@ -571,7 +571,7 @@ extension ToolLibraryTests {
             appKind: .menuBar,
             menuBarSystemImage: "timer",
             sandboxEnabled: false,
-            sandboxPermissions: GeneratedAppSandboxPermissions([.internet]),
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
             resourcePermissions: GeneratedAppResourcePermissions([.microphone])
         )
 
@@ -619,7 +619,7 @@ extension ToolLibraryTests {
         #expect(tool.appKind == .menuBar)
         #expect(tool.validatedMenuBarSystemImage == "timer")
         #expect(!(tool.sandboxEnabled))
-        #expect(tool.storedSandboxPermissions?.enabled == [.internet])
+        #expect(tool.storedSandboxPermissions?.enabled == [.outgoingConnections])
         #expect(tool.storedResourcePermissions?.enabled == [.microphone])
         #expect(rebuiltAppEntrySource.contains("MenuBarExtra"))
         #expect(!(rebuiltAppEntrySource.contains("WindowGroup")))


### PR DESCRIPTION
## Summary
- Add separate incoming/outgoing network permissions and folder-specific sandbox entitlements
- Preserve existing defaults while exposing expanded access settings and store presentation
- Tailor prompt refinement instructions to each coding agent’s capacity
- Update coverage for permissions, entitlements, preferences, persistence, and prompt scope