### PR TITLE
Remixes have more of their own identity

### DIFF
--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -407,8 +407,13 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
     }
 
     nonisolated var cachedAppIconPreviewURL: URL {
-        if FileManager.default.fileExists(atPath: cachedAppIconThumbnailJPEGURL.path) {
-            return cachedAppIconThumbnailJPEGURL
+        let candidates = [
+            cachedAppIconThumbnailJPEGURL,
+            cachedAppIconPNGURL,
+            cachedAppIconICNSURL,
+        ]
+        for url in candidates where FileManager.default.fileExists(atPath: url.path) {
+            return url
         }
         return cachedAppIconPNGURL
     }

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -5,6 +5,19 @@
 
 import Foundation
 
+enum StoreAppNameComparison {
+    static func matches(_ lhs: String, _ rhs: String) -> Bool {
+        normalized(lhs) == normalized(rhs)
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .precomposedStringWithCompatibilityMapping
+            .lowercased(with: Locale(identifier: "en_US_POSIX"))
+    }
+}
+
 enum ToolGenerationState: String, Codable, CaseIterable, Equatable, Sendable {
     case ready
     case generating

--- a/Ironsmith/Core/Persistence/Configuration/IronsmithPreferenceKeys.swift
+++ b/Ironsmith/Core/Persistence/Configuration/IronsmithPreferenceKeys.swift
@@ -10,6 +10,10 @@ enum IronsmithPreferenceKeys {
     nonisolated static let recentHostedIconPaletteIndices = "icon.recentHostedPaletteIndices"
     nonisolated static let toolLibraryViewMode = "toolLibrary.viewMode"
     nonisolated static let toolLibrarySortOrder = "toolLibrary.sortOrder"
+    nonisolated static let generatesIdentityForNewRemixes =
+        "store.generatesIdentityForNewRemixes"
+    nonisolated static let hasPresentedRemixIdentityNotice =
+        "store.hasPresentedRemixIdentityNotice"
 
     #if DEBUG
     nonisolated static let debugAlwaysShowWelcomeOnboarding = "debug.alwaysShowWelcomeOnboarding"

--- a/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
@@ -5,6 +5,8 @@ struct SettingsPreferencesSectionView: View {
     @AppStorage(IronsmithPreferenceKeys.showSandboxOverride) private var showSandboxOverride = false
     @AppStorage(IronsmithPreferenceKeys.diagnosticsLoggingEnabled) private
         var diagnosticsLoggingEnabled = false
+    @AppStorage(IronsmithPreferenceKeys.generatesIdentityForNewRemixes) private
+        var generatesIdentityForNewRemixes = true
     @State private var isConfirmingUnsandboxedTools = false
 
     var body: some View {
@@ -24,6 +26,18 @@ struct SettingsPreferencesSectionView: View {
                 .toggleStyle(.switch)
 
                 Text("Disabling can sometimes improve success rates of smaller AI models.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Toggle(
+                    "Generate a new name and icon for remixes",
+                    isOn: $generatesIdentityForNewRemixes
+                )
+                .toggleStyle(.switch)
+
+                Text("Applies when you edit a downloaded app for the first time.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Ironsmith/Features/Store/StoreToolImportClient.swift
+++ b/Ironsmith/Features/Store/StoreToolImportClient.swift
@@ -1,22 +1,15 @@
 import Foundation
 import SwiftData
 
-enum StoreToolImportMode: Equatable, Sendable {
-    case get
-    case remix
-}
-
 struct StoreToolImportRequest: Sendable {
     let app: StoreAppDetail
     let version: StoreVersionDownload
-    let mode: StoreToolImportMode
     var displayName: String? = nil
     var initialGenerationState: ToolGenerationState = .ready
 }
 
 struct StoreToolImportResult {
     let tool: Tool
-    let mode: StoreToolImportMode
 }
 
 struct StoreToolImportClient {
@@ -42,11 +35,7 @@ extension StoreToolImportClient {
         StoreToolImportClient { request, modelContext in
             try IronsmithStoreClient.verifySourceHash(request.version)
 
-            let displayName =
-                request.displayName
-                ?? (request.mode == .remix
-                    ? "\(request.app.name) Remix"
-                    : request.app.name)
+            let displayName = request.displayName ?? request.app.name
             let packageRootURL = try packageMaterializer.makeUniquePackageRoot(
                 displayName: displayName,
                 toolsDirectoryURL: toolsDirectoryURL
@@ -104,7 +93,7 @@ extension StoreToolImportClient {
                 throw error
             }
 
-            return StoreToolImportResult(tool: tool, mode: request.mode)
+            return StoreToolImportResult(tool: tool)
         }
     }
 
@@ -150,7 +139,7 @@ extension StoreToolImportClient {
         }
     }
 
-    private static func downloadImage(from url: URL) async throws -> Data {
+    static func downloadImage(from url: URL) async throws -> Data {
         let (data, response) = try await URLSession.shared.data(from: url)
         guard let httpResponse = response as? HTTPURLResponse,
             (200...299).contains(httpResponse.statusCode),

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -25,8 +25,8 @@ enum StoreAppInstallDisposition {
 }
 
 enum StorePendingDownloadRequest {
-    case appSummary(StoreAppSummary, mode: StoreToolImportMode)
-    case appDetail(StoreAppDetail, mode: StoreToolImportMode)
+    case appSummary(StoreAppSummary)
+    case appDetail(StoreAppDetail)
     case version(StoreVersionMetadata, app: StoreAppDetail)
 }
 
@@ -260,22 +260,19 @@ final class StoreWindowStore {
 
     func install(
         _ app: StoreAppSummary,
-        mode: StoreToolImportMode,
         tools: [Tool],
         modelContext: ModelContext,
         routeStore: IronsmithRouteStore,
         inferenceStore: InferenceStore
     ) async {
         selectedAppID = app.id
-        if mode == .get,
-            case .openExisting(let tool) = installDisposition(for: app, tools: tools)
-        {
+        if case .openExisting(let tool) = installDisposition(for: app, tools: tools) {
             routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
             return
         }
         guard
             requireAccountForDownload(
-                .appSummary(app, mode: mode),
+                .appSummary(app),
                 inferenceStore: inferenceStore
             )
         else { return }
@@ -291,7 +288,6 @@ final class StoreWindowStore {
             }
             await install(
                 detail,
-                mode: mode,
                 tools: tools,
                 modelContext: modelContext,
                 routeStore: routeStore,
@@ -454,22 +450,19 @@ final class StoreWindowStore {
 
     func install(
         _ app: StoreAppDetail,
-        mode: StoreToolImportMode,
         tools: [Tool],
         modelContext: ModelContext,
         routeStore: IronsmithRouteStore,
         inferenceStore: InferenceStore
     ) async {
         guard workingAppID == nil else { return }
-        if mode == .get,
-            case .openExisting(let tool) = installDisposition(for: app, tools: tools)
-        {
+        if case .openExisting(let tool) = installDisposition(for: app, tools: tools) {
             routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
             return
         }
         guard
             requireAccountForDownload(
-                .appDetail(app, mode: mode),
+                .appDetail(app),
                 inferenceStore: inferenceStore
             )
         else { return }
@@ -483,24 +476,22 @@ final class StoreWindowStore {
             if inferenceStore.ironsmithSession != nil {
                 await refreshPublished(showLoadingIndicator: false)
             }
-            if mode == .get {
-                switch installDisposition(for: app, tools: tools) {
-                case .openExisting(let tool):
-                    routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
-                    return
-                case .updateExisting(let tool):
-                    try await updateExistingTool(
-                        tool,
-                        from: app,
-                        modelContext: modelContext,
-                        routeStore: routeStore,
-                        inferenceStore: inferenceStore
-                    )
-                    contentRevision += 1
-                    return
-                case .createCopy:
-                    break
-                }
+            switch installDisposition(for: app, tools: tools) {
+            case .openExisting(let tool):
+                routeStore.open(.toolLibrary(.selectTool(id: tool.id, focusPrompt: false)))
+                return
+            case .updateExisting(let tool):
+                try await updateExistingTool(
+                    tool,
+                    from: app,
+                    modelContext: modelContext,
+                    routeStore: routeStore,
+                    inferenceStore: inferenceStore
+                )
+                contentRevision += 1
+                return
+            case .createCopy:
+                break
             }
             let version = try await client.fetchVersion(
                 app.storeId,
@@ -510,7 +501,6 @@ final class StoreWindowStore {
             try await importAndBuild(
                 version,
                 app: app,
-                mode: mode,
                 displayName: nil,
                 modelContext: modelContext,
                 routeStore: routeStore
@@ -584,7 +574,6 @@ final class StoreWindowStore {
             try await importAndBuild(
                 download,
                 app: app,
-                mode: .get,
                 displayName: displayName,
                 modelContext: modelContext,
                 routeStore: routeStore
@@ -696,19 +685,17 @@ final class StoreWindowStore {
         inferenceStore: InferenceStore
     ) async {
         switch request {
-        case .appSummary(let app, let mode):
+        case .appSummary(let app):
             await install(
                 app,
-                mode: mode,
                 tools: tools,
                 modelContext: modelContext,
                 routeStore: routeStore,
                 inferenceStore: inferenceStore
             )
-        case .appDetail(let app, let mode):
+        case .appDetail(let app):
             await install(
                 app,
-                mode: mode,
                 tools: tools,
                 modelContext: modelContext,
                 routeStore: routeStore,
@@ -741,7 +728,6 @@ final class StoreWindowStore {
     private func importAndBuild(
         _ version: StoreVersionDownload,
         app: StoreAppDetail,
-        mode: StoreToolImportMode,
         displayName: String?,
         modelContext: ModelContext,
         routeStore: IronsmithRouteStore
@@ -750,18 +736,12 @@ final class StoreWindowStore {
             StoreToolImportRequest(
                 app: app,
                 version: version,
-                mode: mode,
                 displayName: displayName,
-                initialGenerationState: mode == .get ? .generating : .ready
+                initialGenerationState: .generating
             ),
             modelContext
         )
-        routeStore.open(
-            .toolLibrary(
-                .selectTool(id: result.tool.id, focusPrompt: mode == .remix)
-            )
-        )
-        guard mode == .get else { return }
+        routeStore.open(.toolLibrary(.selectTool(id: result.tool.id, focusPrompt: false)))
 
         do {
             try await buildClient.buildTool(result.tool)

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -213,11 +213,10 @@ struct StoreWindowView: View {
         )
     }
 
-    private func install(_ app: StoreAppSummary, mode: StoreToolImportMode = .get) {
+    private func install(_ app: StoreAppSummary) {
         Task {
             await store.install(
                 app,
-                mode: mode,
                 tools: tools,
                 modelContext: modelContext,
                 routeStore: routeStore,
@@ -393,7 +392,7 @@ private struct StoreDiscoverHomeView: View {
     let inferenceStore: InferenceStore
     let onOpen: (StoreAppSummary) -> Void
     let onSeeAll: (StoreHomeSection) -> Void
-    let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
+    let onGet: (StoreAppSummary) -> Void
 
     private var isSearching: Bool {
         !store.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -451,7 +450,7 @@ private struct StoreSearchResultsView: View {
     let tools: [Tool]
     let inferenceStore: InferenceStore
     let onOpen: (StoreAppSummary) -> Void
-    let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
+    let onGet: (StoreAppSummary) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -474,7 +473,7 @@ private struct StoreSearchResultsView: View {
                         store.installDisposition(for: $0, tools: tools).buttonTitle
                     },
                     onOpen: onOpen,
-                    onAction: { onGet($0, .get) },
+                    onAction: onGet,
                     onApproachingEnd: {
                         await store.loadMoreSearchResults()
                     }
@@ -495,7 +494,7 @@ private struct StoreHomeSectionView: View {
     let actionTitle: (StoreAppSummary) -> String
     let onOpen: (StoreAppSummary) -> Void
     let onSeeAll: () -> Void
-    let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
+    let onGet: (StoreAppSummary) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -519,7 +518,7 @@ private struct StoreHomeSectionView: View {
                             actionTitle: actionTitle(app),
                             isWorking: workingAppID == app.id,
                             onOpen: { onOpen(app) },
-                            onAction: { onGet(app, .get) }
+                            onAction: { onGet(app) }
                         )
                         Divider()
                             .padding(.leading, 88)
@@ -538,7 +537,7 @@ private struct StoreSectionAppsView: View {
     let tools: [Tool]
     let inferenceStore: InferenceStore
     let onOpen: (StoreAppSummary) -> Void
-    let onGet: (StoreAppSummary, StoreToolImportMode) -> Void
+    let onGet: (StoreAppSummary) -> Void
     @State private var apps: [StoreAppSummary] = []
     @State private var nextOffset = 0
     @State private var hasMore = false
@@ -600,7 +599,7 @@ private struct StoreSectionAppsView: View {
                             store.installDisposition(for: $0, tools: tools).buttonTitle
                         },
                         onOpen: onOpen,
-                        onAction: { onGet($0, .get) },
+                        onAction: onGet,
                         onApproachingEnd: loadMore
                     )
                     .padding(.horizontal, 28)
@@ -939,7 +938,6 @@ private struct StoreAppDetailDestinationView: View {
                 Task {
                     await store.install(
                         app,
-                        mode: .get,
                         tools: tools,
                         modelContext: modelContext,
                         routeStore: routeStore,

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolAppDetailsEditorStore.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolAppDetailsEditorStore.swift
@@ -107,6 +107,37 @@ final class ToolAppDetailsEditorStore {
         }
     }
 
+    func generateAndSaveRemixIdentity(
+        for tool: Tool,
+        name: String,
+        iconPrompt: String,
+        provider: ToolImageGenerationProvider,
+        in modelContext: ModelContext,
+        rename: (String) -> String?
+    ) async -> Bool {
+        guard tool.isGenerationReady, !isWorking else { return false }
+        editingToolID = tool.id
+        self.name = name
+        prompt = iconPrompt
+        candidate = nil
+        errorMessage = nil
+        currentPreviewData = currentPreviewData(for: tool.packageLayout)
+        isShowingSheet = false
+
+        await generate(for: tool, provider: provider)
+        guard !Task.isCancelled else { return false }
+        guard candidate != nil else {
+            isShowingSheet = true
+            return false
+        }
+
+        let didSave = await save(tool, in: modelContext, rename: rename)
+        if !didSave {
+            isShowingSheet = true
+        }
+        return didSave
+    }
+
     @discardableResult
     func save(
         _ tool: Tool,

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -17,6 +17,10 @@ struct ToolLibraryPopoverView: View {
         ToolLibraryViewMode.list.rawValue
     @AppStorage(IronsmithPreferenceKeys.toolLibrarySortOrder) private var sortOrderRawValue =
         ToolLibrarySortOrder.latest.rawValue
+    @AppStorage(IronsmithPreferenceKeys.generatesIdentityForNewRemixes) private
+        var generatesIdentityForNewRemixes = true
+    @AppStorage(IronsmithPreferenceKeys.hasPresentedRemixIdentityNotice) private
+        var hasPresentedRemixIdentityNotice = false
     #if DEBUG
         @AppStorage(IronsmithPreferenceKeys.debugAlwaysShowWelcomeOnboarding)
         private var debugAlwaysShowWelcomeOnboarding = false
@@ -26,6 +30,7 @@ struct ToolLibraryPopoverView: View {
     #endif
     let appUpdateStore: AppUpdateStore
     private let welcomeOnboardingStore: WelcomeOnboardingStore
+    private let remixMetadataClient: ToolMetadataClient
     @State private var toolLibraryStore = ToolLibraryStore()
     @State private var storePublisher: ToolLibraryStorePublisher
     @State private var detailsEditor: ToolAppDetailsEditorStore
@@ -37,12 +42,21 @@ struct ToolLibraryPopoverView: View {
     @State private var isSearchPresented = false
     @State private var isPromptExpanded = false
     @State private var searchText = ""
+    @State private var detailsEditorToolIDPendingPresentation: UUID?
+    @State private var detailsEditorPublishOriginToolID: UUID?
+    @State private var publishToolIDPendingDetailsReturn: UUID?
+    @State private var remixIdentityNoticeToolID: UUID?
+    @State private var remixIdentityHandledToolIDs: Set<UUID> = []
+    @State private var remixIdentityGeneratingToolID: UUID?
+    @State private var remixIdentityGenerationOperationID: UUID?
+    @State private var remixIdentityGenerationTask: Task<Void, Never>?
     @FocusState private var isPromptFocused: Bool
 
     @MainActor
     init() {
         appUpdateStore = AppUpdateStore()
         welcomeOnboardingStore = WelcomeOnboardingStore()
+        remixMetadataClient = .live()
         _storePublisher = State(initialValue: ToolLibraryStorePublisher())
         _detailsEditor = State(initialValue: ToolAppDetailsEditorStore())
     }
@@ -54,10 +68,12 @@ struct ToolLibraryPopoverView: View {
         storeClient: IronsmithStoreClient? = nil,
         iconClient: ToolIconClient = .cachedOnly(),
         iconEditingClient: ToolIconEditingClient? = nil,
-        iconBuildClient: ToolBuildClient? = nil
+        iconBuildClient: ToolBuildClient? = nil,
+        remixMetadataClient: ToolMetadataClient? = nil
     ) {
         self.appUpdateStore = appUpdateStore
         self.welcomeOnboardingStore = welcomeOnboardingStore ?? WelcomeOnboardingStore()
+        self.remixMetadataClient = remixMetadataClient ?? .live()
         let buildClient = iconBuildClient ?? .live()
         _storePublisher = State(
             initialValue: ToolLibraryStorePublisher(
@@ -193,6 +209,22 @@ struct ToolLibraryPopoverView: View {
         } message: {
             Text("Sign in with Ironsmith to publish this app to the Ironsmith Store.")
         }
+        .alert(
+            "Create a Unique Remix?",
+            isPresented: remixIdentityNoticeBinding
+        ) {
+            Button("Skip Name & Icon", role: .cancel) {
+                continuePendingRemixEdit(generateIdentity: false)
+            }
+            Button("Continue") {
+                continuePendingRemixEdit(generateIdentity: true)
+            }
+        } message: {
+            Text(
+                "Ironsmith will generate a new name and icon so this remix has its own identity. "
+                    + "It will do the same for future remixes. You can turn this off anytime in Settings."
+            )
+        }
         .confirmationDialog(
             "Delete App?",
             isPresented: deleteConfirmationBinding
@@ -226,7 +258,10 @@ struct ToolLibraryPopoverView: View {
                 onComplete: completeWelcomeOnboarding
             )
         }
-        .sheet(isPresented: $storePublisher.isShowingPublishSheet) {
+        .sheet(
+            isPresented: $storePublisher.isShowingPublishSheet,
+            onDismiss: handlePublishSheetDismissed
+        ) {
             storePublishSheet
         }
         .sheet(isPresented: $storePublisher.isShowingCreatorProfileSheet) {
@@ -250,7 +285,10 @@ struct ToolLibraryPopoverView: View {
                 }
             )
         }
-        .sheet(isPresented: $detailsEditor.isShowingSheet) {
+        .sheet(
+            isPresented: $detailsEditor.isShowingSheet,
+            onDismiss: handleDetailsEditorDismissed
+        ) {
             detailsEditorSheet
         }
         .sheet(isPresented: $isShowingModelPicker) {
@@ -306,7 +344,7 @@ struct ToolLibraryPopoverView: View {
                 modelPickerTitle: composerModelPickerTitle,
                 isModelPickerEnabled: isComposerModelPickerEnabled,
                 isSubmitEnabled: canSubmitPrompt,
-                isSubmitting: toolLibraryStore.isGenerating,
+                isSubmitting: toolLibraryStore.isGenerating || remixIdentityGeneratingToolID != nil,
                 isCodexAgentSupported: inferenceStore.selectedModelSupportsCodingAgentPreference(.codex),
                 showsAttachmentControls: selectedModelCanUseCodexAttachments,
                 supportsAttachments: selectedModelSupportsAttachments,
@@ -317,18 +355,14 @@ struct ToolLibraryPopoverView: View {
                     isShowingModelPicker = true
                 },
                 onSubmit: {
-                    guard inferenceStore.selectedModel != nil, !shouldForceNoModels else { return }
-                    collapsePromptIfNeeded()
-                    if !showSandboxOverride {
-                        toolLibraryStore.sandboxEnabled = true
-                    }
-                    toolLibraryStore.startPromptSubmission(
-                        modelContext: modelContext,
-                        inferenceStore: inferenceStore
-                    )
+                    requestPromptSubmission()
                 },
                 onCancel: {
-                    toolLibraryStore.cancelGeneration()
+                    if remixIdentityGeneratingToolID != nil {
+                        cancelRemixIdentityGeneration()
+                    } else {
+                        toolLibraryStore.cancelGeneration()
+                    }
                 },
                 onAddAttachments: { urls in
                     guard toolLibraryStore.addAttachments(from: urls) else { return }
@@ -439,6 +473,7 @@ struct ToolLibraryPopoverView: View {
             isRebuilding: toolLibraryStore.rebuildingToolID == tool.id,
             isRestoring: toolLibraryStore.restoringToolID == tool.id,
             isEditingDetails: detailsEditor.isWorking && detailsEditor.editingToolID == tool.id,
+            isPreparingGeneration: remixIdentityGeneratingToolID == tool.id,
             canRevert: toolLibraryStore.canRestorePreviousVersion(tool),
             showsStoreActions: isStoreFeatureEnabled,
             canUpdateStoreVersion: canUpdateStoreVersion(for: tool),
@@ -514,7 +549,11 @@ struct ToolLibraryPopoverView: View {
                 toolLibraryStore.discardGeneration(tool, in: modelContext)
             },
             onStop: {
-                toolLibraryStore.cancelGeneration()
+                if remixIdentityGeneratingToolID == tool.id {
+                    cancelRemixIdentityGeneration()
+                } else {
+                    toolLibraryStore.cancelGeneration()
+                }
             },
             onDelete: {
                 toolPendingDeletion = tool
@@ -552,28 +591,28 @@ struct ToolLibraryPopoverView: View {
                     routeStore.open(.settings(.root))
                 },
                 onCancel: {
+                    detailsEditorPublishOriginToolID = nil
+                    publishToolIDPendingDetailsReturn = nil
                     detailsEditor.cancel()
                 },
                 onSave: {
                     Task {
-                        await detailsEditor.save(
+                        let shouldReturnToPublishing =
+                            detailsEditorPublishOriginToolID == tool.id
+                        if shouldReturnToPublishing {
+                            publishToolIDPendingDetailsReturn = tool.id
+                        }
+                        let didSave = await detailsEditor.save(
                             tool,
                             in: modelContext,
-                            rename: { proposedName in
-                                guard toolLibraryStore.rename(
-                                    tool,
-                                    to: proposedName,
-                                    in: modelContext
-                                ) else {
-                                    let message =
-                                        toolLibraryStore.presentedErrorMessage
-                                        ?? "Ironsmith could not rename this app."
-                                    toolLibraryStore.clearPresentedError()
-                                    return message
-                                }
-                                return nil
-                            }
+                            rename: { renameTool(tool, to: $0) }
                         )
+                        if didSave, tool.storeRemixedFromVersionId != nil {
+                            remixIdentityHandledToolIDs.insert(tool.id)
+                        }
+                        if !didSave, shouldReturnToPublishing {
+                            publishToolIDPendingDetailsReturn = nil
+                        }
                     }
                 }
             )
@@ -592,11 +631,20 @@ struct ToolLibraryPopoverView: View {
                 publishDescription: $storePublisher.publishDescription,
                 publishCategory: $storePublisher.publishCategory,
                 publishScreenshotName: storePublisher.publishScreenshotName,
+                publishIconPreviewData: storePublisher.publishIconPreviewData,
+                publishNameMatchesOriginal: storePublisher.publishNameMatchesOriginal(
+                    for: tool
+                ),
+                isUsingOriginalRemixIcon: storePublisher.isUsingOriginalRemixIcon,
                 isPublishing: storePublisher.isPublishing,
                 onChooseScreenshot: { url in
                     storePublisher.importScreenshot(from: url)
                 },
                 onCancel: {
+                    storePublisher.isShowingPublishSheet = false
+                },
+                onEditDetails: {
+                    detailsEditorToolIDPendingPresentation = tool.id
                     storePublisher.isShowingPublishSheet = false
                 },
                 onPublish: {
@@ -612,6 +660,32 @@ struct ToolLibraryPopoverView: View {
                 }
             )
         }
+    }
+
+    private func handlePublishSheetDismissed() {
+        guard let toolID = detailsEditorToolIDPendingPresentation else { return }
+        detailsEditorToolIDPendingPresentation = nil
+        guard storePublisher.publishingToolID == toolID,
+            let tool = tools.first(where: { $0.id == toolID })
+        else { return }
+        detailsEditorPublishOriginToolID = toolID
+        detailsEditor.beginEditing(tool)
+        if !detailsEditor.isShowingSheet {
+            detailsEditorPublishOriginToolID = nil
+        }
+    }
+
+    private func handleDetailsEditorDismissed() {
+        defer {
+            detailsEditorPublishOriginToolID = nil
+            publishToolIDPendingDetailsReturn = nil
+        }
+        guard let toolID = publishToolIDPendingDetailsReturn,
+            storePublisher.publishingToolID == toolID,
+            let tool = tools.first(where: { $0.id == toolID })
+        else { return }
+        storePublisher.refreshPublishIdentity(for: tool)
+        storePublisher.isShowingPublishSheet = true
     }
 
     private func refreshSelectedIronsmithAccountIfNeeded() async {
@@ -883,10 +957,164 @@ struct ToolLibraryPopoverView: View {
         }
     }
 
-    private func selectToolForEditing(_ tool: Tool) {
-        guard tool.isGenerationReady else { return }
+    private func continuePendingRemixEdit(generateIdentity: Bool) {
+        let toolID = remixIdentityNoticeToolID
+        remixIdentityNoticeToolID = nil
+        hasPresentedRemixIdentityNotice = true
+        generatesIdentityForNewRemixes = generateIdentity
+        guard let toolID,
+            let tool = tools.first(where: { $0.id == toolID })
+        else { return }
+        if generateIdentity {
+            startRemixIdentityGeneration(for: tool)
+        } else {
+            submitCurrentPrompt()
+        }
+    }
+
+    private func requestPromptSubmission() {
+        guard inferenceStore.selectedModel != nil, !shouldForceNoModels else { return }
+        guard let selectedToolID = toolLibraryStore.selectedToolID,
+            let tool = tools.first(where: { $0.id == selectedToolID })
+        else {
+            submitCurrentPrompt()
+            return
+        }
+        if remixIdentityHandledToolIDs.contains(tool.id) {
+            submitCurrentPrompt()
+            return
+        }
+        switch toolLibraryStore.remixIdentitySubmissionAction(
+            for: tool,
+            generatesIdentity: generatesIdentityForNewRemixes,
+            hasPresentedNotice: hasPresentedRemixIdentityNotice
+        ) {
+        case .submit:
+            submitCurrentPrompt()
+        case .presentNotice:
+            remixIdentityNoticeToolID = tool.id
+        case .generateIdentity:
+            startRemixIdentityGeneration(for: tool)
+        }
+    }
+
+    private func startRemixIdentityGeneration(for tool: Tool) {
+        guard remixIdentityGenerationTask == nil else { return }
+        let operationID = UUID()
+        remixIdentityGeneratingToolID = tool.id
+        remixIdentityGenerationOperationID = operationID
+        remixIdentityGenerationTask = Task {
+            let didGenerate = await generateRemixIdentity(tool)
+            let wasCancelled = Task.isCancelled
+            finishRemixIdentityGeneration(operationID: operationID)
+            guard didGenerate, !wasCancelled else { return }
+            submitCurrentPrompt()
+        }
+    }
+
+    private func cancelRemixIdentityGeneration() {
+        remixIdentityGenerationTask?.cancel()
+        remixIdentityGenerationTask = nil
+        remixIdentityGeneratingToolID = nil
+        remixIdentityGenerationOperationID = nil
+    }
+
+    private func finishRemixIdentityGeneration(operationID: UUID) {
+        guard remixIdentityGenerationOperationID == operationID else { return }
+        remixIdentityGenerationTask = nil
+        remixIdentityGeneratingToolID = nil
+        remixIdentityGenerationOperationID = nil
+    }
+
+    private func submitCurrentPrompt() {
+        collapsePromptIfNeeded()
+        if !showSandboxOverride {
+            toolLibraryStore.sandboxEnabled = true
+        }
+        toolLibraryStore.startPromptSubmission(
+            modelContext: modelContext,
+            inferenceStore: inferenceStore
+        )
+    }
+
+    private func generateRemixIdentity(_ tool: Tool) async -> Bool {
+        do {
+            try await inferenceStore.prepareSelectedModelForGeneration()
+            let languageModelContext = try await inferenceStore.makeSelectedAgentLanguageModelContext(
+                resolutionContext: ToolCodingAgentResolutionContext(
+                    generationMode: .edit,
+                    existingSourceLineCount: nil
+                )
+            )
+            let sourceURL = try tool.packageLayout.packageFileURL(for: tool.contentViewSourcePath)
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            let suggestion = await remixMetadataClient.suggestMetadata(
+                userPrompt: Self.remixIdentityPrompt(for: tool, source: source),
+                imageGenerationProvider: inferenceStore.effectiveImageGenerationProvider,
+                invoker: languageModelContext.languageModelInvoker
+            )
+            guard !Task.isCancelled else { return false }
+            let generatedName = Self.distinctRemixName(
+                suggestion.displayName,
+                originalName: tool.name
+            )
+            let didSave = await detailsEditor.generateAndSaveRemixIdentity(
+                for: tool,
+                name: generatedName,
+                iconPrompt: suggestion.iconPrompt,
+                provider: inferenceStore.effectiveImageGenerationProvider,
+                in: modelContext,
+                rename: { renameTool(tool, to: $0) }
+            )
+            if inferenceStore.effectiveImageGenerationProvider == .ironsmith {
+                await inferenceStore.refreshIronsmithAccountSummary()
+            }
+            if didSave {
+                remixIdentityHandledToolIDs.insert(tool.id)
+            }
+            return didSave
+        } catch {
+            toolLibraryStore.presentedErrorMessage = IronsmithErrorPresentation.message(for: error)
+            return false
+        }
+    }
+
+    private func renameTool(_ tool: Tool, to proposedName: String) -> String? {
+        guard toolLibraryStore.rename(tool, to: proposedName, in: modelContext) else {
+            let message =
+                toolLibraryStore.presentedErrorMessage
+                ?? "Ironsmith could not rename this app."
+            toolLibraryStore.clearPresentedError()
+            return message
+        }
+        return nil
+    }
+
+    private static func remixIdentityPrompt(for tool: Tool, source: String) -> String {
+        let sourceExcerpt = String(source.prefix(6_000))
+        return """
+            Create a fresh, distinctive identity for a remixed macOS app.
+            Do not reuse the original name “\(tool.name)”. Suggest a different concise app name and a new icon concept that reflects what the app does.
+
+            Category: \(tool.category.rawValue)
+            Existing source:
+            \(sourceExcerpt)
+            """
+    }
+
+    private static func distinctRemixName(_ proposedName: String, originalName: String) -> String {
+        let trimmedName = proposedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty,
+            !StoreAppNameComparison.matches(trimmedName, originalName)
+        else {
+            return "Fresh \(originalName)"
+        }
+        return trimmedName
+    }
+
+    private func selectToolForEditing(_ tool: Tool, focusPrompt: Bool = true) {
         toolLibraryStore.selectForEditing(tool, defaultSettings: defaultGenerationSettings)
-        isPromptFocused = true
+        isPromptFocused = focusPrompt
     }
 
     private func applyPendingToolLibraryRoute() {
@@ -1040,6 +1268,17 @@ struct ToolLibraryPopoverView: View {
             set: { isPresented in
                 if !isPresented {
                     storePublisher.pendingSignInToolID = nil
+                }
+            }
+        )
+    }
+
+    private var remixIdentityNoticeBinding: Binding<Bool> {
+        Binding(
+            get: { remixIdentityNoticeToolID != nil },
+            set: { isPresented in
+                if !isPresented {
+                    remixIdentityNoticeToolID = nil
                 }
             }
         )

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -8,9 +9,13 @@ struct ToolLibraryStorePublishSheetView: View {
     @Binding var publishDescription: String
     @Binding var publishCategory: StoreAppCategory
     let publishScreenshotName: String?
+    let publishIconPreviewData: Data?
+    let publishNameMatchesOriginal: Bool
+    let isUsingOriginalRemixIcon: Bool
     let isPublishing: Bool
     let onChooseScreenshot: (URL) -> Void
     let onCancel: () -> Void
+    let onEditDetails: () -> Void
     let onPublish: () -> Void
     @State private var isChoosingScreenshot = false
 
@@ -22,6 +27,8 @@ struct ToolLibraryStorePublishSheetView: View {
                     : "Publish \(tool.name) to Ironsmith Store"
             )
                 .font(.headline)
+
+            appIdentitySection
 
             field("Short Description") {
                 TextField(
@@ -92,7 +99,7 @@ struct ToolLibraryStorePublishSheetView: View {
             }
         }
         .padding(18)
-        .frame(width: 390)
+        .frame(width: 460)
         .fileImporter(
             isPresented: $isChoosingScreenshot,
             allowedContentTypes: [.image],
@@ -101,6 +108,60 @@ struct ToolLibraryStorePublishSheetView: View {
             if case .success(let urls) = result, let url = urls.first {
                 onChooseScreenshot(url)
             }
+        }
+    }
+
+    private var appIdentitySection: some View {
+        field("App Identity") {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 10) {
+                    identityIcon(localData: publishIconPreviewData)
+                    Text(tool.name)
+                        .font(.body.weight(.medium))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Button("Edit Details", action: onEditDetails)
+                        .disabled(isPublishing)
+                }
+
+                if isUsingOriginalRemixIcon {
+                    Label(
+                        "This app still uses the original icon. Consider using Edit Details to choose a new one.",
+                        systemImage: "info.circle"
+                    )
+                    .foregroundStyle(.secondary)
+                    .font(.callout)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if publishNameMatchesOriginal {
+                    Label(
+                        "Current app name is the same as the original. Change the app name in Edit Details before publishing.",
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .foregroundStyle(.red)
+                    .font(.callout)
+                    .lineLimit(nil)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(10)
+            .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    @ViewBuilder
+    private func identityIcon(localData: Data?) -> some View {
+        if let localData, let image = NSImage(data: localData) {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 48, height: 48)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+        } else {
+            StoreIconView(url: nil, size: 48)
         }
     }
 
@@ -118,6 +179,7 @@ struct ToolLibraryStorePublishSheetView: View {
     private var canPublish: Bool {
         listingFieldsAreValid
             && !tool.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !publishNameMatchesOriginal
     }
 
     private var listingFieldsAreValid: Bool {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -12,6 +12,8 @@ final class ToolLibraryStorePublisher {
     var publishCategory: StoreAppCategory = .utilities
     var publishScreenshotData: Data?
     var publishScreenshotName: String?
+    var publishIconPreviewData: Data?
+    var originalRemixApp: StoreAppDetail?
     var isShowingPublishSheet = false
     var isPublishing = false
     var isUpdatingPublishedListing = false
@@ -26,13 +28,16 @@ final class ToolLibraryStorePublisher {
 
     @ObservationIgnored private let storeClient: IronsmithStoreClient
     @ObservationIgnored private let iconClient: ToolIconClient
+    @ObservationIgnored private let originalIconDataLoader: @Sendable (URL) async throws -> Data
     @ObservationIgnored private let buildClient: ToolBuildClient
     @ObservationIgnored private let saveModelContext: (ModelContext) throws -> Void
     @ObservationIgnored private var currentPublishedSourceSha256: String?
+    @ObservationIgnored private var originalRemixIconData: Data?
 
     init() {
         self.storeClient = .live
         self.iconClient = .live()
+        self.originalIconDataLoader = { try await StoreToolImportClient.downloadImage(from: $0) }
         self.buildClient = .live()
         self.saveModelContext = { try $0.save() }
     }
@@ -40,11 +45,15 @@ final class ToolLibraryStorePublisher {
     init(
         storeClient: IronsmithStoreClient,
         iconClient: ToolIconClient,
+        originalIconDataLoader: (@Sendable (URL) async throws -> Data)? = nil,
         buildClient: ToolBuildClient? = nil,
         saveModelContext: ((ModelContext) throws -> Void)? = nil
     ) {
         self.storeClient = storeClient
         self.iconClient = iconClient
+        self.originalIconDataLoader = originalIconDataLoader ?? {
+            try await StoreToolImportClient.downloadImage(from: $0)
+        }
         self.buildClient = buildClient ?? .live()
         self.saveModelContext = saveModelContext ?? { try $0.save() }
     }
@@ -56,6 +65,24 @@ final class ToolLibraryStorePublisher {
 
     func hasStoreSourceChanges(for tool: Tool) -> Bool {
         storeSourceChangesByToolID[tool.id] ?? (tool.storeSourceSha256 == nil)
+    }
+
+    func publishNameMatchesOriginal(for tool: Tool) -> Bool {
+        guard let originalRemixApp else { return false }
+        return StoreAppNameComparison.matches(tool.name, originalRemixApp.name)
+    }
+
+    var isUsingOriginalRemixIcon: Bool {
+        guard let originalRemixIconData, let publishIconPreviewData else { return false }
+        return originalRemixIconData == publishIconPreviewData
+    }
+
+    func canPublishRemixIdentity(for tool: Tool) -> Bool {
+        originalRemixApp == nil || !publishNameMatchesOriginal(for: tool)
+    }
+
+    func refreshPublishIdentity(for tool: Tool) {
+        publishIconPreviewData = try? Data(contentsOf: tool.packageLayout.cachedAppIconPreviewURL)
     }
 
     func refreshStoreSourceChanges(for tools: [Tool]) async {
@@ -207,6 +234,12 @@ final class ToolLibraryStorePublisher {
             publishCategory = tool.category
             currentPublishedSourceSha256 = nil
         }
+        do {
+            try await preparePublishIdentity(for: tool, linkedApp: linkedApp)
+        } catch {
+            present(error)
+            return
+        }
         isUpdatingPublishedListing = linkedApp != nil
         publishingToolID = tool.id
         publishScreenshotData = nil
@@ -226,6 +259,13 @@ final class ToolLibraryStorePublisher {
         defer { isPublishing = false }
 
         do {
+            let publicationName = tool.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !publicationName.isEmpty else {
+                throw ToolLibraryStorePublishingError.invalidAppName
+            }
+            guard canPublishRemixIdentity(for: tool) else {
+                throw ToolLibraryStorePublishingError.remixNameMatchesOriginal
+            }
             let source = try sourceCode(for: tool)
             if linkedPublishedApp(for: tool) != nil,
                 let currentPublishedSourceSha256,
@@ -271,7 +311,7 @@ final class ToolLibraryStorePublisher {
                 app = try await storeClient.publishApp(
                     StorePublicationRequest(
                         storeId: tool.storeId ?? IronsmithStoreConstants.communityStoreId,
-                        name: tool.name,
+                        name: publicationName,
                         shortDescription: publishShortDescription.trimmingCharacters(
                             in: .whitespacesAndNewlines),
                         description: publishDescription.trimmingCharacters(
@@ -357,6 +397,48 @@ final class ToolLibraryStorePublisher {
         return publishedStoreAppsByID[storeAppId]
     }
 
+    private func preparePublishIdentity(
+        for tool: Tool,
+        linkedApp: StoreAppSummary?
+    ) async throws {
+        refreshPublishIdentity(for: tool)
+        originalRemixApp = nil
+        originalRemixIconData = nil
+
+        guard linkedApp == nil,
+            tool.storeRemixedFromVersionId != nil,
+            let storeId = tool.storeId,
+            let appId = tool.storeAppId
+        else { return }
+
+        let originalApp = try await storeClient.fetchApp(storeId, appId)
+        originalRemixApp = originalApp
+        if let url = originalApp.iconAsset?.url {
+            if let downloadedIconData = try? await originalIconDataLoader(url) {
+                originalRemixIconData = comparableOriginalIconData(
+                    downloadedIconData,
+                    app: originalApp
+                )
+            }
+        }
+    }
+
+    private func comparableOriginalIconData(
+        _ downloadedIconData: Data,
+        app: StoreAppDetail
+    ) -> Data {
+        guard app.iconMaster == nil,
+            let decodedIcon = try? ToolImageAssetEncoder.decodeImage(
+                downloadedIconData,
+                applyingOrientation: true
+            ),
+            let normalizedIcon = try? ToolImageAssetEncoder.iconAssets(from: decodedIcon)
+        else {
+            return downloadedIconData
+        }
+        return normalizedIcon.thumbnailData
+    }
+
     private func sourceCode(for tool: Tool) throws -> String {
         try String(
             contentsOf: try tool.packageLayout.packageFileURL(for: tool.contentViewSourcePath),
@@ -435,8 +517,10 @@ private struct StoreSourceChangeInput: Sendable {
 }
 
 private enum ToolLibraryStorePublishingError: LocalizedError {
+    case invalidAppName
     case invalidDisplayName
     case invalidHandle
+    case remixNameMatchesOriginal
     case localFinalizationFailed(String)
 
     static func localFinalizationWarning(
@@ -460,10 +544,14 @@ private enum ToolLibraryStorePublishingError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
+        case .invalidAppName:
+            "Enter an app name before publishing."
         case .invalidDisplayName:
             "Enter a display name between 1 and 80 characters."
         case .invalidHandle:
             "Enter a handle using 3–30 letters, numbers, or underscores that begins and ends with a letter or number."
+        case .remixNameMatchesOriginal:
+            "Current app name is the same as the original. Change the app name in Edit Details before publishing."
         case .localFinalizationFailed(let detail):
             """
             This app was published successfully, but Ironsmith could not finish updating its \

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolGridItemView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolGridItemView.swift
@@ -94,7 +94,7 @@ struct ToolGridItemView: View {
     }
 
     private var busyAccessibilityLabel: String? {
-        if tool.generationState == .generating {
+        if tool.generationState == .generating || state.isPreparingGeneration {
             return "Generating \(tool.name)"
         }
         if state.isLaunching {
@@ -116,7 +116,7 @@ struct ToolGridItemView: View {
     }
 
     private var accessibilityHint: String {
-        if tool.isGenerationReady {
+        if tool.isGenerationReady, !state.isPreparingGeneration {
             return "Selects the app for editing. Hover over its icon to run it."
         }
         if tool.generationState == .stopped || tool.generationState == .failed {
@@ -136,7 +136,7 @@ struct ToolGridItemView: View {
     }
 
     private func selectIfAvailable() {
-        guard ToolGridItemInteraction.canSelect(tool: tool) else { return }
+        guard ToolGridItemInteraction.canSelect(tool: tool, state: state) else { return }
         actions.onSelect()
     }
 
@@ -154,15 +154,15 @@ struct ToolGridItemView: View {
 
 @MainActor
 enum ToolGridItemInteraction {
-    static func canSelect(tool: Tool) -> Bool {
-        tool.isGenerationReady
+    static func canSelect(tool: Tool, state: ToolItemPresentationState) -> Bool {
+        tool.isGenerationReady && !state.isPreparingGeneration
     }
 
     static func iconAction(
         tool: Tool,
         state: ToolItemPresentationState
     ) -> ToolGridIconAction? {
-        if tool.generationState == .generating {
+        if tool.generationState == .generating || state.isPreparingGeneration {
             return .pauseGeneration
         }
         guard !state.isBusy else { return nil }
@@ -228,6 +228,7 @@ enum ToolGridIconAction: Equatable {
         isRebuilding: false,
         isRestoring: false,
         isEditingDetails: false,
+        isPreparingGeneration: false,
         canRevert: false,
         showsStoreActions: false,
         canUpdateStoreVersion: false,

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolItemActions.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolItemActions.swift
@@ -8,6 +8,7 @@ struct ToolItemPresentationState {
     let isRebuilding: Bool
     let isRestoring: Bool
     let isEditingDetails: Bool
+    let isPreparingGeneration: Bool
     let canRevert: Bool
     let showsStoreActions: Bool
     let canUpdateStoreVersion: Bool
@@ -17,6 +18,7 @@ struct ToolItemPresentationState {
 
     var isBusy: Bool {
         isLaunching || isExporting || isRebuilding || isRestoring || isEditingDetails
+            || isPreparingGeneration
     }
 }
 
@@ -71,7 +73,7 @@ struct ToolItemActionsMenu: View {
                 actions.onEdit()
             }
         }
-        .disabled(!(state.isSelected || tool.isGenerationReady))
+        .disabled(state.isPreparingGeneration || !(state.isSelected || tool.isGenerationReady))
 
         Button(launchAction.title) {
             switch launchAction {
@@ -85,7 +87,10 @@ struct ToolItemActionsMenu: View {
                 actions.onRun()
             }
         }
-        .disabled(state.isBusy || !(tool.isGenerationReady || canContinue || isGenerating))
+        .disabled(
+            (state.isBusy && !isGenerating)
+                || !(tool.isGenerationReady || canContinue || isGenerating)
+        )
 
         Divider()
         Button("Edit App Details...", action: actions.onEditDetails)
@@ -134,7 +139,7 @@ struct ToolItemActionsMenu: View {
     }
 
     private var isGenerating: Bool {
-        tool.generationState == .generating
+        tool.generationState == .generating || state.isPreparingGeneration
     }
 
     private var shouldDiscardFromMenu: Bool {
@@ -153,7 +158,7 @@ enum ToolItemLaunchAction: Equatable {
         tool: Tool,
         state: ToolItemPresentationState
     ) -> ToolItemLaunchAction {
-        if tool.generationState == .generating {
+        if tool.generationState == .generating || state.isPreparingGeneration {
             return .pauseGeneration
         }
         if tool.generationState == .stopped || tool.generationState == .failed {

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -42,7 +42,7 @@ struct ToolRowView: View {
             .background(backgroundStyle, in: RoundedRectangle(cornerRadius: 14))
             .contentShape(RoundedRectangle(cornerRadius: 14))
             .onTapGesture {
-                guard tool.isGenerationReady else { return }
+                guard tool.isGenerationReady, !state.isPreparingGeneration else { return }
                 actions.onSelect()
             }
             .contextMenu {
@@ -73,7 +73,7 @@ struct ToolRowView: View {
             ToolIconImageView(tool: tool)
                 .frame(width: 42, height: 42)
 
-            if tool.generationState == .generating && isHoveringRow {
+            if isGenerating && isHoveringRow {
                 Button(action: actions.onStop) {
                     Image(systemName: "pause.fill")
                         .font(.system(size: 15, weight: .bold))
@@ -83,7 +83,7 @@ struct ToolRowView: View {
                 .help("Pause \(tool.name)")
                 .accessibilityLabel("Pause \(tool.name)")
                 .accessibilityIdentifier("pause-tool-\(tool.id.uuidString)")
-            } else if tool.generationState == .generating {
+            } else if isGenerating {
                 iconProgressOverlay("Generating \(tool.name)")
             } else if state.isLaunching {
                 iconProgressOverlay("Running \(tool.name)")
@@ -124,6 +124,9 @@ struct ToolRowView: View {
     }
 
     private var generationStatusText: String? {
+        if state.isPreparingGeneration {
+            return "Creating remix identity"
+        }
         switch tool.generationState {
         case .ready:
             return nil
@@ -142,6 +145,10 @@ struct ToolRowView: View {
 
     private var canContinue: Bool {
         tool.generationState == .stopped || tool.generationState == .failed
+    }
+
+    private var isGenerating: Bool {
+        tool.generationState == .generating || state.isPreparingGeneration
     }
 
     private var statusStyle: some ShapeStyle {
@@ -183,6 +190,7 @@ struct ToolRowView: View {
             isRebuilding: false,
             isRestoring: false,
             isEditingDetails: false,
+            isPreparingGeneration: false,
             canRevert: true,
             showsStoreActions: true,
             canUpdateStoreVersion: false,

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -11,6 +11,12 @@ enum ToolLibraryPresentedErrorAction: Equatable {
     case buyIronsmithCredits
 }
 
+enum ToolRemixIdentitySubmissionAction: Equatable {
+    case submit
+    case presentNotice
+    case generateIdentity
+}
+
 private enum ToolLibraryGenerationError: LocalizedError {
     case missingPreparedTool
 
@@ -1064,6 +1070,29 @@ final class ToolLibraryStore {
         tool.applyGenerationSettings(result.settings)
         tool.packageRootPath = result.packageRootURL.path
         clearPendingGeneration(on: tool)
+    }
+
+    func isFirstEditOfDownloadedApp(_ tool: Tool) -> Bool {
+        guard tool.storeAppId != nil,
+              tool.storeRemixedFromVersionId != nil,
+              tool.isGenerationReady,
+              let storeSourceSha256 = tool.storeSourceSha256?.lowercased(),
+              let source = try? String(
+                  contentsOf: Self.contentViewURL(for: tool),
+                  encoding: .utf8
+              ),
+              IronsmithStoreClient.sha256Hex(for: source) == storeSourceSha256
+        else { return false }
+        return true
+    }
+
+    func remixIdentitySubmissionAction(
+        for tool: Tool,
+        generatesIdentity: Bool,
+        hasPresentedNotice: Bool
+    ) -> ToolRemixIdentitySubmissionAction {
+        guard isFirstEditOfDownloadedApp(tool), generatesIdentity else { return .submit }
+        return hasPresentedNotice ? .generateIdentity : .presentNotice
     }
 
     private func clearPendingGeneration(on tool: Tool) {

--- a/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/ToolImageAssetEncoderTests.swift
@@ -433,6 +433,57 @@ struct ToolImageAssetEncoderTests {
 
     @MainActor
     @Test
+    func generatedRemixIdentityRenamesReiconsAndPreservesStoreSourceBaseline() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let tool = Tool(
+            name: "Tiny Notes",
+            executableName: "TinyNotes",
+            packageRootPath: root.appendingPathComponent("TinyNotes").path,
+            storeAppId: "00000000-0000-4000-8000-000000000101",
+            storeSourceSha256: "downloaded-source-hash",
+            storeRemixedFromVersionId: "00000000-0000-4000-8000-000000000201"
+        )
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = container.mainContext
+        context.insert(tool)
+        try context.save()
+        let generatedImage = try Self.solidImage(width: 1024, height: 1024)
+        let iconClient = ToolIconEditingClient.live(
+            imageClient: ToolImageGenerationClient { _, _ in generatedImage }
+        )
+        let buildCapture = IconEditorBuildCapture()
+        let store = ToolAppDetailsEditorStore(
+            iconClient: iconClient,
+            buildClient: ToolBuildClient { tool in
+                await buildCapture.record(name: tool.name)
+            }
+        )
+
+        let saved = await store.generateAndSaveRemixIdentity(
+            for: tool,
+            name: "Pocket Pages",
+            iconPrompt: "A playful stack of colorful note cards",
+            provider: .imagePlayground,
+            in: context,
+            rename: { proposedName in
+                tool.name = proposedName
+                try? context.save()
+                return nil
+            }
+        )
+
+        #expect(saved)
+        #expect(tool.name == "Pocket Pages")
+        #expect(tool.storeSourceSha256 == "downloaded-source-hash")
+        #expect(await buildCapture.names == ["Pocket Pages"])
+        #expect(FileManager.default.fileExists(
+            atPath: tool.packageLayout.cachedAppIconThumbnailJPEGURL.path
+        ))
+    }
+
+    @MainActor
+    @Test
     func appDetailsEditorRestoresThePreviousNameWhenTheStagedBuildFails() async throws {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -37,7 +37,6 @@ struct StoreImportTests {
 
         await store.install(
             app,
-            mode: .get,
             tools: [],
             modelContext: context,
             routeStore: IronsmithRouteStore(openSettingsWindow: {}),
@@ -48,7 +47,7 @@ struct StoreImportTests {
         #expect(store.workingAppID == nil)
         #expect(store.errorMessage == nil)
         #expect(try context.fetch(FetchDescriptor<Tool>()).isEmpty)
-        guard case .appSummary(let pendingApp, mode: .get) = store.pendingDownloadRequest else {
+        guard case .appSummary(let pendingApp) = store.pendingDownloadRequest else {
             Issue.record("Expected the Get request to remain pending for sign-in.")
             return
         }
@@ -100,14 +99,14 @@ struct StoreImportTests {
 
     @MainActor
     @Test
-    func unsignedRemixRequiresAnAccountAndPreservesThePendingAction() async throws {
+    func unsignedDownloadRequiresAnAccountAndPreservesThePendingAction() async throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
         let app = Self.appListing(sourceCode: Self.sourceCode("remix"))
         let store = StoreWindowStore(
             client: .unconfigured,
             importClient: StoreToolImportClient(importTool: { _, _ in
-                Issue.record("An unsigned remix must not import an app.")
+                Issue.record("An unsigned download must not import an app.")
                 throw IronsmithStoreClientError.notConfigured
             }),
             buildClient: ToolBuildClient(buildTool: { _ in })
@@ -115,7 +114,6 @@ struct StoreImportTests {
 
         await store.install(
             app,
-            mode: .remix,
             tools: [],
             modelContext: context,
             routeStore: IronsmithRouteStore(openSettingsWindow: {}),
@@ -123,8 +121,8 @@ struct StoreImportTests {
         )
 
         #expect(store.isDownloadSignInRequired)
-        guard case .appDetail(let pendingApp, mode: .remix) = store.pendingDownloadRequest else {
-            Issue.record("Expected the Remix request to remain pending for sign-in.")
+        guard case .appDetail(let pendingApp) = store.pendingDownloadRequest else {
+            Issue.record("Expected the download request to remain pending for sign-in.")
             return
         }
         #expect(pendingApp.id == app.id)
@@ -146,7 +144,7 @@ struct StoreImportTests {
         )
         let importer = StoreToolImportClient.live(toolsDirectoryURL: root)
         let installed = try await importer.importTool(
-            StoreToolImportRequest(app: app, version: version, mode: .get),
+            StoreToolImportRequest(app: app, version: version),
             context
         ).tool
         let store = StoreWindowStore(
@@ -157,7 +155,6 @@ struct StoreImportTests {
 
         await store.install(
             app,
-            mode: .get,
             tools: [installed],
             modelContext: context,
             routeStore: IronsmithRouteStore(openSettingsWindow: {}),
@@ -240,7 +237,7 @@ struct StoreImportTests {
         )
 
         let result = try await StoreToolImportClient.live(toolsDirectoryURL: root)
-            .importTool(StoreToolImportRequest(app: app, version: version, mode: .get), context)
+            .importTool(StoreToolImportRequest(app: app, version: version), context)
 
         let tool = result.tool
         let sourceOnDisk = try String(
@@ -248,7 +245,6 @@ struct StoreImportTests {
             encoding: .utf8)
         let tools = try context.fetch(FetchDescriptor<Tool>())
 
-        #expect(result.mode == .get)
         #expect(tools.map(\.id) == [tool.id])
         #expect(sourceOnDisk == source)
         #expect(tool.generationState == .ready)
@@ -317,7 +313,7 @@ struct StoreImportTests {
         )
 
         let result = try await client.importTool(
-            StoreToolImportRequest(app: app, version: version, mode: .get),
+            StoreToolImportRequest(app: app, version: version),
             context
         )
         let layout = result.tool.packageLayout
@@ -342,7 +338,7 @@ struct StoreImportTests {
 
     @MainActor
     @Test
-    func remixImportTracksParentVersionWithoutLinkingOriginalAppForUpdates() async throws {
+    func downloadImportTracksParentVersionForFutureRemixAttribution() async throws {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
@@ -356,9 +352,9 @@ struct StoreImportTests {
         )
 
         let result = try await StoreToolImportClient.live(toolsDirectoryURL: root)
-            .importTool(StoreToolImportRequest(app: app, version: version, mode: .remix), context)
+            .importTool(StoreToolImportRequest(app: app, version: version), context)
 
-        #expect(result.tool.name == "\(app.name) Remix")
+        #expect(result.tool.name == app.name)
         #expect(result.tool.storeId == app.storeId)
         #expect(result.tool.storeAppId == app.id)
         #expect(result.tool.storeVersionId == version.id)
@@ -388,7 +384,6 @@ struct StoreImportTests {
                 StoreToolImportRequest(
                     app: app,
                     version: version,
-                    mode: .get
                 ),
                 context
             )
@@ -418,9 +413,9 @@ struct StoreImportTests {
         let client = StoreToolImportClient.live(toolsDirectoryURL: root)
 
         let first = try await client.importTool(
-            StoreToolImportRequest(app: app, version: version, mode: .get), context)
+            StoreToolImportRequest(app: app, version: version), context)
         let second = try await client.importTool(
-            StoreToolImportRequest(app: app, version: version, mode: .get), context)
+            StoreToolImportRequest(app: app, version: version), context)
         let tools = try context.fetch(FetchDescriptor<Tool>())
 
         #expect(tools.count == 2)
@@ -456,7 +451,7 @@ struct StoreImportTests {
         )
 
         let imported = try await StoreToolImportClient.live(toolsDirectoryURL: root)
-            .importTool(StoreToolImportRequest(app: app, version: oldVersion, mode: .get), context)
+            .importTool(StoreToolImportRequest(app: app, version: oldVersion), context)
 
         guard
             case .updateExisting(let updatableTool) = store.installDisposition(
@@ -531,7 +526,6 @@ struct StoreImportTests {
                     sourceCode: oldSource,
                     sourceSha256: oldMetadata.sourceSha256
                 ),
-                mode: .get
             ),
             context
         )
@@ -557,7 +551,6 @@ struct StoreImportTests {
                     sourceCode: currentSource,
                     sourceSha256: currentMetadata.sourceSha256
                 ),
-                mode: .get
             ),
             context
         )
@@ -920,7 +913,7 @@ struct StoreImportTests {
         )
         let importer = StoreToolImportClient.live(toolsDirectoryURL: root)
         let existing = try await importer.importTool(
-            StoreToolImportRequest(app: app, version: currentDownload, mode: .get),
+            StoreToolImportRequest(app: app, version: currentDownload),
             context
         ).tool
         var client = IronsmithStoreClient.unconfigured

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
@@ -8,6 +8,70 @@ import Testing
 extension ToolLibraryTests {
     @MainActor
     @Test
+    func downloadedAppFirstEditUsesExistingStoreAttributionAndSourceHash() throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let source = "import SwiftUI\nstruct ContentView: View { var body: some View { Text(\"Original\") } }\n"
+        let tool = Tool(
+            name: "Tiny Notes",
+            executableName: "TinyNotes",
+            packageRootPath: root.path,
+            storeAppId: "00000000-0000-4000-8000-000000000101",
+            storeSourceSha256: IronsmithStoreClient.sha256Hex(for: source),
+            storeRemixedFromVersionId: "00000000-0000-4000-8000-000000000201"
+        )
+        let sourceURL = try tool.packageLayout.packageFileURL(for: tool.contentViewSourcePath)
+        try FileManager.default.createDirectory(
+            at: sourceURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try source.write(to: sourceURL, atomically: true, encoding: .utf8)
+        let store = ToolLibraryStore()
+
+        #expect(store.isFirstEditOfDownloadedApp(tool))
+        #expect(
+            store.remixIdentitySubmissionAction(
+                for: tool,
+                generatesIdentity: true,
+                hasPresentedNotice: false
+            ) == .presentNotice
+        )
+        #expect(
+            store.remixIdentitySubmissionAction(
+                for: tool,
+                generatesIdentity: true,
+                hasPresentedNotice: true
+            ) == .generateIdentity
+        )
+        #expect(
+            store.remixIdentitySubmissionAction(
+                for: tool,
+                generatesIdentity: false,
+                hasPresentedNotice: false
+            ) == .submit
+        )
+        try (source + "// changed\n").write(
+            to: sourceURL,
+            atomically: true,
+            encoding: .utf8
+        )
+        #expect(!store.isFirstEditOfDownloadedApp(tool))
+        #expect(
+            store.remixIdentitySubmissionAction(
+                for: tool,
+                generatesIdentity: true,
+                hasPresentedNotice: false
+            ) == .submit
+        )
+
+        try source.write(to: sourceURL, atomically: true, encoding: .utf8)
+        tool.generationState = .stopped
+        tool.generationMode = .edit
+        #expect(!store.isFirstEditOfDownloadedApp(tool))
+    }
+
+    @MainActor
+    @Test
     func toolLibraryStoreSuppressesGenerationCancellationErrors() async throws {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryPresentationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryPresentationTests.swift
@@ -92,9 +92,11 @@ extension ToolLibraryTests {
         let idleState = Self.toolItemState()
         let runningState = Self.toolItemState(isRunning: true)
         let launchingState = Self.toolItemState(isLaunching: true)
+        let preparingGenerationState = Self.toolItemState(isPreparingGeneration: true)
 
-        #expect(ToolGridItemInteraction.canSelect(tool: readyTool))
-        #expect(!ToolGridItemInteraction.canSelect(tool: stoppedTool))
+        #expect(ToolGridItemInteraction.canSelect(tool: readyTool, state: idleState))
+        #expect(!ToolGridItemInteraction.canSelect(tool: stoppedTool, state: idleState))
+        #expect(!ToolGridItemInteraction.canSelect(tool: readyTool, state: preparingGenerationState))
         #expect(ToolGridItemInteraction.iconAction(tool: readyTool, state: idleState) == .run)
         #expect(ToolGridItemInteraction.iconAction(tool: readyTool, state: runningState) == .run)
         #expect(ToolGridItemInteraction.iconAction(tool: readyTool, state: launchingState) == nil)
@@ -113,11 +115,20 @@ extension ToolLibraryTests {
             ToolGridItemInteraction.iconAction(tool: generatingTool, state: idleState)
                 == .pauseGeneration
         )
+        #expect(
+            ToolGridItemInteraction.iconAction(tool: readyTool, state: preparingGenerationState)
+                == .pauseGeneration
+        )
+        #expect(
+            ToolItemLaunchAction.resolve(tool: readyTool, state: preparingGenerationState)
+                == .pauseGeneration
+        )
     }
 
     private static func toolItemState(
         isRunning: Bool = false,
-        isLaunching: Bool = false
+        isLaunching: Bool = false,
+        isPreparingGeneration: Bool = false
     ) -> ToolItemPresentationState {
         ToolItemPresentationState(
             isSelected: false,
@@ -127,6 +138,7 @@ extension ToolLibraryTests {
             isRebuilding: false,
             isRestoring: false,
             isEditingDetails: false,
+            isPreparingGeneration: isPreparingGeneration,
             canRevert: false,
             showsStoreActions: false,
             canUpdateStoreVersion: false,

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -58,7 +58,9 @@ extension ToolLibraryTests {
         let tool = Tool(
             name: "Old Name",
             executableName: "RenamePackage",
-            packageRootPath: packageRoot.path
+            packageRootPath: packageRoot.path,
+            storeSourceSha256: "downloaded-source-hash",
+            storeRemixedFromVersionId: "00000000-0000-4000-8000-000000000201"
         )
         context.insert(tool)
         try FileManager.default.createDirectory(at: tool.appBundleURL, withIntermediateDirectories: true)
@@ -72,6 +74,7 @@ extension ToolLibraryTests {
         toolLibraryState.rename(tool, to: "  New Name  ", in: context)
 
         #expect(tool.name == "New Name")
+        #expect(tool.storeSourceSha256 == "downloaded-source-hash")
         #expect(toolLibraryState.promptPlaceholder == "Describe changes for New Name…")
         #expect(!(FileManager.default.fileExists(atPath: oldBundleURL.path)))
         #expect(FileManager.default.fileExists(atPath: newBundleURL.path))

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -65,6 +65,127 @@ extension ToolLibraryTests {
 
     @MainActor
     @Test
+    func remixPublishingShowsCurrentLegacyIconAndRequiresDistinctName() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let sourceIcon = try ToolImageAssetEncoder.decodeImage(
+            Self.publisherLegacyIconPNG(),
+            applyingOrientation: true
+        )
+        let originalIconData = try ToolImageAssetEncoder.iconAssets(
+            from: sourceIcon
+        ).thumbnailData
+        let importedIcon = try ToolImageAssetEncoder.iconAssets(
+            from: ToolImageAssetEncoder.decodeImage(
+                originalIconData,
+                applyingOrientation: true
+            )
+        ).thumbnailData
+        let original = Self.publisherAppDetail(
+            icon: StoreAsset(
+                id: "00000000-0000-4000-8000-000000000301",
+                kind: .icon,
+                sortOrder: 0,
+                width: 256,
+                height: 256,
+                byteSize: originalIconData.count,
+                url: URL(string: "https://example.com/icon.jpg")
+            )
+        )
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, _, _, _, _, _, _ in
+            StoreAppPage(apps: [], hasMore: false)
+        }
+        client.fetchApp = { _, _ in original }
+        let publisher = ToolLibraryStorePublisher(
+            storeClient: client,
+            iconClient: .noOp,
+            originalIconDataLoader: { _ in originalIconData }
+        )
+        let tool = Tool(
+            name: "Clipboard Cleaner",
+            executableName: "ClipboardCleaner",
+            packageRootPath: root.path,
+            storeId: original.storeId,
+            storeAppId: original.id,
+            storeRemixedFromVersionId: original.currentVersion.id
+        )
+        try Self.writeSource(
+            Self.publisherSource.replacingOccurrences(of: "Published", with: "Remixed"),
+            to: tool
+        )
+        try FileManager.default.createDirectory(
+            at: tool.packageLayout.packageMetadataDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try importedIcon.write(to: tool.packageLayout.cachedAppIconPNGURL)
+        let inferenceStore = InferenceStore(
+            dependencies: Self.inferenceDependencies(
+                accountClient: Self.ironsmithAccountClient(balanceCredits: 100)
+            )
+        )
+        inferenceStore.ironsmithSession = Self.ironsmithSession()
+
+        await publisher.beginPublishing(tool, inferenceStore: inferenceStore, tools: [tool])
+
+        #expect(publisher.originalRemixApp?.id == original.id)
+        #expect(publisher.publishNameMatchesOriginal(for: tool))
+        #expect(publisher.isUsingOriginalRemixIcon)
+        #expect(!publisher.canPublishRemixIdentity(for: tool))
+        tool.name = "clipboard cleaner"
+        #expect(publisher.publishNameMatchesOriginal(for: tool))
+        tool.name = "Clip Forge"
+        #expect(!publisher.publishNameMatchesOriginal(for: tool))
+        #expect(publisher.canPublishRemixIdentity(for: tool))
+
+        let editedIconData = Data([9, 8, 7])
+        try editedIconData.write(to: tool.packageLayout.cachedAppIconThumbnailJPEGURL)
+        publisher.refreshPublishIdentity(for: tool)
+        #expect(publisher.publishIconPreviewData == editedIconData)
+        #expect(!publisher.isUsingOriginalRemixIcon)
+    }
+
+    @MainActor
+    @Test
+    func remixPublishingRejectsOriginalNameBeforeUploading() async throws {
+        let original = Self.publisherAppDetail()
+        let publicationCapture = PublisherPublicationCapture()
+        var client = IronsmithStoreClient.unconfigured
+        client.publishApp = { request in
+            await publicationCapture.record(request)
+            return original
+        }
+        let publisher = ToolLibraryStorePublisher(
+            storeClient: client,
+            iconClient: .noOp
+        )
+        publisher.originalRemixApp = original
+        let tool = Tool(
+            name: "  clipboard cleaner  ",
+            packageRootPath: "/tmp/ClipboardCleaner"
+        )
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = container.mainContext
+        context.insert(tool)
+        let inferenceStore = InferenceStore(dependencies: Self.inferenceDependencies())
+
+        await publisher.publish(
+            tool,
+            modelContext: context,
+            inferenceStore: inferenceStore,
+            defaultSettings: .default,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {})
+        )
+
+        #expect(await publicationCapture.count == 0)
+        #expect(
+            publisher.errorMessage
+                == "Current app name is the same as the original. Change the app name in Edit Details before publishing."
+        )
+    }
+
+    @MainActor
+    @Test
     func storePublisherPrefillsDescriptionsForVersionUpdates() async throws {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
@@ -662,7 +783,8 @@ extension ToolLibraryTests {
     private static func publisherAppDetail(
         versionNumber: Int = 1,
         category: StoreAppCategory = .utilities,
-        source: String = publisherSource
+        source: String = publisherSource,
+        icon: StoreAsset? = nil
     ) -> StoreAppDetail {
         let appID = "00000000-0000-4000-8000-000000000101"
         let version = StoreVersionMetadata(
@@ -691,7 +813,7 @@ extension ToolLibraryTests {
             publishedAt: "2026-07-28T00:00:00.000Z",
             createdAt: "2026-07-28T00:00:00.000Z",
             updatedAt: "2026-07-28T00:00:00.000Z",
-            icon: nil,
+            icon: icon,
             iconMaster: nil,
             screenshots: [],
             currentVersion: version,


### PR DESCRIPTION
## Summary

- Editing an app after downloads turns it into an official remix, and changes the name and creates a new icon
- The publish sheet now has an app identity section to show the app name and icon.
- Prevents a remix from being published if it has the same name as the original app.
- Extend focused coverage for importing, publishing, presentation, selection, and image assets.