### PR TITLE
Improve Store remix attribution and publishing flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -6,10 +6,9 @@ struct StoreAppDetailView: View {
     let isWorking: Bool
     let workingVersionID: String?
     let installDisposition: StoreAppInstallDisposition
-    let canRemix: Bool
     let versionInstallDisposition: (StoreAppDetail, StoreVersionMetadata) -> StoreAppInstallDisposition
     let onGet: (StoreAppDetail) -> Void
-    let onRemix: (StoreAppDetail) -> Void
+    let onOpenRemix: (StoreRemixMetadata) -> Void
     let onOpenCreator: (String, String) -> Void
     let onInstallVersion: (StoreAppDetail, StoreVersionMetadata) -> Void
 
@@ -24,12 +23,14 @@ struct StoreAppDetailView: View {
                             app: app,
                             isWorking: isWorking,
                             installDisposition: installDisposition,
-                            canRemix: canRemix,
-                            onGet: { onGet(app) },
-                            onRemix: { onRemix(app) }
+                            onGet: { onGet(app) }
                         )
 
-                        StoreDetailMetadataStrip(app: app, onOpenCreator: onOpenCreator)
+                        StoreDetailMetadataStrip(
+                            app: app,
+                            onOpenCreator: onOpenCreator,
+                            onOpenRemix: onOpenRemix
+                        )
 
                         if let screenshot = app.screenshots.first {
                             StoreDetailScreenshot(asset: screenshot)
@@ -73,9 +74,7 @@ private struct StoreDetailHeroView: View {
     let app: StoreAppDetail
     let isWorking: Bool
     let installDisposition: StoreAppInstallDisposition
-    let canRemix: Bool
     let onGet: () -> Void
-    let onRemix: () -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 18) {
@@ -93,13 +92,6 @@ private struct StoreDetailHeroView: View {
                         .buttonBorderShape(.capsule)
                         .controlSize(.small)
 
-                    if canRemix {
-                        Button("Remix", action: onRemix)
-                            .buttonStyle(.bordered)
-                            .buttonBorderShape(.capsule)
-                            .controlSize(.small)
-                    }
-
                     if isWorking {
                         ProgressView()
                             .controlSize(.small)
@@ -116,9 +108,13 @@ private struct StoreDetailHeroView: View {
 private struct StoreDetailMetadataStrip: View {
     let app: StoreAppDetail
     let onOpenCreator: (String, String) -> Void
+    let onOpenRemix: (StoreRemixMetadata) -> Void
 
     private var columns: [GridItem] {
-        [GridItem(.adaptive(minimum: 140), spacing: 16, alignment: .top)]
+        if app.remix != nil {
+            return [GridItem(.adaptive(minimum: 128), spacing: 12, alignment: .top)]
+        }
+        return [GridItem(.adaptive(minimum: 140), spacing: 16, alignment: .top)]
     }
 
     var body: some View {
@@ -131,6 +127,13 @@ private struct StoreDetailMetadataStrip: View {
                 )
             } else {
                 StoreDetailMetadataItem(title: "Creator", value: app.creatorDisplayText)
+            }
+            if let remix = app.remix {
+                StoreDetailLinkedMetadataItem(
+                    title: "Remixed From",
+                    value: remix.appName,
+                    action: { onOpenRemix(remix) }
+                )
             }
             StoreDetailMetadataItem(
                 title: "Version",
@@ -161,6 +164,38 @@ private struct StoreDetailCreatorMetadataItem: View {
             Button(action: action) {
                 Text("\(Text(displayName).bold()) · @\(handle)")
                     .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
+                    .background {
+                        RoundedRectangle(cornerRadius: 4, style: .continuous)
+                            .fill(isHovering ? Color.primary.opacity(0.08) : Color.clear)
+                    }
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .onHover { isHovering = $0 }
+            .animation(.easeOut(duration: 0.12), value: isHovering)
+        }
+    }
+}
+
+private struct StoreDetailLinkedMetadataItem: View {
+    let title: String
+    let value: String
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.tertiary)
+            Button(action: action) {
+                Text(value)
+                    .font(.callout.weight(.medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(2)
                     .padding(.horizontal, 4)

--- a/Ironsmith/Features/Store/StoreToolImportClient.swift
+++ b/Ironsmith/Features/Store/StoreToolImportClient.swift
@@ -11,7 +11,6 @@ struct StoreToolImportRequest: Sendable {
     let version: StoreVersionDownload
     let mode: StoreToolImportMode
     var displayName: String? = nil
-    var isOwnApp = false
     var initialGenerationState: ToolGenerationState = .ready
 }
 
@@ -92,7 +91,7 @@ extension StoreToolImportClient {
                 storeVersionNumber: request.version.versionNumber,
                 storeSourceSha256: request.version.sourceSha256,
                 storeImportedAt: now,
-                storeRemixedFromVersionId: request.isOwnApp ? nil : request.version.id,
+                storeRemixedFromVersionId: request.version.id,
                 createdAt: now,
                 updatedAt: now
             )

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -385,6 +385,7 @@ final class StoreWindowStore {
         }
         selectedAppID = appID
         selectedAppDetail = nil
+        isLoadingDetail = true
         Task {
             await loadDetail(storeID: storeID, appID: appID)
         }
@@ -813,7 +814,6 @@ final class StoreWindowStore {
     }
 
     private func loadDetail(storeID: String, appID: String) async {
-        isLoadingDetail = true
         defer {
             if selectedAppID == appID {
                 isLoadingDetail = false

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -11,7 +11,7 @@ enum StoreAppInstallDisposition {
         switch self {
         case .openExisting: "Open"
         case .updateExisting: "Update"
-        case .createCopy: "Get"
+        case .createCopy: "Download"
         }
     }
 
@@ -390,10 +390,6 @@ final class StoreWindowStore {
         }
     }
 
-    func isOwnPublishedApp(_ app: StoreAppDetail) -> Bool {
-        publishedApps.contains { $0.id == app.id }
-    }
-
     func installDisposition(
         for app: StoreAppSummary,
         tools: [Tool]
@@ -486,7 +482,6 @@ final class StoreWindowStore {
             if inferenceStore.ironsmithSession != nil {
                 await refreshPublished(showLoadingIndicator: false)
             }
-            let isOwnApp = isOwnPublishedApp(app)
             if mode == .get {
                 switch installDisposition(for: app, tools: tools) {
                 case .openExisting(let tool):
@@ -496,7 +491,6 @@ final class StoreWindowStore {
                     try await updateExistingTool(
                         tool,
                         from: app,
-                        isOwnApp: isOwnApp,
                         modelContext: modelContext,
                         routeStore: routeStore,
                         inferenceStore: inferenceStore
@@ -517,7 +511,6 @@ final class StoreWindowStore {
                 app: app,
                 mode: mode,
                 displayName: nil,
-                isOwnApp: isOwnApp,
                 modelContext: modelContext,
                 routeStore: routeStore
             )
@@ -592,7 +585,6 @@ final class StoreWindowStore {
                 app: app,
                 mode: .get,
                 displayName: displayName,
-                isOwnApp: isOwnPublishedApp(app),
                 modelContext: modelContext,
                 routeStore: routeStore
             )
@@ -625,7 +617,6 @@ final class StoreWindowStore {
     private func updateExistingTool(
         _ tool: Tool,
         from app: StoreAppDetail,
-        isOwnApp: Bool,
         modelContext: ModelContext,
         routeStore: IronsmithRouteStore,
         inferenceStore: InferenceStore
@@ -659,7 +650,7 @@ final class StoreWindowStore {
                 app.currentVersion.versionNumber
             )
             try IronsmithStoreClient.verifySourceHash(version)
-            try writeStoreVersion(version, app: app, isOwnApp: isOwnApp, to: tool)
+            try writeStoreVersion(version, app: app, to: tool)
             try await StoreToolImportClient.cacheIconIfAvailable(
                 app: app,
                 layout: tool.packageLayout
@@ -751,7 +742,6 @@ final class StoreWindowStore {
         app: StoreAppDetail,
         mode: StoreToolImportMode,
         displayName: String?,
-        isOwnApp: Bool,
         modelContext: ModelContext,
         routeStore: IronsmithRouteStore
     ) async throws {
@@ -761,7 +751,6 @@ final class StoreWindowStore {
                 version: version,
                 mode: mode,
                 displayName: displayName,
-                isOwnApp: isOwnApp,
                 initialGenerationState: mode == .get ? .generating : .ready
             ),
             modelContext
@@ -792,7 +781,6 @@ final class StoreWindowStore {
     private func writeStoreVersion(
         _ version: StoreVersionDownload,
         app: StoreAppDetail,
-        isOwnApp: Bool,
         to tool: Tool
     ) throws {
         let layout = tool.packageLayout
@@ -805,7 +793,7 @@ final class StoreWindowStore {
             settings: settings
         )
         tool.applyGenerationSettings(settings)
-        applyStoreLinkage(app, version: version, isOwnApp: isOwnApp, to: tool)
+        applyStoreLinkage(app, version: version, to: tool)
     }
 
     private func restoreToolSource(
@@ -844,7 +832,6 @@ final class StoreWindowStore {
     private func applyStoreLinkage(
         _ app: StoreAppDetail,
         version: StoreVersionDownload,
-        isOwnApp: Bool,
         to tool: Tool
     ) {
         tool.storeId = app.storeId
@@ -853,7 +840,7 @@ final class StoreWindowStore {
         tool.storeVersionNumber = version.versionNumber
         tool.storeSourceSha256 = version.sourceSha256
         tool.storeImportedAt = Date()
-        tool.storeRemixedFromVersionId = isOwnApp ? nil : version.id
+        tool.storeRemixedFromVersionId = version.id
         tool.updatedAt = Date()
     }
 

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -75,7 +75,8 @@ struct StoreWindowView: View {
                             modelContext: modelContext,
                             routeStore: routeStore,
                             inferenceStore: inferenceStore,
-                            onOpenCreator: openCreator
+                            onOpenCreator: openCreator,
+                            onOpenRemix: openRemix
                         )
                     case .section(let section):
                         StoreSectionAppsView(
@@ -201,6 +202,13 @@ struct StoreWindowView: View {
         )
     }
 
+    private func openRemix(_ remix: StoreRemixMetadata) {
+        store.select(storeID: remix.storeId, appID: remix.appId)
+        path.append(
+            .app(StoreAppRoute(appID: remix.appId, storeID: remix.storeId))
+        )
+    }
+
     private func install(_ app: StoreAppSummary, mode: StoreToolImportMode = .get) {
         Task {
             await store.install(
@@ -299,6 +307,11 @@ private struct StoreAppRoute: Hashable {
     init(app: StoreAppSummary) {
         appID = app.id
         storeID = app.storeId
+    }
+
+    init(appID: String, storeID: String) {
+        self.appID = appID
+        self.storeID = storeID
     }
 }
 
@@ -904,6 +917,7 @@ private struct StoreAppDetailDestinationView: View {
     let routeStore: IronsmithRouteStore
     let inferenceStore: InferenceStore
     let onOpenCreator: (String, String) -> Void
+    let onOpenRemix: (StoreRemixMetadata) -> Void
 
     var body: some View {
         StoreAppDetailView(
@@ -914,7 +928,6 @@ private struct StoreAppDetailDestinationView: View {
             installDisposition: detail.map {
                 store.installDisposition(for: $0, tools: tools)
             } ?? .createCopy,
-            canRemix: detail.map { !store.isOwnPublishedApp($0) } ?? false,
             versionInstallDisposition: { app, version in
                 store.installDisposition(for: version, of: app, tools: tools)
             },
@@ -930,18 +943,7 @@ private struct StoreAppDetailDestinationView: View {
                     )
                 }
             },
-            onRemix: { app in
-                Task {
-                    await store.install(
-                        app,
-                        mode: .remix,
-                        tools: tools,
-                        modelContext: modelContext,
-                        routeStore: routeStore,
-                        inferenceStore: inferenceStore
-                    )
-                }
-            },
+            onOpenRemix: onOpenRemix,
             onOpenCreator: onOpenCreator,
             onInstallVersion: { app, version in
                 Task {

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -121,6 +121,10 @@ struct StoreWindowView: View {
                 Task { await store.refreshPublished() }
             }
         }
+        .onChange(of: path) { _, path in
+            guard case .app(let appRoute) = path.last else { return }
+            store.select(storeID: appRoute.storeID, appID: appRoute.appID)
+        }
         .onChange(of: store.contentRevision) { _, _ in
             Task { await refreshStoreContent() }
         }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -86,6 +86,10 @@ struct ToolLibraryPopoverView: View {
         .task(id: restoreAvailabilityRefreshID) {
             await toolLibraryStore.refreshRestoreAvailability(for: tools)
         }
+        .task(id: storeSourceChangesRefreshID) {
+            guard isStoreFeatureEnabled else { return }
+            await storePublisher.refreshStoreSourceChanges(for: tools)
+        }
         .task(id: publishedStoreLinkRefreshID) {
             guard isStoreFeatureEnabled else {
                 await storePublisher.refreshPublishedStoreApps(
@@ -438,6 +442,7 @@ struct ToolLibraryPopoverView: View {
             canRevert: toolLibraryStore.canRestorePreviousVersion(tool),
             showsStoreActions: isStoreFeatureEnabled,
             canUpdateStoreVersion: canUpdateStoreVersion(for: tool),
+            hasStoreSourceChanges: storePublisher.hasStoreSourceChanges(for: tool),
             activeCodingAgent: toolLibraryStore.activeCodingAgent(for: tool),
             canShowAgentOutput: toolLibraryStore.canShowAgentOutput(for: tool)
         )
@@ -582,7 +587,7 @@ struct ToolLibraryPopoverView: View {
         if let tool = tools.first(where: { $0.id == storePublisher.publishingToolID }) {
             ToolLibraryStorePublishSheetView(
                 tool: tool,
-                isUpdatingPublishedListing: canUpdateStoreVersion(for: tool),
+                isUpdatingPublishedListing: storePublisher.isUpdatingPublishedListing,
                 publishShortDescription: $storePublisher.publishShortDescription,
                 publishDescription: $storePublisher.publishDescription,
                 publishCategory: $storePublisher.publishCategory,
@@ -642,6 +647,13 @@ struct ToolLibraryPopoverView: View {
     private var runningApplicationsRefreshID: String {
         let toolIDs = tools.map(\.id.uuidString).sorted().joined(separator: "|")
         return "\(menuBarPopoverPresentationStore.showCount)|\(toolIDs)"
+    }
+
+    private var storeSourceChangesRefreshID: [String] {
+        [isStoreFeatureEnabled ? "store-on" : "store-off"]
+            + tools.map {
+                "\($0.id.uuidString)-\($0.updatedAt.timeIntervalSinceReferenceDate)-\($0.storeSourceSha256 ?? "")"
+            }
     }
 
     private var publishedStoreLinkRefreshID: String {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -35,12 +35,27 @@ struct ToolLibraryStorePublishSheetView: View {
                     }
             }
             field("Description") {
-                TextField(
-                    "Describe what your app does and how people can use it",
-                    text: $publishDescription,
-                    axis: .vertical
-                )
-                    .lineLimit(3...5)
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $publishDescription)
+                        .font(.body)
+                        .scrollContentBackground(.hidden)
+                        .padding(4)
+
+                    if publishDescription.isEmpty {
+                        Text("Describe what your app does and how people can use it")
+                            .font(.body)
+                            .foregroundStyle(.tertiary)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 8)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .frame(minHeight: 100, maxHeight: 160)
+                .background(.background, in: RoundedRectangle(cornerRadius: 5))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 5)
+                        .strokeBorder(.quaternary)
+                }
             }
             if !isUpdatingPublishedListing {
                 field("Category") {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -194,7 +194,12 @@ final class ToolLibraryStorePublisher {
                 contentsOf: tool.packageLayout.cachedAppIconThumbnailJPEGURL
             )
             let app: StoreAppDetail
-            if let linkedApp = linkedPublishedApp(for: tool) {
+            let linkedApp = linkedPublishedApp(for: tool)
+            if let linkedApp {
+                let remixedFromVersionId =
+                    tool.storeRemixedFromVersionId == tool.storeVersionId
+                    ? nil
+                    : tool.storeRemixedFromVersionId
                 app = try await storeClient.publishVersion(
                     StoreVersionPublicationRequest(
                         storeId: linkedApp.storeId,
@@ -209,7 +214,7 @@ final class ToolLibraryStorePublisher {
                         iconThumbnailJPEG: iconThumbnailJPEG,
                         screenshotJPEGs: publishScreenshotData.map { [$0] } ?? [],
                         replaceScreenshots: publishScreenshotData != nil,
-                        remixedFromVersionId: tool.storeRemixedFromVersionId
+                        remixedFromVersionId: remixedFromVersionId
                     )
                 )
             } else {
@@ -235,6 +240,9 @@ final class ToolLibraryStorePublisher {
             await finishSuccessfulPublication(
                 app,
                 for: tool,
+                localRemixedFromVersionId: linkedApp == nil
+                    ? app.currentVersion.id
+                    : app.currentVersion.remixedFromVersionId,
                 modelContext: modelContext,
                 routeStore: routeStore
             )
@@ -306,7 +314,11 @@ final class ToolLibraryStorePublisher {
         )
     }
 
-    private func applyPublishedStoreLinkage(_ app: StoreAppDetail, to tool: Tool) {
+    private func applyPublishedStoreLinkage(
+        _ app: StoreAppDetail,
+        to tool: Tool,
+        localRemixedFromVersionId: String?
+    ) {
         tool.storeId = app.storeId
         tool.storeAppId = app.id
         tool.category = app.category
@@ -314,17 +326,22 @@ final class ToolLibraryStorePublisher {
         tool.storeVersionNumber = app.currentVersion.versionNumber
         tool.storeSourceSha256 = app.currentVersion.sourceSha256
         tool.storeImportedAt = Date()
-        tool.storeRemixedFromVersionId = app.currentVersion.remixedFromVersionId
+        tool.storeRemixedFromVersionId = localRemixedFromVersionId
         tool.updatedAt = Date()
     }
 
     private func finishSuccessfulPublication(
         _ app: StoreAppDetail,
         for tool: Tool,
+        localRemixedFromVersionId: String?,
         modelContext: ModelContext,
         routeStore: IronsmithRouteStore
     ) async {
-        applyPublishedStoreLinkage(app, to: tool)
+        applyPublishedStoreLinkage(
+            app,
+            to: tool,
+            localRemixedFromVersionId: localRemixedFromVersionId
+        )
 
         let persistenceError: Error?
         do {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -14,6 +14,7 @@ final class ToolLibraryStorePublisher {
     var publishScreenshotName: String?
     var isShowingPublishSheet = false
     var isPublishing = false
+    var isUpdatingPublishedListing = false
     var errorMessage: String?
     var pendingSignInToolID: UUID?
     var pendingCreatorProfileToolID: UUID?
@@ -21,6 +22,7 @@ final class ToolLibraryStorePublisher {
     var creatorHandle = ""
     var isShowingCreatorProfileSheet = false
     var isSavingCreatorProfile = false
+    private(set) var storeSourceChangesByToolID: [UUID: Bool] = [:]
 
     @ObservationIgnored private let storeClient: IronsmithStoreClient
     @ObservationIgnored private let iconClient: ToolIconClient
@@ -50,6 +52,49 @@ final class ToolLibraryStorePublisher {
     func canUpdateStoreVersion(for tool: Tool) -> Bool {
         guard let storeAppId = tool.storeAppId else { return false }
         return publishedStoreAppsByID[storeAppId] != nil
+    }
+
+    func hasStoreSourceChanges(for tool: Tool) -> Bool {
+        storeSourceChangesByToolID[tool.id] ?? (tool.storeSourceSha256 == nil)
+    }
+
+    func refreshStoreSourceChanges(for tools: [Tool]) async {
+        let inputs = tools.map { tool in
+            StoreSourceChangeInput(
+                toolID: tool.id,
+                sourceURL: try? tool.packageLayout.packageFileURL(
+                    for: tool.contentViewSourcePath
+                ),
+                storeSourceSha256: tool.storeSourceSha256?.lowercased()
+            )
+        }
+        let changesByToolID = await Task.detached(priority: .utility) {
+            Dictionary(uniqueKeysWithValues: inputs.map { input in
+                let hasChanges: Bool
+                if let storeSourceSha256 = input.storeSourceSha256,
+                    let sourceURL = input.sourceURL,
+                    let source = try? String(contentsOf: sourceURL, encoding: .utf8)
+                {
+                    hasChanges =
+                        IronsmithStoreClient.sha256Hex(for: source) != storeSourceSha256
+                } else {
+                    hasChanges = input.storeSourceSha256 == nil
+                }
+                return (input.toolID, hasChanges)
+            })
+        }.value
+        guard !Task.isCancelled else { return }
+        storeSourceChangesByToolID = changesByToolID
+    }
+
+    private func sourceHasStoreChanges(for tool: Tool) -> Bool {
+        guard let storeSourceSha256 = tool.storeSourceSha256?.lowercased() else {
+            return true
+        }
+        guard let source = try? sourceCode(for: tool) else {
+            return true
+        }
+        return IronsmithStoreClient.sha256Hex(for: source) != storeSourceSha256
     }
 
     func refreshPublishedStoreApps(
@@ -129,6 +174,10 @@ final class ToolLibraryStorePublisher {
             return
         }
         pendingCreatorProfileToolID = nil
+        guard sourceHasStoreChanges(for: tool) else {
+            present(IronsmithStoreClientError.unchangedStoreVersion)
+            return
+        }
         await refreshPublishedStoreApps(
             isSignedIn: true,
             tools: tools
@@ -158,6 +207,7 @@ final class ToolLibraryStorePublisher {
             publishCategory = tool.category
             currentPublishedSourceSha256 = nil
         }
+        isUpdatingPublishedListing = linkedApp != nil
         publishingToolID = tool.id
         publishScreenshotData = nil
         publishScreenshotName = nil
@@ -376,6 +426,12 @@ final class ToolLibraryStorePublisher {
             IronsmithErrorPresentation.message(for: error)
             ?? error.localizedDescription
     }
+}
+
+private struct StoreSourceChangeInput: Sendable {
+    let toolID: UUID
+    let sourceURL: URL?
+    let storeSourceSha256: String?
 }
 
 private enum ToolLibraryStorePublishingError: LocalizedError {

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolGridItemView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolGridItemView.swift
@@ -231,6 +231,7 @@ enum ToolGridIconAction: Equatable {
         canRevert: false,
         showsStoreActions: false,
         canUpdateStoreVersion: false,
+        hasStoreSourceChanges: true,
         activeCodingAgent: nil,
         canShowAgentOutput: false
     )

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolItemActions.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolItemActions.swift
@@ -11,6 +11,7 @@ struct ToolItemPresentationState {
     let canRevert: Bool
     let showsStoreActions: Bool
     let canUpdateStoreVersion: Bool
+    let hasStoreSourceChanges: Bool
     let activeCodingAgent: ToolCodingAgent?
     let canShowAgentOutput: Bool
 
@@ -93,7 +94,9 @@ struct ToolItemActionsMenu: View {
             .disabled(!tool.isGenerationReady || state.isBusy)
         if state.showsStoreActions {
             Button(storePublishActionTitle, action: actions.onPublishToStore)
-                .disabled(!tool.isGenerationReady || state.isBusy)
+                .disabled(
+                    !tool.isGenerationReady || state.isBusy || !state.hasStoreSourceChanges
+                )
         }
         Button("Go Back to Previous Version", action: actions.onRevert)
             .disabled(!tool.isGenerationReady || !state.canRevert || state.isBusy)

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -186,6 +186,7 @@ struct ToolRowView: View {
             canRevert: true,
             showsStoreActions: true,
             canUpdateStoreVersion: false,
+            hasStoreSourceChanges: true,
             activeCodingAgent: nil,
             canShowAgentOutput: false
         ),

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -611,6 +611,44 @@ struct StoreImportTests {
 
     @MainActor
     @Test
+    func storeDetailSelectionCanReturnToPreviouslyVisitedApp() async {
+        let first = Self.appListing(
+            sourceCode: Self.sourceCode("first"),
+            appId: "00000000-0000-4000-8000-000000000101",
+            name: "First App"
+        )
+        let remix = Self.appListing(
+            sourceCode: Self.sourceCode("remix"),
+            appId: "00000000-0000-4000-8000-000000000102",
+            name: "Remix App"
+        )
+        var client = IronsmithStoreClient.unconfigured
+        client.fetchApp = { _, appID in
+            appID == first.id ? first : remix
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        store.select(storeID: first.storeId, appID: first.id)
+        #expect(store.isLoadingDetail)
+        await Self.waitForStoreDetail(first.id, in: store)
+        store.select(storeID: remix.storeId, appID: remix.id)
+        await Self.waitForStoreDetail(remix.id, in: store)
+        store.select(storeID: first.storeId, appID: first.id)
+        #expect(store.isLoadingDetail)
+        await Self.waitForStoreDetail(first.id, in: store)
+
+        #expect(store.selectedAppDetail?.id == first.id)
+        #expect(!store.isLoadingDetail)
+    }
+
+    @MainActor
+    @Test
     func searchPaginationAppendsUniqueResultsAndAdvancesOffset() async {
         let first = Self.appSummary(id: "app-one")
         let second = Self.appSummary(id: "app-two")
@@ -1157,10 +1195,11 @@ struct StoreImportTests {
         versions suppliedVersions: [StoreVersionMetadata]? = nil,
         icon: StoreAsset? = nil,
         iconMaster: StoreAsset? = nil,
-        authorHandle: String? = nil
+        authorHandle: String? = nil,
+        appId: String = "00000000-0000-4000-8000-000000000101",
+        name: String = "Clipboard Cleaner"
     ) -> StoreAppDetail {
         let storeId = "00000000-0000-4000-8000-000000000011"
-        let appId = "00000000-0000-4000-8000-000000000101"
         let version = StoreVersionMetadata(
             id: "00000000-0000-4000-8000-000000000201",
             appId: appId,
@@ -1181,7 +1220,7 @@ struct StoreImportTests {
             storeVisibility: "public",
             authorDisplayName: "Jade",
             authorHandle: authorHandle,
-            name: "Clipboard Cleaner",
+            name: name,
             shortDescription: "Clipboard cleanup",
             description: "Cleans clipboard text.",
             category: .utilities,
@@ -1196,6 +1235,19 @@ struct StoreImportTests {
             versions: versions,
             remix: nil
         )
+    }
+
+    @MainActor
+    private static func waitForStoreDetail(
+        _ appID: String,
+        in store: StoreWindowStore
+    ) async {
+        for _ in 0..<100 {
+            if store.selectedAppDetail?.id == appID, !store.isLoadingDetail {
+                return
+            }
+            await Task.yield()
+        }
     }
 
     private static func versionMetadata(

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -8,6 +8,11 @@ import Testing
 @testable import Ironsmith
 
 struct StoreImportTests {
+    @Test
+    func freshStoreInstallUsesDownloadTitle() {
+        #expect(StoreAppInstallDisposition.createCopy.buttonTitle == "Download")
+    }
+
     @MainActor
     @Test
     func unsignedStoreDownloadRequiresAnAccountBeforeFetchingAppDetails() async throws {
@@ -365,7 +370,7 @@ struct StoreImportTests {
 
     @MainActor
     @Test
-    func ownAppImportLinksPublishedAppWithoutRemixAttribution() async throws {
+    func ownAppImportRetainsParentAttributionAcrossAccountSwitches() async throws {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
@@ -383,8 +388,7 @@ struct StoreImportTests {
                 StoreToolImportRequest(
                     app: app,
                     version: version,
-                    mode: .get,
-                    isOwnApp: true
+                    mode: .get
                 ),
                 context
             )
@@ -394,7 +398,7 @@ struct StoreImportTests {
         #expect(result.tool.storeVersionId == version.id)
         #expect(result.tool.storeVersionNumber == version.versionNumber)
         #expect(result.tool.storeSourceSha256 == version.sourceSha256)
-        #expect(result.tool.storeRemixedFromVersionId == nil)
+        #expect(result.tool.storeRemixedFromVersionId == version.id)
     }
 
     @MainActor

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryPresentationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryPresentationTests.swift
@@ -130,6 +130,7 @@ extension ToolLibraryTests {
             canRevert: false,
             showsStoreActions: false,
             canUpdateStoreVersion: false,
+            hasStoreSourceChanges: true,
             activeCodingAgent: nil,
             canShowAgentOutput: false
         )

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -59,6 +59,7 @@ extension ToolLibraryTests {
 
         #expect(publisher.publishShortDescription.isEmpty)
         #expect(publisher.publishDescription.isEmpty)
+        #expect(!publisher.isUpdatingPublishedListing)
         #expect(publisher.isShowingPublishSheet)
     }
 
@@ -104,6 +105,7 @@ extension ToolLibraryTests {
 
         #expect(publisher.publishShortDescription == detail.shortDescription)
         #expect(publisher.publishDescription == detail.description)
+        #expect(publisher.isUpdatingPublishedListing)
         #expect(publisher.isShowingPublishSheet)
     }
 
@@ -147,6 +149,53 @@ extension ToolLibraryTests {
 
         #expect(publisher.errorMessage?.contains("currently published version") == true)
         #expect(tool.storeVersionNumber == 1)
+        #expect(!publisher.isShowingPublishSheet)
+    }
+
+    @MainActor
+    @Test
+    func storePublisherRejectsUnchangedDownloadedAppBeforeOpeningSheet() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, _, _, _, _, _, _ in
+            StoreAppPage(apps: [], hasMore: false)
+        }
+        client.fetchApp = { _, _ in
+            Issue.record("An unowned unchanged download must not fetch listing details.")
+            throw IronsmithStoreClientError.notConfigured
+        }
+        let inferenceStore = InferenceStore(
+            dependencies: Self.inferenceDependencies(
+                accountClient: Self.ironsmithAccountClient(balanceCredits: 100)
+            )
+        )
+        inferenceStore.ironsmithSession = Self.ironsmithSession()
+        let publisher = ToolLibraryStorePublisher(
+            storeClient: client,
+            iconClient: .live()
+        )
+        let tool = Tool(
+            name: "Clipboard Cleaner",
+            executableName: "ClipboardCleaner",
+            packageRootPath: root.path,
+            storeId: "00000000-0000-4000-8000-000000000011",
+            storeAppId: "00000000-0000-4000-8000-000000000101"
+        )
+        try Self.writeSource(Self.publisherSource, to: tool)
+        tool.storeSourceSha256 = IronsmithStoreClient.sha256Hex(for: Self.publisherSource)
+
+        await publisher.refreshStoreSourceChanges(for: [tool])
+        #expect(!publisher.hasStoreSourceChanges(for: tool))
+
+        await publisher.beginPublishing(
+            tool,
+            inferenceStore: inferenceStore,
+            tools: [tool]
+        )
+
+        #expect(publisher.errorMessage?.contains("currently published version") == true)
         #expect(!publisher.isShowingPublishSheet)
     }
 
@@ -253,6 +302,7 @@ extension ToolLibraryTests {
         #expect(tool.storeRemixedFromVersionId == publishedDetail.currentVersion.id)
         #expect(tool.storeVersionNumber == 1)
         #expect(await buildCapture.versionNumbers == [1])
+        #expect(!publisher.isUpdatingPublishedListing)
         #expect(publisher.errorMessage == nil)
     }
 

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -197,6 +197,7 @@ extension ToolLibraryTests {
             return publishedDetail
         }
         let buildCapture = PublisherBuildCapture()
+        let parentVersionId = "00000000-0000-4000-8000-000000000299"
         let publisher = ToolLibraryStorePublisher(
             storeClient: storeClient,
             iconClient: .noOp,
@@ -212,6 +213,7 @@ extension ToolLibraryTests {
             executableName: "ClipboardCleaner",
             packageRootPath: root.appendingPathComponent("ClipboardCleaner").path
         )
+        tool.storeRemixedFromVersionId = parentVersionId
         try Self.writeSource(Self.publisherSource, to: tool)
         try FileManager.default.createDirectory(
             at: tool.packageLayout.packageMetadataDirectoryURL,
@@ -243,9 +245,12 @@ extension ToolLibraryTests {
         let updatedNames = await profileCapture.updatedNames
         let publicationCount = await publicationCapture.count
         let publishedName = await publicationCapture.lastName
+        let remixedFromVersionId = await publicationCapture.lastRemixedFromVersionId
         #expect(updatedNames == ["Jade Westover"])
         #expect(publicationCount == 1)
         #expect(publishedName == tool.name)
+        #expect(remixedFromVersionId == parentVersionId)
+        #expect(tool.storeRemixedFromVersionId == publishedDetail.currentVersion.id)
         #expect(tool.storeVersionNumber == 1)
         #expect(await buildCapture.versionNumbers == [1])
         #expect(publisher.errorMessage == nil)
@@ -349,8 +354,12 @@ extension ToolLibraryTests {
             category: .finance,
             source: changedSource
         )
+        let versionCapture = PublisherVersionCapture()
         var storeClient = IronsmithStoreClient.unconfigured
-        storeClient.publishVersion = { _ in publishedDetail }
+        storeClient.publishVersion = { request in
+            await versionCapture.record(request)
+            return publishedDetail
+        }
         let buildCapture = PublisherBuildCapture()
         let publisher = ToolLibraryStorePublisher(
             storeClient: storeClient,
@@ -377,6 +386,7 @@ extension ToolLibraryTests {
             storeVersionId: previousDetail.currentVersion.id,
             storeVersionNumber: 1
         )
+        tool.storeRemixedFromVersionId = previousDetail.currentVersion.id
         try Self.writeSource(changedSource, to: tool)
         try FileManager.default.createDirectory(
             at: tool.packageLayout.packageMetadataDirectoryURL,
@@ -408,6 +418,8 @@ extension ToolLibraryTests {
         #expect(tool.storeVersionNumber == 2)
         #expect(await buildCapture.categories == [.finance])
         #expect(await buildCapture.versionNumbers == [2])
+        #expect(await versionCapture.lastRemixedFromVersionId == nil)
+        #expect(tool.storeRemixedFromVersionId == publishedDetail.currentVersion.remixedFromVersionId)
         #expect(publisher.errorMessage == nil)
         #expect(!publisher.isShowingPublishSheet)
     }
@@ -687,10 +699,20 @@ private actor PublisherProfileCapture {
 private actor PublisherPublicationCapture {
     private(set) var count = 0
     private(set) var lastName: String?
+    private(set) var lastRemixedFromVersionId: String?
 
     func record(_ request: StorePublicationRequest) {
         count += 1
         lastName = request.name
+        lastRemixedFromVersionId = request.remixedFromVersionId
+    }
+}
+
+private actor PublisherVersionCapture {
+    private(set) var lastRemixedFromVersionId: String?
+
+    func record(_ request: StoreVersionPublicationRequest) {
+        lastRemixedFromVersionId = request.remixedFromVersionId
     }
 }
 


### PR DESCRIPTION
## Summary

- show clickable “Remixed From” attribution in Store app details and keep the metadata layout responsive
- replace Get with Download and remove the explicit Remix action while preserving Open and Update states
- retain remix lineage across account switches and set newly published versions as the local future remix origin
- fix Back navigation after following remix attribution
- keep publish-sheet mode stable while publishing and provide a multiline description editor
- prevent unchanged downloaded source from entering the publication flow

## Why

Remix lineage could be lost when an app was downloaded under its original owner and later published from another account. The Store UI also exposed redundant remix controls, could briefly switch from Publish to Update during publication, and allowed unchanged downloads to enter a flow that the backend would eventually reject.

## User impact

Store listings now expose their direct remix origin, account switching preserves correct attribution, publication controls reflect the actual available action, and unchanged downloads are blocked before the publish sheet opens.

## Validation

- `script/test.sh --filter StoreImportTests`
- `script/test.sh --filter ToolLibraryTests`
- `script/test.sh` — 547 tests passed
- `git diff --check`
