### PR TITLE
Add Store license selection and legal bundles

### DIFF
--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolAppBundleClient.swift
@@ -150,6 +150,12 @@ struct ToolAppBundleClient {
             iconClient: iconClient
         )
 
+        try copyLegalDocumentsIfAvailable(
+            request: request,
+            resourcesURL: resourcesURL,
+            fileManager: fileManager
+        )
+
         let infoPlistURL = contentsURL.appendingPathComponent("Info.plist")
         try writeInfoPlist(
             for: request,
@@ -216,6 +222,17 @@ struct ToolAppBundleClient {
         )
         try layout.fixedAppEntrySource(displayName: request.displayName, settings: request.settings)
             .write(to: appEntryURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func copyLegalDocumentsIfAvailable(
+        request: ToolAppBundleRequest,
+        resourcesURL: URL,
+        fileManager: FileManager
+    ) throws {
+        let sourceURL = request.layout.legalDirectoryURL
+        guard fileManager.fileExists(atPath: sourceURL.path) else { return }
+        let destinationURL = resourcesURL.appendingPathComponent("Legal", isDirectory: true)
+        try fileManager.copyItem(at: sourceURL, to: destinationURL)
     }
 
     private static func temporarySiblingAppBundleURL(for destinationAppURL: URL, label: String) -> URL {

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -382,6 +382,10 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
             .appendingPathComponent(executableName, isDirectory: true)
     }
 
+    nonisolated var legalDirectoryURL: URL {
+        packageRootURL.appendingPathComponent("Legal", isDirectory: true)
+    }
+
     nonisolated var appEntryFileName: String {
         "\(executableName).swift"
     }

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -306,6 +306,7 @@ nonisolated struct StorePublicationRequest: Sendable {
 nonisolated struct StoreVersionPublicationRequest: Sendable {
     let storeId: String
     let appId: String
+    let license: StoreLicenseIdentifier
     let shortDescription: String
     let description: String
     let sourceCode: String
@@ -503,6 +504,7 @@ extension IronsmithStoreClient {
                     throw IronsmithStoreClientError.invalidResponse
                 }
                 let metadata = StoreVersionMetadataPayload(
+                    license: request.license,
                     runtimeVersion: IronsmithStoreConstants.runtimeVersion,
                     generationSettings: StoreGenerationSettingsDTO(
                         settings: request.generationSettings),
@@ -733,6 +735,7 @@ nonisolated private struct StorePublicationMetadataPayload: Encodable {
 }
 
 nonisolated private struct StoreVersionMetadataPayload: Encodable {
+    let license: StoreLicenseIdentifier
     let runtimeVersion: String
     let generationSettings: StoreGenerationSettingsDTO
     let remixedFromVersionId: String?

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -118,7 +118,8 @@ nonisolated struct StoreVersionMetadata: Decodable, Identifiable, Equatable, Sen
     let sourceSha256: String
     let generationSettings: StoreGenerationSettingsDTO
     let runtimeVersion: String
-    let license: String
+    let license: StoreLicenseIdentifier
+    let legalAttributions: [StoreLegalAttribution]
     let scannerVersion: String
     let remixedFromVersionId: String?
     let publishedAt: String
@@ -133,7 +134,8 @@ nonisolated struct StoreVersionDownload: Decodable, Equatable, Sendable {
     let sourceSha256: String
     let generationSettings: StoreGenerationSettingsDTO
     let runtimeVersion: String
-    let license: String
+    let license: StoreLicenseIdentifier
+    let legalAttributions: [StoreLegalAttribution]
     let scannerVersion: String
     let remixedFromVersionId: String?
     let publishedAt: String
@@ -261,6 +263,7 @@ nonisolated struct StorePublicationRequest: Sendable {
     let shortDescription: String
     let description: String
     let category: StoreAppCategory
+    let license: StoreLicenseIdentifier
     let sourceCode: String
     let generationSettings: ToolGenerationSettings
     let iconMasterJPEG: Data
@@ -297,6 +300,7 @@ nonisolated enum IronsmithStoreClientError: LocalizedError, Equatable {
     case invalidResponse
     case requestFailed(statusCode: Int, message: String)
     case sourceHashMismatch(expected: String, actual: String)
+    case unsupportedLicense(String)
     case unchangedStoreVersion
 
     var errorDescription: String? {
@@ -311,6 +315,8 @@ nonisolated enum IronsmithStoreClientError: LocalizedError, Equatable {
             return "The Ironsmith Store returned HTTP \(statusCode): \(message)"
         case .sourceHashMismatch:
             return "The downloaded source did not match the scanned source hash."
+        case .unsupportedLicense(let identifier):
+            return "Update Ironsmith to download or remix apps containing the \(identifier) license."
         case .unchangedStoreVersion:
             return "The source matches the currently published version. Make a source change before publishing a new version."
         }
@@ -421,6 +427,7 @@ extension IronsmithStoreClient {
                     shortDescription: request.shortDescription,
                     description: request.description,
                     category: request.category,
+                    license: request.license,
                     runtimeVersion: IronsmithStoreConstants.runtimeVersion,
                     generationSettings: StoreGenerationSettingsDTO(
                         settings: request.generationSettings),
@@ -675,6 +682,7 @@ nonisolated private struct StorePublicationMetadataPayload: Encodable {
     let shortDescription: String
     let description: String
     let category: StoreAppCategory
+    let license: StoreLicenseIdentifier
     let runtimeVersion: String
     let generationSettings: StoreGenerationSettingsDTO
     let remixedFromVersionId: String?

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -155,38 +155,36 @@ private struct StoreDetailMetadataStrip: View {
         .overlay(alignment: .top) { Divider() }
         .overlay(alignment: .bottom) { Divider() }
         .sheet(isPresented: $isShowingLicense) {
-            StoreLicenseDetailSheet(app: app)
+            StoreLicenseDetailSheet(
+                license: app.currentVersion.license,
+                documents: StoreLegalDocumentRenderer.render(
+                    appName: app.name,
+                    currentVersionId: app.currentVersion.id,
+                    primaryLicense: app.currentVersion.license,
+                    attributions: app.currentVersion.legalAttributions
+                ),
+                inheritedAttributions: app.currentVersion.legalAttributions.filter {
+                    $0.versionId != app.currentVersion.id
+                }
+            )
         }
     }
 
 }
 
-private struct StoreLicenseDetailSheet: View {
-    let app: StoreAppDetail
+struct StoreLicenseDetailSheet: View {
+    let license: StoreLicenseIdentifier
+    let documents: StoreLegalDocuments
+    let inheritedAttributions: [StoreLegalAttribution]
     @Environment(\.dismiss) private var dismiss
-
-    private var documents: StoreLegalDocuments {
-        StoreLegalDocumentRenderer.render(
-            appName: app.name,
-            currentVersionId: app.currentVersion.id,
-            primaryLicense: app.currentVersion.license,
-            attributions: app.currentVersion.legalAttributions
-        )
-    }
-
-    private var inherited: [StoreLegalAttribution] {
-        app.currentVersion.legalAttributions.filter {
-            $0.versionId != app.currentVersion.id
-        }
-    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(alignment: .top) {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(app.currentVersion.license.title)
+                    Text(license.title)
                         .font(.title2.weight(.semibold))
-                    Text(app.currentVersion.license.summary)
+                    Text(license.summary)
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
@@ -194,11 +192,11 @@ private struct StoreLicenseDetailSheet: View {
                     .keyboardShortcut(.defaultAction)
             }
 
-            if !inherited.isEmpty {
+            if !inheritedAttributions.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Includes material under")
                         .font(.headline)
-                    ForEach(inherited, id: \.versionId) { attribution in
+                    ForEach(inheritedAttributions, id: \.versionId) { attribution in
                         Text(
                             "\(attribution.license.title) — \(attribution.appName), \(attribution.holderDisplayName)"
                         )

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -109,6 +109,7 @@ private struct StoreDetailMetadataStrip: View {
     let app: StoreAppDetail
     let onOpenCreator: (String, String) -> Void
     let onOpenRemix: (StoreRemixMetadata) -> Void
+    @State private var isShowingLicense = false
 
     private var columns: [GridItem] {
         if app.remix != nil {
@@ -140,13 +141,90 @@ private struct StoreDetailMetadataStrip: View {
                 value: String(app.currentVersion.versionNumber)
             )
             StoreDetailMetadataItem(title: "Category", value: app.category.title)
-            StoreDetailMetadataItem(title: "License", value: app.currentVersion.license)
+            StoreDetailLinkedMetadataItem(
+                title: "License",
+                value: app.currentVersion.license.title,
+                action: { isShowingLicense = true }
+            )
         }
         .padding(.vertical, 16)
         .overlay(alignment: .top) { Divider() }
         .overlay(alignment: .bottom) { Divider() }
+        .sheet(isPresented: $isShowingLicense) {
+            StoreLicenseDetailSheet(app: app)
+        }
     }
 
+}
+
+private struct StoreLicenseDetailSheet: View {
+    let app: StoreAppDetail
+    @Environment(\.dismiss) private var dismiss
+
+    private var documents: StoreLegalDocuments {
+        StoreLegalDocumentRenderer.render(
+            appName: app.name,
+            currentVersionId: app.currentVersion.id,
+            primaryLicense: app.currentVersion.license,
+            attributions: app.currentVersion.legalAttributions
+        )
+    }
+
+    private var inherited: [StoreLegalAttribution] {
+        app.currentVersion.legalAttributions.filter {
+            $0.versionId != app.currentVersion.id
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(app.currentVersion.license.title)
+                        .font(.title2.weight(.semibold))
+                    Text(app.currentVersion.license.summary)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+
+            if !inherited.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Includes material under")
+                        .font(.headline)
+                    ForEach(inherited, id: \.versionId) { attribution in
+                        Text(
+                            "\(attribution.license.title) — \(attribution.appName), \(attribution.holderDisplayName)"
+                        )
+                        .font(.callout)
+                    }
+                }
+            }
+
+            TabView {
+                legalText(documents.license)
+                    .tabItem { Text("License") }
+                legalText(documents.notice)
+                    .tabItem { Text("Notice") }
+                legalText(documents.attributions)
+                    .tabItem { Text("Attributions") }
+            }
+        }
+        .padding(20)
+        .frame(width: 680, height: 620)
+    }
+
+    private func legalText(_ text: String) -> some View {
+        ScrollView {
+            Text(text)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+        }
+    }
 }
 
 private struct StoreDetailCreatorMetadataItem: View {
@@ -519,7 +597,7 @@ private struct StoreVersionMetadataList: View {
             row("Published", StoreVersionPresentation.formattedDate(version.publishedAt))
             row("App Type", version.generationSettings.appKind.displayName)
             row("Permissions", StoreVersionPresentation.permissionsSummary(version))
-            row("License", version.license)
+            row("License", version.license.title)
             row("Runtime", version.runtimeVersion)
             row("Source Hash", version.sourceSha256, monospaced: true)
         }

--- a/Ironsmith/Features/Store/StoreLicense.swift
+++ b/Ironsmith/Features/Store/StoreLicense.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+nonisolated struct StoreLicenseIdentifier: RawRepresentable, Codable, Equatable, Hashable,
+    Identifiable, Sendable
+{
+    static let mit = Self(rawValue: "MIT")
+    static let apache2 = Self(rawValue: "Apache-2.0")
+    static let supported: [Self] = [.mit, .apache2]
+
+    let rawValue: String
+    init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .mit: "MIT License"
+        case .apache2: "Apache License 2.0"
+        default: rawValue
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .mit:
+            "A short permissive license requiring preservation of the copyright and license notice."
+        case .apache2:
+            "A permissive license with explicit patent terms and notice-preservation requirements."
+        default:
+            "This license is not supported by this version of Ironsmith."
+        }
+    }
+
+    var isSupportedForPublication: Bool {
+        Self.supported.contains(self)
+    }
+}
+
+nonisolated struct StoreLegalAttribution: Codable, Equatable, Sendable {
+    let versionId: String
+    let appName: String
+    let creatorHandle: String?
+    let creatorDisplayName: String
+    let publicationYear: Int
+    let license: StoreLicenseIdentifier
+
+    var holderDisplayName: String {
+        guard let creatorHandle, !creatorHandle.isEmpty else {
+            return creatorDisplayName
+        }
+        return "@\(creatorHandle)"
+    }
+}
+
+nonisolated struct StoreLegalDocuments: Equatable, Sendable {
+    let license: String
+    let notice: String
+    let attributions: String
+}
+
+nonisolated struct StoreLicenseTemplates: Equatable, Sendable {
+    let mit: String
+    let apache2: String
+
+    static func bundled(bundle: Bundle = .main) -> Self {
+        Self(
+            mit: load(named: "MIT", bundle: bundle),
+            apache2: load(named: "Apache-2.0", bundle: bundle)
+        )
+    }
+
+    private static func load(named name: String, bundle: Bundle) -> String {
+        guard let url = bundle.url(
+            forResource: name,
+            withExtension: "txt",
+            subdirectory: "StoreLicenses"
+        ), let text = try? String(contentsOf: url, encoding: .utf8)
+        else {
+            return "\(name) license text could not be loaded."
+        }
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+nonisolated enum StoreLegalDocumentRenderer {
+    static func render(
+        appName: String,
+        currentVersionId: String,
+        primaryLicense: StoreLicenseIdentifier,
+        attributions: [StoreLegalAttribution],
+        templates: StoreLicenseTemplates = .bundled()
+    ) -> StoreLegalDocuments {
+        let mitText = templates.mit
+        let apacheText = templates.apache2
+        let current = attributions.last(where: { $0.versionId == currentVersionId })
+        let holder = current?.holderDisplayName ?? "Unknown Creator"
+        let year = current?.publicationYear ?? Calendar(identifier: .gregorian).component(
+            .year, from: Date())
+        let copyright = "Copyright \(year) \(holder)"
+
+        let licenseText: String
+        switch primaryLicense {
+        case .mit:
+            licenseText = "Copyright (c) \(year) \(holder)\n\n\(mitText)"
+        case .apache2:
+            licenseText = apacheText
+        default:
+            licenseText = "Unsupported Store license: \(primaryLicense.rawValue)"
+        }
+
+        let inherited = attributions.filter { $0.versionId != currentVersionId }
+        let inheritedApacheNotices = inherited
+            .filter { $0.license == .apache2 }
+            .map { "\($0.appName)\nCopyright \($0.publicationYear) \($0.holderDisplayName)" }
+        let notice = (["\(appName)\n\(copyright)"] + inheritedApacheNotices)
+            .joined(separator: "\n\n")
+
+        let attributionText: String
+        if inherited.isEmpty {
+            attributionText = "No inherited Store attributions."
+        } else {
+            attributionText = inherited.map { attribution in
+                let heading = "\(attribution.appName) (Store version \(attribution.versionId))"
+                let upstreamCopyright =
+                    "Copyright \(attribution.publicationYear) \(attribution.holderDisplayName)"
+                let terms: String
+                switch attribution.license {
+                case .mit:
+                    terms = mitText
+                case .apache2:
+                    terms = apacheText
+                default:
+                    terms = "License text is unavailable for \(attribution.license.rawValue)."
+                }
+                return """
+                    \(heading)
+                    License: \(attribution.license.rawValue)
+                    \(upstreamCopyright)
+
+                    \(terms)
+                    """
+            }.joined(separator: "\n\n---\n\n")
+        }
+
+        return StoreLegalDocuments(
+            license: licenseText + "\n",
+            notice: notice + "\n",
+            attributions: attributionText + "\n"
+        )
+    }
+
+}
+
+nonisolated enum StoreLegalPackageWriter {
+    static func write(
+        _ documents: StoreLegalDocuments,
+        to layout: ToolPackageLayout,
+        fileManager: FileManager = .default
+    ) throws {
+        let directory = layout.legalDirectoryURL
+        let identifier = UUID().uuidString.lowercased()
+        let stagingDirectory = layout.packageRootURL.appendingPathComponent(
+            ".Legal.staging.\(identifier)", isDirectory: true)
+        let backupDirectory = layout.packageRootURL.appendingPathComponent(
+            ".Legal.backup.\(identifier)", isDirectory: true)
+        defer {
+            try? fileManager.removeItem(at: stagingDirectory)
+        }
+
+        try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        try write(documents, to: stagingDirectory)
+
+        let hadExistingDirectory = fileManager.fileExists(atPath: directory.path)
+        if hadExistingDirectory {
+            try fileManager.moveItem(at: directory, to: backupDirectory)
+        }
+        do {
+            try fileManager.moveItem(at: stagingDirectory, to: directory)
+        } catch let replacementError {
+            if hadExistingDirectory {
+                try fileManager.moveItem(at: backupDirectory, to: directory)
+            }
+            throw replacementError
+        }
+        try? fileManager.removeItem(at: backupDirectory)
+    }
+
+    private static func write(_ documents: StoreLegalDocuments, to directory: URL) throws {
+        try documents.license.write(
+            to: directory.appendingPathComponent("LICENSE.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try documents.notice.write(
+            to: directory.appendingPathComponent("NOTICE.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try documents.attributions.write(
+            to: directory.appendingPathComponent("ATTRIBUTIONS.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+}

--- a/Ironsmith/Features/Store/StoreLicense.swift
+++ b/Ironsmith/Features/Store/StoreLicense.swift
@@ -147,6 +147,7 @@ nonisolated enum StoreLegalDocumentRenderer {
                     \(heading)
                     License: \(attribution.license.rawValue)
                     \(upstreamCopyright)
+                    The source in this version was modified from the work above.
 
                     \(terms)
                     """

--- a/Ironsmith/Features/Store/StoreToolImportClient.swift
+++ b/Ironsmith/Features/Store/StoreToolImportClient.swift
@@ -41,6 +41,14 @@ extension StoreToolImportClient {
     ) -> Self {
         StoreToolImportClient { request, modelContext in
             try IronsmithStoreClient.verifySourceHash(request.version)
+            let licenses = [request.version.license]
+                + request.version.legalAttributions.map(\.license)
+            if let unsupportedLicense = licenses.first(where: {
+                !$0.isSupportedForPublication
+            }) {
+                throw IronsmithStoreClientError.unsupportedLicense(
+                    unsupportedLicense.rawValue)
+            }
 
             let displayName =
                 request.displayName
@@ -61,6 +69,15 @@ extension StoreToolImportClient {
                 displayName: displayName,
                 settings: settings,
                 contentViewSource: request.version.sourceCode
+            )
+            try StoreLegalPackageWriter.write(
+                StoreLegalDocumentRenderer.render(
+                    appName: request.app.name,
+                    currentVersionId: request.version.id,
+                    primaryLicense: request.version.license,
+                    attributions: request.version.legalAttributions
+                ),
+                to: layout
             )
             try await cacheIconIfAvailable(
                 app: request.app,

--- a/Ironsmith/Features/Store/StoreWindowStore.swift
+++ b/Ironsmith/Features/Store/StoreWindowStore.swift
@@ -373,12 +373,13 @@ final class StoreWindowStore {
         }
     }
 
-    func select(_ app: StoreAppSummary) {
-        select(storeID: app.storeId, appID: app.id)
+    func select(_ app: StoreAppSummary, forceReload: Bool = false) {
+        select(storeID: app.storeId, appID: app.id, forceReload: forceReload)
     }
 
-    func select(storeID: String, appID: String) {
-        if selectedAppID == appID,
+    func select(storeID: String, appID: String, forceReload: Bool = false) {
+        if !forceReload,
+            selectedAppID == appID,
             selectedAppDetail?.id == appID || isLoadingDetail
         {
             return

--- a/Ironsmith/Features/Store/StoreWindowView.swift
+++ b/Ironsmith/Features/Store/StoreWindowView.swift
@@ -319,7 +319,7 @@ struct StoreWindowView: View {
                 await store.refreshPublished(showLoadingIndicator: false)
                 categoryRefreshToken += 1
                 if let app = store.publishedApps.first(where: { $0.id == appID }) {
-                    store.select(app)
+                    store.select(app, forceReload: true)
                     path = [.app(StoreAppRoute(app: app))]
                 }
             }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -591,6 +591,7 @@ struct ToolLibraryPopoverView: View {
                 publishShortDescription: $storePublisher.publishShortDescription,
                 publishDescription: $storePublisher.publishDescription,
                 publishCategory: $storePublisher.publishCategory,
+                publishLicense: $storePublisher.publishLicense,
                 publishScreenshotName: storePublisher.publishScreenshotName,
                 isPublishing: storePublisher.isPublishing,
                 onChooseScreenshot: { url in

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -633,6 +633,8 @@ struct ToolLibraryPopoverView: View {
                 publishLicense: $storePublisher.publishLicense,
                 publishScreenshotName: storePublisher.publishScreenshotName,
                 publishIconPreviewData: storePublisher.publishIconPreviewData,
+                creatorHandle: inferenceStore.ironsmithAccountSummary?.profile?.handle ?? "",
+                inheritedLegalAttributions: storePublisher.publishInheritedLegalAttributions,
                 publishNameMatchesOriginal: storePublisher.publishNameMatchesOriginal(
                     for: tool
                 ),

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -74,24 +74,22 @@ struct ToolLibraryStorePublishSheetView: View {
                     }
                     .labelsHidden()
                 }
-                field("License") {
-                    Picker("License", selection: $publishLicense) {
-                        ForEach(StoreLicenseIdentifier.supported) { license in
-                            Text(license.title).tag(license)
-                        }
+            }
+
+            field("License") {
+                Picker("License", selection: $publishLicense) {
+                    ForEach(StoreLicenseIdentifier.supported) { license in
+                        Text(license.title).tag(license)
                     }
-                    .labelsHidden()
-                    Text(publishLicense.summary)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                 }
-            } else {
-                field("License") {
-                    Text(publishLicense.title)
-                    Text("The license is fixed for all versions of this Store app.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                .labelsHidden()
+                Text(
+                    isUpdatingPublishedListing
+                        ? "This license applies to the new version. Earlier versions keep their existing licenses."
+                        : publishLicense.summary
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
 
             field("Screenshot") {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -11,6 +11,8 @@ struct ToolLibraryStorePublishSheetView: View {
     @Binding var publishLicense: StoreLicenseIdentifier
     let publishScreenshotName: String?
     let publishIconPreviewData: Data?
+    let creatorHandle: String
+    let inheritedLegalAttributions: [StoreLegalAttribution]
     let publishNameMatchesOriginal: Bool
     let isUsingOriginalRemixIcon: Bool
     let isPublishing: Bool
@@ -19,6 +21,7 @@ struct ToolLibraryStorePublishSheetView: View {
     let onEditDetails: () -> Void
     let onPublish: () -> Void
     @State private var isChoosingScreenshot = false
+    @State private var isShowingLicense = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -77,19 +80,25 @@ struct ToolLibraryStorePublishSheetView: View {
             }
 
             field("License") {
-                Picker("License", selection: $publishLicense) {
-                    ForEach(StoreLicenseIdentifier.supported) { license in
-                        Text(license.title).tag(license)
+                HStack {
+                    Picker("License", selection: $publishLicense) {
+                        ForEach(StoreLicenseIdentifier.supported) { license in
+                            Text(license.title).tag(license)
+                        }
+                    }
+                    .labelsHidden()
+                    Spacer()
+                    Button("View License…") {
+                        isShowingLicense = true
                     }
                 }
-                .labelsHidden()
-                Text(
-                    isUpdatingPublishedListing
-                        ? "This license applies to the new version. Earlier versions keep their existing licenses."
-                        : publishLicense.summary
-                )
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                if isUpdatingPublishedListing {
+                    Text(
+                        "This license applies to the new version. Earlier versions keep their existing licenses."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
             }
 
             field("Screenshot") {
@@ -126,6 +135,32 @@ struct ToolLibraryStorePublishSheetView: View {
                 onChooseScreenshot(url)
             }
         }
+        .sheet(isPresented: $isShowingLicense) {
+            StoreLicenseDetailSheet(
+                license: publishLicense,
+                documents: previewLegalDocuments,
+                inheritedAttributions: inheritedLegalAttributions
+            )
+        }
+    }
+
+    private var previewLegalDocuments: StoreLegalDocuments {
+        StoreLegalDocumentRenderer.render(
+            appName: tool.name,
+            currentVersionId: "preview-current-version",
+            primaryLicense: publishLicense,
+            attributions: inheritedLegalAttributions + [
+                StoreLegalAttribution(
+                    versionId: "preview-current-version",
+                    appName: tool.name,
+                    creatorHandle: creatorHandle,
+                    creatorDisplayName: creatorHandle,
+                    publicationYear: Calendar(identifier: .gregorian).component(
+                        .year, from: Date()),
+                    license: publishLicense
+                )
+            ]
+        )
     }
 
     private var appIdentitySection: some View {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -7,6 +7,7 @@ struct ToolLibraryStorePublishSheetView: View {
     @Binding var publishShortDescription: String
     @Binding var publishDescription: String
     @Binding var publishCategory: StoreAppCategory
+    @Binding var publishLicense: StoreLicenseIdentifier
     let publishScreenshotName: String?
     let isPublishing: Bool
     let onChooseScreenshot: (URL) -> Void
@@ -65,6 +66,24 @@ struct ToolLibraryStorePublishSheetView: View {
                         }
                     }
                     .labelsHidden()
+                }
+                field("License") {
+                    Picker("License", selection: $publishLicense) {
+                        ForEach(StoreLicenseIdentifier.supported) { license in
+                            Text(license.title).tag(license)
+                        }
+                    }
+                    .labelsHidden()
+                    Text(publishLicense.summary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                field("License") {
+                    Text(publishLicense.title)
+                    Text("The license is fixed for all versions of this Store app.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                 }
             }
 

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -10,6 +10,7 @@ final class ToolLibraryStorePublisher {
     var publishShortDescription = ""
     var publishDescription = ""
     var publishCategory: StoreAppCategory = .utilities
+    var publishLicense: StoreLicenseIdentifier = .mit
     var publishScreenshotData: Data?
     var publishScreenshotName: String?
     var isShowingPublishSheet = false
@@ -196,6 +197,7 @@ final class ToolLibraryStorePublisher {
                 publishShortDescription = detail.shortDescription
                 publishDescription = detail.description
                 publishCategory = detail.category
+                publishLicense = detail.currentVersion.license
                 currentPublishedSourceSha256 = detail.currentVersion.sourceSha256.lowercased()
             } catch {
                 present(error)
@@ -205,6 +207,7 @@ final class ToolLibraryStorePublisher {
             publishShortDescription = ""
             publishDescription = ""
             publishCategory = tool.category
+            publishLicense = .mit
             currentPublishedSourceSha256 = nil
         }
         isUpdatingPublishedListing = linkedApp != nil
@@ -277,6 +280,7 @@ final class ToolLibraryStorePublisher {
                         description: publishDescription.trimmingCharacters(
                             in: .whitespacesAndNewlines),
                         category: publishCategory,
+                        license: publishLicense,
                         sourceCode: source,
                         generationSettings: settings,
                         iconMasterJPEG: iconMasterJPEG,
@@ -401,6 +405,23 @@ final class ToolLibraryStorePublisher {
             persistenceError = error
         }
 
+        let legalDocumentsError: Error?
+        do {
+            let version = app.currentVersion
+            try StoreLegalPackageWriter.write(
+                StoreLegalDocumentRenderer.render(
+                    appName: app.name,
+                    currentVersionId: version.id,
+                    primaryLicense: version.license,
+                    attributions: version.legalAttributions
+                ),
+                to: tool.packageLayout
+            )
+            legalDocumentsError = nil
+        } catch {
+            legalDocumentsError = error
+        }
+
         let rebuildError: Error?
         do {
             try await buildClient.buildTool(tool)
@@ -415,6 +436,7 @@ final class ToolLibraryStorePublisher {
 
         if let warning = ToolLibraryStorePublishingError.localFinalizationWarning(
             persistenceError: persistenceError,
+            legalDocumentsError: legalDocumentsError,
             rebuildError: rebuildError
         ) {
             present(warning)
@@ -441,12 +463,18 @@ private enum ToolLibraryStorePublishingError: LocalizedError {
 
     static func localFinalizationWarning(
         persistenceError: Error?,
+        legalDocumentsError: Error?,
         rebuildError: Error?
     ) -> Self? {
         var details: [String] = []
         if let persistenceError {
             details.append(
                 "Ironsmith could not save the Store linkage locally: \(persistenceError.localizedDescription)"
+            )
+        }
+        if let legalDocumentsError {
+            details.append(
+                "Ironsmith could not write the local Legal documents: \(legalDocumentsError.localizedDescription)"
             )
         }
         if let rebuildError {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -14,6 +14,7 @@ final class ToolLibraryStorePublisher {
     var publishScreenshotData: Data?
     var publishScreenshotName: String?
     var publishIconPreviewData: Data?
+    var publishInheritedLegalAttributions: [StoreLegalAttribution] = []
     var originalRemixApp: StoreAppDetail?
     var isShowingPublishSheet = false
     var isPublishing = false
@@ -225,6 +226,9 @@ final class ToolLibraryStorePublisher {
                 publishDescription = detail.description
                 publishCategory = detail.category
                 publishLicense = detail.currentVersion.license
+                publishInheritedLegalAttributions = detail.currentVersion.legalAttributions.filter {
+                    $0.versionId != detail.currentVersion.id
+                }
                 currentPublishedSourceSha256 = detail.currentVersion.sourceSha256.lowercased()
             } catch {
                 present(error)
@@ -235,6 +239,7 @@ final class ToolLibraryStorePublisher {
             publishDescription = ""
             publishCategory = tool.category
             publishLicense = .mit
+            publishInheritedLegalAttributions = []
             currentPublishedSourceSha256 = nil
         }
         do {
@@ -413,6 +418,7 @@ final class ToolLibraryStorePublisher {
 
         let originalApp = try await storeClient.fetchApp(storeId, appId)
         originalRemixApp = originalApp
+        publishInheritedLegalAttributions = originalApp.currentVersion.legalAttributions
         if let url = originalApp.iconAsset?.url {
             if let downloadedIconData = try? await originalIconDataLoader(url) {
                 originalRemixIconData = comparableOriginalIconData(

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -293,6 +293,7 @@ final class ToolLibraryStorePublisher {
                     StoreVersionPublicationRequest(
                         storeId: linkedApp.storeId,
                         appId: linkedApp.id,
+                        license: publishLicense,
                         shortDescription: publishShortDescription.trimmingCharacters(
                             in: .whitespacesAndNewlines),
                         description: publishDescription.trimmingCharacters(

--- a/Ironsmith/Resources/StoreLicenses/Apache-2.0.txt
+++ b/Ironsmith/Resources/StoreLicenses/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Ironsmith/Resources/StoreLicenses/MIT.txt
+++ b/Ironsmith/Resources/StoreLicenses/MIT.txt
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelinePackageAndProcessTests.swift
@@ -441,6 +441,14 @@ extension AgentPipelineTests {
         try FileManager.default.createDirectory(
             at: cachedIconURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         try Data("icon".utf8).write(to: cachedIconURL)
+        let legalDirectoryURL = packageRoot.appendingPathComponent("Legal", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: legalDirectoryURL, withIntermediateDirectories: true)
+        try "license text".write(
+            to: legalDirectoryURL.appendingPathComponent("LICENSE.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
 
         let capture = BundleProcessCapture()
         let processClient = SwiftPackageProcessClient(
@@ -506,6 +514,13 @@ extension AgentPipelineTests {
         #expect(plist["LSApplicationCategoryType"] as? String == "public.app-category.finance")
         #expect(plist["LSUIElement"] as? Bool == true)
         #expect(plist["IronsmithQuitOnLastWindowClose"] as? Bool == true)
+        #expect(
+            try String(
+                contentsOf: appURL.appendingPathComponent(
+                    "Contents/Resources/Legal/LICENSE.txt"),
+                encoding: .utf8
+            ) == "license text"
+        )
         #expect(entitlements["com.apple.security.app-sandbox"] as? Bool == true)
         #expect(entitlements["com.apple.security.files.user-selected.read-write"] as? Bool == true)
         #expect(entitlements["com.apple.security.network.client"] as? Bool == true)

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -331,6 +331,18 @@ struct StoreImportTests {
                 == iconAssets.thumbnailData
         )
         #expect(FileManager.default.fileExists(atPath: layout.cachedAppIconICNSURL.path))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.legalDirectoryURL.appendingPathComponent("LICENSE.txt").path)
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.legalDirectoryURL.appendingPathComponent("NOTICE.txt").path)
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: layout.legalDirectoryURL.appendingPathComponent("ATTRIBUTIONS.txt").path)
+        )
         let importedICNS = try ToolImageAssetEncoder.largestImage(
             at: layout.cachedAppIconICNSURL
         )
@@ -1190,6 +1202,38 @@ struct StoreImportTests {
         )
     }
 
+    @MainActor
+    @Test
+    func storeImportRejectsLicensesThisVersionCannotMaterialize() async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = ModelContext(container)
+        let source = Self.sourceCode("future-license")
+        let license = StoreLicenseIdentifier(rawValue: "Future-License-1.0")
+        let version = Self.versionDownload(
+            sourceCode: source,
+            sourceSha256: IronsmithStoreClient.sha256Hex(for: source),
+            license: license
+        )
+
+        await #expect(
+            throws: IronsmithStoreClientError.unsupportedLicense(license.rawValue)
+        ) {
+            try await StoreToolImportClient.live(toolsDirectoryURL: root)
+                .importTool(
+                    StoreToolImportRequest(
+                        app: Self.appListing(sourceCode: source),
+                        version: version,
+                        mode: .remix
+                    ),
+                    context
+                )
+        }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).isEmpty)
+        #expect(try context.fetch(FetchDescriptor<Tool>()).isEmpty)
+    }
+
     private static func appListing(
         sourceCode: String,
         versions suppliedVersions: [StoreVersionMetadata]? = nil,
@@ -1207,7 +1251,17 @@ struct StoreImportTests {
             sourceSha256: IronsmithStoreClient.sha256Hex(for: sourceCode),
             generationSettings: StoreGenerationSettingsDTO(settings: .default),
             runtimeVersion: "ironsmith-macos-v1",
-            license: "MIT",
+            license: .mit,
+            legalAttributions: [
+                StoreLegalAttribution(
+                    versionId: "00000000-0000-4000-8000-000000000201",
+                    appName: name,
+                    creatorHandle: "creator",
+                    creatorDisplayName: "Creator",
+                    publicationYear: 2026,
+                    license: .mit
+                )
+            ],
             scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: nil,
             publishedAt: "2026-06-27T00:00:00.000Z"
@@ -1264,7 +1318,17 @@ struct StoreImportTests {
             sourceSha256: IronsmithStoreClient.sha256Hex(for: sourceCode),
             generationSettings: StoreGenerationSettingsDTO(settings: settings),
             runtimeVersion: "ironsmith-macos-v1",
-            license: "MIT",
+            license: .mit,
+            legalAttributions: [
+                StoreLegalAttribution(
+                    versionId: id,
+                    appName: "Clipboard Cleaner",
+                    creatorHandle: "creator",
+                    creatorDisplayName: "Creator",
+                    publicationYear: 2026,
+                    license: .mit
+                )
+            ],
             scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: nil,
             publishedAt: publishedAt
@@ -1297,7 +1361,8 @@ struct StoreImportTests {
         versionNumber: Int = 1,
         appId: String = "00000000-0000-4000-8000-000000000101",
         sourceCode: String,
-        sourceSha256: String
+        sourceSha256: String,
+        license: StoreLicenseIdentifier = .mit
     ) -> StoreVersionDownload {
         StoreVersionDownload(
             id: id,
@@ -1308,7 +1373,17 @@ struct StoreImportTests {
             sourceSha256: sourceSha256,
             generationSettings: StoreGenerationSettingsDTO(settings: .default),
             runtimeVersion: "ironsmith-macos-v1",
-            license: "MIT",
+            license: license,
+            legalAttributions: [
+                StoreLegalAttribution(
+                    versionId: id,
+                    appName: "Clipboard Cleaner",
+                    creatorHandle: "creator",
+                    creatorDisplayName: "Creator",
+                    publicationYear: 2026,
+                    license: license
+                )
+            ],
             scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: nil,
             publishedAt: "2026-06-27T00:00:00.000Z",

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -784,6 +784,47 @@ struct StoreImportTests {
 
     @MainActor
     @Test
+    func forcedStoreDetailSelectionReloadsTheCurrentlySelectedApp() async {
+        let sourceV1 = Self.sourceCode("version one")
+        let sourceV2 = Self.sourceCode("version two")
+        let firstVersion = Self.versionMetadata(versionNumber: 1, sourceCode: sourceV1)
+        let secondVersion = Self.versionMetadata(
+            id: "00000000-0000-4000-8000-000000000202",
+            versionNumber: 2,
+            sourceCode: sourceV2
+        )
+        let first = Self.appListing(sourceCode: sourceV1, versions: [firstVersion])
+        let updated = Self.appListing(
+            sourceCode: sourceV2,
+            versions: [firstVersion, secondVersion]
+        )
+        let responses = StoreDetailResponseSequence([first, updated])
+        var client = IronsmithStoreClient.unconfigured
+        client.fetchApp = { _, _ in
+            await responses.next()
+        }
+        let store = StoreWindowStore(
+            client: client,
+            importClient: StoreToolImportClient(importTool: { _, _ in
+                throw IronsmithStoreClientError.notConfigured
+            }),
+            buildClient: ToolBuildClient(buildTool: { _ in })
+        )
+
+        store.select(storeID: first.storeId, appID: first.id)
+        await Self.waitForStoreDetail(first.id, in: store)
+        #expect(store.selectedAppDetail?.currentVersion.versionNumber == 1)
+
+        store.select(storeID: first.storeId, appID: first.id, forceReload: true)
+        #expect(store.isLoadingDetail)
+        await Self.waitForStoreDetail(first.id, in: store)
+
+        #expect(store.selectedAppDetail?.currentVersion.versionNumber == 2)
+        #expect(await responses.requestCount == 2)
+    }
+
+    @MainActor
+    @Test
     func searchPaginationAppendsUniqueResultsAndAdvancesOffset() async {
         let first = Self.appSummary(id: "app-one")
         let second = Self.appSummary(id: "app-two")
@@ -1524,6 +1565,21 @@ struct StoreImportTests {
                 "ironsmith-store-import-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         return root
+    }
+}
+
+private actor StoreDetailResponseSequence {
+    private let responses: [StoreAppDetail]
+    private(set) var requestCount = 0
+
+    init(_ responses: [StoreAppDetail]) {
+        self.responses = responses
+    }
+
+    func next() -> StoreAppDetail {
+        let response = responses[min(requestCount, responses.count - 1)]
+        requestCount += 1
+        return response
     }
 }
 

--- a/IronsmithTests/Features/Store/StoreLicenseTests.swift
+++ b/IronsmithTests/Features/Store/StoreLicenseTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+
+@testable import Ironsmith
+
+@Suite("Store license documents")
+struct StoreLicenseTests {
+    private let templates = StoreLicenseTemplates(
+        mit: "MIT TERMS",
+        apache2: "APACHE TERMS"
+    )
+
+    @Test
+    func identifierUsesStringWireFormatAndPreservesUnknownValues() throws {
+        let encoded = try JSONEncoder().encode(StoreLicenseIdentifier.apache2)
+        #expect(String(decoding: encoded, as: UTF8.self) == "\"Apache-2.0\"")
+        let unknown = try JSONDecoder().decode(
+            StoreLicenseIdentifier.self,
+            from: Data("\"Future-License\"".utf8)
+        )
+        #expect(unknown.rawValue == "Future-License")
+        #expect(!unknown.isSupportedForPublication)
+    }
+
+    @Test
+    func mitUsesCreatorHandleAndPreservesInheritedApacheTerms() {
+        let documents = StoreLegalDocumentRenderer.render(
+            appName: "Remixed Notes",
+            currentVersionId: "current",
+            primaryLicense: .mit,
+            attributions: [
+                StoreLegalAttribution(
+                    versionId: "parent",
+                    appName: "Original Notes",
+                    creatorHandle: "original_author",
+                    creatorDisplayName: "Original Author",
+                    publicationYear: 2025,
+                    license: .apache2
+                ),
+                StoreLegalAttribution(
+                    versionId: "current",
+                    appName: "Remixed Notes",
+                    creatorHandle: "remixer",
+                    creatorDisplayName: "Remixer",
+                    publicationYear: 2026,
+                    license: .mit
+                ),
+            ],
+            templates: templates
+        )
+
+        #expect(documents.license.contains("Copyright (c) 2026 @remixer"))
+        #expect(documents.license.contains("MIT TERMS"))
+        #expect(documents.notice.contains("Copyright 2025 @original_author"))
+        #expect(documents.attributions.contains("License: Apache-2.0"))
+        #expect(documents.attributions.contains("APACHE TERMS"))
+    }
+
+    @Test
+    func legacyCreatorFallsBackToDisplayName() {
+        let documents = StoreLegalDocumentRenderer.render(
+            appName: "Legacy Tool",
+            currentVersionId: "legacy",
+            primaryLicense: .apache2,
+            attributions: [
+                StoreLegalAttribution(
+                    versionId: "legacy",
+                    appName: "Legacy Tool",
+                    creatorHandle: nil,
+                    creatorDisplayName: "Legacy Creator",
+                    publicationYear: 2024,
+                    license: .apache2
+                )
+            ],
+            templates: templates
+        )
+
+        #expect(documents.license == "APACHE TERMS\n")
+        #expect(documents.notice.contains("Copyright 2024 Legacy Creator"))
+        #expect(documents.attributions == "No inherited Store attributions.\n")
+    }
+
+    @Test
+    func writerCreatesUniformLegalDirectory() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let layout = ToolPackageLayout(packageRootURL: root, executableName: "Tool")
+        let documents = StoreLegalDocuments(
+            license: "license",
+            notice: "notice",
+            attributions: "attributions"
+        )
+
+        try StoreLegalPackageWriter.write(documents, to: layout)
+        try StoreLegalPackageWriter.write(
+            StoreLegalDocuments(
+                license: "updated license",
+                notice: "updated notice",
+                attributions: "updated attributions"
+            ),
+            to: layout
+        )
+
+        #expect(try String(contentsOf: layout.legalDirectoryURL.appendingPathComponent("LICENSE.txt"), encoding: .utf8) == "updated license")
+        #expect(try String(contentsOf: layout.legalDirectoryURL.appendingPathComponent("NOTICE.txt"), encoding: .utf8) == "updated notice")
+        #expect(try String(contentsOf: layout.legalDirectoryURL.appendingPathComponent("ATTRIBUTIONS.txt"), encoding: .utf8) == "updated attributions")
+    }
+}

--- a/IronsmithTests/Features/Store/StoreLicenseTests.swift
+++ b/IronsmithTests/Features/Store/StoreLicenseTests.swift
@@ -53,6 +53,11 @@ struct StoreLicenseTests {
         #expect(documents.license.contains("MIT TERMS"))
         #expect(documents.notice.contains("Copyright 2025 @original_author"))
         #expect(documents.attributions.contains("License: Apache-2.0"))
+        #expect(
+            documents.attributions.contains(
+                "The source in this version was modified from the work above."
+            )
+        )
         #expect(documents.attributions.contains("APACHE TERMS"))
     }
 

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -191,7 +191,7 @@ extension ToolLibraryTests {
         let root = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let detail = Self.publisherAppDetail()
+        let detail = Self.publisherAppDetail(license: .apache2)
         var client = IronsmithStoreClient.unconfigured
         client.listApps = { _, _, _, _, _, _, _ in
             StoreAppPage(apps: [StoreAppSummary(detail: detail)], hasMore: false)
@@ -227,6 +227,7 @@ extension ToolLibraryTests {
 
         #expect(publisher.publishShortDescription == detail.shortDescription)
         #expect(publisher.publishDescription == detail.description)
+        #expect(publisher.publishLicense == .apache2)
         #expect(publisher.isUpdatingPublishedListing)
         #expect(publisher.isShowingPublishSheet)
     }
@@ -590,6 +591,7 @@ extension ToolLibraryTests {
         )
         let parentVersionId = "00000000-0000-4000-8000-000000000299"
         let previousDetail = Self.publisherAppDetail(
+            license: .apache2,
             remixedFromVersionId: parentVersionId
         )
         let publishedDetail = Self.publisherAppDetail(
@@ -620,6 +622,7 @@ extension ToolLibraryTests {
         )
         publisher.publishShortDescription = "Clean copied text"
         publisher.publishDescription = "Cleans and reformats text."
+        publisher.publishLicense = .mit
         let tool = Tool(
             name: "Clipboard Cleaner",
             executableName: "ClipboardCleaner",
@@ -663,6 +666,7 @@ extension ToolLibraryTests {
         #expect(await buildCapture.categories == [.finance])
         #expect(await buildCapture.versionNumbers == [2])
         #expect(await versionCapture.lastRemixedFromVersionId == parentVersionId)
+        #expect(await versionCapture.lastLicense == .mit)
         #expect(tool.storeRemixedFromVersionId == publishedDetail.currentVersion.remixedFromVersionId)
         #expect(publisher.errorMessage == nil)
         #expect(!publisher.isShowingPublishSheet)
@@ -857,6 +861,7 @@ extension ToolLibraryTests {
         versionNumber: Int = 1,
         category: StoreAppCategory = .utilities,
         source: String = publisherSource,
+        license: StoreLicenseIdentifier = .mit,
         remixedFromVersionId: String? = nil,
         icon: StoreAsset? = nil
     ) -> StoreAppDetail {
@@ -868,7 +873,7 @@ extension ToolLibraryTests {
             sourceSha256: IronsmithStoreClient.sha256Hex(for: source),
             generationSettings: StoreGenerationSettingsDTO(settings: .default),
             runtimeVersion: "ironsmith-macos-v1",
-            license: .mit,
+            license: license,
             legalAttributions: [
                 StoreLegalAttribution(
                     versionId: "00000000-0000-4000-8000-000000000201",
@@ -876,7 +881,7 @@ extension ToolLibraryTests {
                     creatorHandle: "jade",
                     creatorDisplayName: "Jade",
                     publicationYear: 2026,
-                    license: .mit
+                    license: license
                 )
             ],
             scannerVersion: "swift-execution-blocklist-v1",
@@ -968,9 +973,11 @@ private actor PublisherPublicationCapture {
 
 private actor PublisherVersionCapture {
     private(set) var lastRemixedFromVersionId: String?
+    private(set) var lastLicense: StoreLicenseIdentifier?
 
     func record(_ request: StoreVersionPublicationRequest) {
         lastRemixedFromVersionId = request.remixedFromVersionId
+        lastLicense = request.license
     }
 }
 

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -130,6 +130,10 @@ extension ToolLibraryTests {
         await publisher.beginPublishing(tool, inferenceStore: inferenceStore, tools: [tool])
 
         #expect(publisher.originalRemixApp?.id == original.id)
+        #expect(
+            publisher.publishInheritedLegalAttributions
+                == original.currentVersion.legalAttributions
+        )
         #expect(publisher.publishNameMatchesOriginal(for: tool))
         #expect(publisher.isUsingOriginalRemixIcon)
         #expect(!publisher.canPublishRemixIdentity(for: tool))

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -295,15 +295,22 @@ extension ToolLibraryTests {
         let publicationCount = await publicationCapture.count
         let publishedName = await publicationCapture.lastName
         let remixedFromVersionId = await publicationCapture.lastRemixedFromVersionId
+        let license = await publicationCapture.lastLicense
         #expect(updatedNames == ["Jade Westover"])
         #expect(publicationCount == 1)
         #expect(publishedName == tool.name)
         #expect(remixedFromVersionId == parentVersionId)
+        #expect(license == .mit)
         #expect(tool.storeRemixedFromVersionId == publishedDetail.currentVersion.id)
         #expect(tool.storeVersionNumber == 1)
         #expect(await buildCapture.versionNumbers == [1])
         #expect(!publisher.isUpdatingPublishedListing)
         #expect(publisher.errorMessage == nil)
+        #expect(
+            FileManager.default.fileExists(
+                atPath: tool.packageLayout.legalDirectoryURL
+                    .appendingPathComponent("LICENSE.txt").path)
+        )
     }
 
     @MainActor
@@ -672,7 +679,17 @@ extension ToolLibraryTests {
             sourceSha256: IronsmithStoreClient.sha256Hex(for: source),
             generationSettings: StoreGenerationSettingsDTO(settings: .default),
             runtimeVersion: "ironsmith-macos-v1",
-            license: "MIT",
+            license: .mit,
+            legalAttributions: [
+                StoreLegalAttribution(
+                    versionId: "00000000-0000-4000-8000-000000000201",
+                    appName: "Clipboard Cleaner",
+                    creatorHandle: "jade",
+                    creatorDisplayName: "Jade",
+                    publicationYear: 2026,
+                    license: .mit
+                )
+            ],
             scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: nil,
             publishedAt: "2026-07-28T00:00:00.000Z"
@@ -750,11 +767,13 @@ private actor PublisherPublicationCapture {
     private(set) var count = 0
     private(set) var lastName: String?
     private(set) var lastRemixedFromVersionId: String?
+    private(set) var lastLicense: StoreLicenseIdentifier?
 
     func record(_ request: StorePublicationRequest) {
         count += 1
         lastName = request.name
         lastRemixedFromVersionId = request.remixedFromVersionId
+        lastLicense = request.license
     }
 }
 


### PR DESCRIPTION
## Summary

- add MIT and Apache-2.0 selection when publishing Store apps and later versions
- preserve per-version licenses and inherited remix attribution
- generate and copy License, Notice, and Attributions documents into packages and app bundles
- add a reusable Store license detail sheet and publication preview
- force-refresh an app after publishing so the Store shows Open instead of a stale Update action

## Why

Every Store app must remain remixable while carrying clear licensing and attribution terms. Publishers need to understand and select those terms at publication time, and later versions must retain their own immutable license history.

The post-publication refresh also fixes stale Store detail state: the local tool advanced to the new version while the Store view could still compare it against the previous version.

## Validation

- `script/test.sh` — 560 tests passed during the licensing implementation
- `script/test.sh --filter ToolLibraryStorePublisherTests` — 13 tests passed
- `script/test.sh --filter StoreImportTests` — 33 tests passed
- `git diff --check`
