### PR TITLE
Fix Store publishing permissions and alerts

### DIFF
--- a/Ironsmith/Features/Settings/SettingsWindowView.swift
+++ b/Ironsmith/Features/Settings/SettingsWindowView.swift
@@ -13,6 +13,7 @@ struct SettingsWindowView: View {
     #endif
     @State private var presentedSheet: SettingsPresentedSheet?
     @State private var pendingProviderEditorIdentifierAfterSheetDismissal: String?
+    @State private var isShowingNestedSettingsSheet = false
     @State private var hasPreparedSettings = false
 
     var body: some View {
@@ -44,28 +45,20 @@ struct SettingsWindowView: View {
         }
         .sheet(
             item: $presentedSheet,
-            onDismiss: presentPendingProviderEditorIfNeeded
-        ) { sheet in
-            switch sheet {
-            case .addProvider(let initialKind):
-                AddProviderSheetView(
-                    initialKind: initialKind,
-                    onProviderAdded: handleProviderAdded
-                )
-            case .editProvider(let provider, let showsCreditPacks):
-                ProviderEditorSheetView(
-                    provider: provider,
-                    showsCreditPacksOnAppear: showsCreditPacks
-                )
-            case .manageAccount:
-                ManageIronsmithAccountSheetView(
-                    onBuyCredits: {
-                        presentedSheet = inferenceStore.providers
-                            .first { $0.kind == .ironsmith }
-                            .map { .editProvider($0, showsCreditPacks: true) }
-                    }
-                )
+            onDismiss: {
+                isShowingNestedSettingsSheet = false
+                presentPendingProviderEditorIfNeeded()
             }
+        ) { sheet in
+            settingsSheetContent(sheet)
+                .alert(
+                    "Settings Error",
+                    isPresented: activeSheetErrorAlertBinding
+                ) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text(inferenceStore.presentedErrorMessage ?? "")
+                }
         }
         .alert(
             "Settings Error",
@@ -127,13 +120,55 @@ struct SettingsWindowView: View {
 
     private var errorAlertBinding: Binding<Bool> {
         Binding(
-            get: { inferenceStore.presentedErrorMessage != nil },
+            get: { inferenceStore.presentedErrorMessage != nil && presentedSheet == nil },
             set: { isPresented in
                 if !isPresented {
                     inferenceStore.clearPresentedError()
                 }
             }
         )
+    }
+
+    private var activeSheetErrorAlertBinding: Binding<Bool> {
+        Binding(
+            get: {
+                inferenceStore.presentedErrorMessage != nil
+                    && presentedSheet != nil
+                    && !isShowingNestedSettingsSheet
+            },
+            set: { isPresented in
+                if !isPresented {
+                    inferenceStore.clearPresentedError()
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func settingsSheetContent(_ sheet: SettingsPresentedSheet) -> some View {
+        switch sheet {
+        case .addProvider(let initialKind):
+            AddProviderSheetView(
+                initialKind: initialKind,
+                onProviderAdded: handleProviderAdded
+            )
+        case .editProvider(let provider, let showsCreditPacks):
+            ProviderEditorSheetView(
+                provider: provider,
+                showsCreditPacksOnAppear: showsCreditPacks,
+                onNestedSheetPresentationChange: { isPresented in
+                    isShowingNestedSettingsSheet = isPresented
+                }
+            )
+        case .manageAccount:
+            ManageIronsmithAccountSheetView(
+                onBuyCredits: {
+                    presentedSheet = inferenceStore.providers
+                        .first { $0.kind == .ironsmith }
+                        .map { .editProvider($0, showsCreditPacks: true) }
+                }
+            )
+        }
     }
 }
 

--- a/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/ProviderEditor/ProviderEditorSheetView.swift
@@ -16,6 +16,7 @@ struct ProviderEditorSheetView: View {
     @State private var isSigningOut = false
     @State private var isSigningInToChatGPT = false
     @State private var isSigningOutOfChatGPT = false
+    let onNestedSheetPresentationChange: (Bool) -> Void
 
     private var isCustomOpenAICompatible: Bool {
         provider.kind == .customOpenAICompatible
@@ -39,9 +40,11 @@ struct ProviderEditorSheetView: View {
 
     init(
         provider: ProviderConfig,
-        showsCreditPacksOnAppear: Bool = false
+        showsCreditPacksOnAppear: Bool = false,
+        onNestedSheetPresentationChange: @escaping (Bool) -> Void = { _ in }
     ) {
         self.provider = provider
+        self.onNestedSheetPresentationChange = onNestedSheetPresentationChange
         _isShowingCreditPacks = State(initialValue: showsCreditPacksOnAppear)
     }
 
@@ -167,6 +170,7 @@ struct ProviderEditorSheetView: View {
         }
         .frame(minWidth: 540, minHeight: 430)
         .onAppear {
+            onNestedSheetPresentationChange(isShowingCreditPacks)
             apiKey = inferenceStore.apiKey(for: provider)
             displayName = provider.displayName
             baseURLString = provider.baseURLString
@@ -189,6 +193,12 @@ struct ProviderEditorSheetView: View {
                 await inferenceStore.refreshIronsmithAccountSummary()
             }
         }
+        .onChange(of: isShowingCreditPacks) { _, isPresented in
+            onNestedSheetPresentationChange(isPresented)
+        }
+        .onDisappear {
+            onNestedSheetPresentationChange(false)
+        }
         .textFieldStyle(.roundedBorder)
         .sheet(isPresented: $isShowingCreditPacks, onDismiss: {
             Task {
@@ -197,6 +207,11 @@ struct ProviderEditorSheetView: View {
         }) {
             IronsmithCreditPackPurchaseSheetView()
                 .environment(inferenceStore)
+                .alert("Settings Error", isPresented: errorAlertBinding) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text(inferenceStore.presentedErrorMessage ?? "")
+                }
         }
         .confirmationDialog(
             "Delete \(provider.displayName)?",
@@ -219,6 +234,17 @@ struct ProviderEditorSheetView: View {
     private var providerSummaryRow: some View {
         ProviderSummaryRowView(provider: provider, logoSize: 34, subtitleFont: .subheadline)
             .padding(.vertical, 2)
+    }
+
+    private var errorAlertBinding: Binding<Bool> {
+        Binding(
+            get: { inferenceStore.presentedErrorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    inferenceStore.clearPresentedError()
+                }
+            }
+        )
     }
 
     @ViewBuilder

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -436,11 +436,18 @@ nonisolated struct StorePermissionPresentation: Identifiable, Equatable, Sendabl
         let sandbox: [Self] = settings.sandboxEnabled
             ? settings.sandboxPermissions.enabledPermissions.map { permission in
                 switch permission {
-                case .incomingConnections, .outgoingConnections:
+                case .incomingConnections:
                     Self(
                         id: "sandbox.\(permission.rawValue)",
                         title: permission.displayName,
-                        explanation: "Access to network connections",
+                        explanation: "Accept connections from other devices",
+                        systemImage: "server.rack"
+                    )
+                case .outgoingConnections:
+                    Self(
+                        id: "sandbox.\(permission.rawValue)",
+                        title: permission.displayName,
+                        explanation: "Connect to websites and online services",
                         systemImage: "network"
                     )
                 case .userSelectedFiles:
@@ -450,12 +457,33 @@ nonisolated struct StorePermissionPresentation: Identifiable, Equatable, Sendabl
                         explanation: "Access to files you choose",
                         systemImage: "folder.badge.plus"
                     )
-                case .downloadsFolder, .picturesFolder, .musicFolder, .moviesFolder:
+                case .downloadsFolder:
                     Self(
                         id: "sandbox.\(permission.rawValue)",
                         title: permission.displayName,
-                        explanation: "Read and write access to this folder",
-                        systemImage: "folder"
+                        explanation: "Read and write items in your Downloads folder",
+                        systemImage: "tray.and.arrow.down"
+                    )
+                case .picturesFolder:
+                    Self(
+                        id: "sandbox.\(permission.rawValue)",
+                        title: permission.displayName,
+                        explanation: "Read and write images in your Pictures folder",
+                        systemImage: "photo.on.rectangle"
+                    )
+                case .musicFolder:
+                    Self(
+                        id: "sandbox.\(permission.rawValue)",
+                        title: permission.displayName,
+                        explanation: "Read and write music in your Music folder",
+                        systemImage: "music.note"
+                    )
+                case .moviesFolder:
+                    Self(
+                        id: "sandbox.\(permission.rawValue)",
+                        title: permission.displayName,
+                        explanation: "Read and write videos in your Movies folder",
+                        systemImage: "film"
                     )
                 }
             }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryCreatorProfileSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryCreatorProfileSheetView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ToolLibraryCreatorProfileSheetView: View {
     @Binding var displayName: String
     @Binding var handle: String
+    @Binding var errorMessage: String?
     let isSaving: Bool
     let isClaimingHandle: Bool
     let onCancel: () -> Void
@@ -62,6 +63,22 @@ struct ToolLibraryCreatorProfileSheetView: View {
                 "@\(IronsmithCreatorHandle.normalized(handle)) cannot be changed after it is claimed."
             )
         }
+        .alert("Ironsmith Store", isPresented: errorPresentedBinding) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var errorPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    errorMessage = nil
+                }
+            }
+        )
     }
 
     static func isValidHandle(_ handle: String) -> Bool {

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -268,6 +268,7 @@ struct ToolLibraryPopoverView: View {
             ToolLibraryCreatorProfileSheetView(
                 displayName: $storePublisher.creatorDisplayName,
                 handle: $storePublisher.creatorHandle,
+                errorMessage: $storePublisher.errorMessage,
                 isSaving: storePublisher.isSavingCreatorProfile,
                 isClaimingHandle:
                     inferenceStore.ironsmithAccountSummary?.profile?.handle == nil,
@@ -640,6 +641,7 @@ struct ToolLibraryPopoverView: View {
                 ),
                 isUsingOriginalRemixIcon: storePublisher.isUsingOriginalRemixIcon,
                 isPublishing: storePublisher.isPublishing,
+                errorMessage: $storePublisher.errorMessage,
                 onChooseScreenshot: { url in
                     storePublisher.importScreenshot(from: url)
                 },
@@ -1256,7 +1258,11 @@ struct ToolLibraryPopoverView: View {
 
     private var storeErrorPresentedBinding: Binding<Bool> {
         Binding(
-            get: { storePublisher.errorMessage != nil },
+            get: {
+                storePublisher.errorMessage != nil
+                    && !storePublisher.isShowingPublishSheet
+                    && !storePublisher.isShowingCreatorProfileSheet
+            },
             set: { isPresented in
                 if !isPresented {
                     storePublisher.errorMessage = nil

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -16,6 +16,7 @@ struct ToolLibraryStorePublishSheetView: View {
     let publishNameMatchesOriginal: Bool
     let isUsingOriginalRemixIcon: Bool
     let isPublishing: Bool
+    @Binding var errorMessage: String?
     let onChooseScreenshot: (URL) -> Void
     let onCancel: () -> Void
     let onEditDetails: () -> Void
@@ -30,7 +31,7 @@ struct ToolLibraryStorePublishSheetView: View {
                     ? "Update \(tool.name) on Ironsmith Store"
                     : "Publish \(tool.name) to Ironsmith Store"
             )
-                .font(.headline)
+            .font(.headline)
 
             appIdentitySection
 
@@ -39,11 +40,11 @@ struct ToolLibraryStorePublishSheetView: View {
                     "Summarize your app in a few words",
                     text: $publishShortDescription
                 )
-                    .onChange(of: publishShortDescription) { _, value in
-                        if value.count > 40 {
-                            publishShortDescription = String(value.prefix(40))
-                        }
+                .onChange(of: publishShortDescription) { _, value in
+                    if value.count > 40 {
+                        publishShortDescription = String(value.prefix(40))
                     }
+                }
             }
             field("Description") {
                 ZStack(alignment: .topLeading) {
@@ -142,6 +143,25 @@ struct ToolLibraryStorePublishSheetView: View {
                 inheritedAttributions: inheritedLegalAttributions
             )
         }
+        .alert(
+            "Ironsmith Store",
+            isPresented: errorPresentedBinding
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "")
+        }
+    }
+
+    private var errorPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    errorMessage = nil
+                }
+            }
+        )
     }
 
     private var previewLegalDocuments: StoreLegalDocuments {

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -1252,19 +1252,53 @@ struct StoreImportTests {
             sourceCode: source,
             settings: ToolGenerationSettings(
                 sandboxEnabled: true,
-                sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
+                sandboxPermissions: GeneratedAppSandboxPermissions([
+                    .incomingConnections,
+                    .outgoingConnections,
+                    .userSelectedFiles,
+                    .downloadsFolder,
+                    .picturesFolder,
+                    .musicFolder,
+                    .moviesFolder,
+                ]),
                 resourcePermissions: GeneratedAppResourcePermissions([.microphone])
             )
         )
         let items = StorePermissionPresentation.items(for: permissionVersion)
 
-        #expect(items.map(\.title) == ["Internet access", "Microphone"])
+        #expect(items.map(\.title) == [
+            "Incoming connections (server)",
+            "Internet access",
+            "User-selected files",
+            "Downloads folder",
+            "Pictures folder",
+            "Music folder",
+            "Movies folder",
+            "Microphone",
+        ])
         #expect(
             items.map(\.explanation) == [
-                "Access to network connections",
+                "Accept connections from other devices",
+                "Connect to websites and online services",
+                "Access to files you choose",
+                "Read and write items in your Downloads folder",
+                "Read and write images in your Pictures folder",
+                "Read and write music in your Music folder",
+                "Read and write videos in your Movies folder",
                 "Access to audio input",
             ]
         )
+        #expect(Set(items.map(\.explanation)).count == items.count)
+        #expect(items.map(\.systemImage) == [
+            "server.rack",
+            "network",
+            "folder.badge.plus",
+            "tray.and.arrow.down",
+            "photo.on.rectangle",
+            "music.note",
+            "film",
+            "mic",
+        ])
 
         let emptyVersion = Self.versionMetadata(
             versionNumber: 1,


### PR DESCRIPTION
## Summary
- present Store and Settings errors from the active sheet
- show all sandbox permissions with clear, distinct copy and icons

## Why
Publishing failures were hidden behind modal sheets, and new sandbox permissions needed Store presentation coverage.

## Validation
- `script/test.sh` (561 tests passed)
- `git diff --check`