### PR TITLE
Surface Store review rejection reasons

### DIFF
--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -328,6 +328,7 @@ nonisolated enum IronsmithStoreClientError: LocalizedError, Equatable {
     case notConfigured
     case missingSession
     case invalidResponse
+    case reviewRejected(reasons: [String])
     case requestFailed(statusCode: Int, message: String)
     case sourceHashMismatch(expected: String, actual: String)
     case unsupportedLicense(String)
@@ -341,6 +342,9 @@ nonisolated enum IronsmithStoreClientError: LocalizedError, Equatable {
             return "Sign in with Ironsmith before using the Ironsmith Store."
         case .invalidResponse:
             return "The Ironsmith Store returned an invalid response."
+        case .reviewRejected(let reasons):
+            let explanation = reasons.map { "• \($0)" }.joined(separator: "\n")
+            return "This app was not approved for the Ironsmith Store:\n\n\(explanation)"
         case .requestFailed(let statusCode, let message):
             return "The Ironsmith Store returned HTTP \(statusCode): \(message)"
         case .sourceHashMismatch:
@@ -593,6 +597,44 @@ extension IronsmithStoreClient {
             )
         }
     }
+
+    nonisolated static func backendError(
+        statusCode: Int,
+        data: Data
+    ) -> IronsmithStoreClientError {
+        let decoder = StoreJSON.decoder
+        let nestedError = try? decoder.decode(StoreBackendErrorEnvelope.self, from: data).error
+        let topLevelError = try? decoder.decode(StoreBackendError.self, from: data)
+        let backendError = nestedError ?? topLevelError
+
+        if statusCode == 401 {
+            return .missingSession
+        }
+        if backendError?.code == "store_review_rejected" {
+            var seenReasons: Set<String> = []
+            let reasons = backendError?.findings?
+                .map { finding in
+                    let detail = finding.detail?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    let reason = (detail?.isEmpty == false ? detail : nil) ?? finding.summary
+                    guard let line = finding.line else { return reason }
+                    return "\(reason) (ContentView.swift line \(line))"
+                }
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty && seenReasons.insert($0).inserted }
+                ?? []
+            return .reviewRejected(
+                reasons: reasons.isEmpty
+                    ? [backendError?.message ?? "Automated review could not approve this app."]
+                    : reasons
+            )
+        }
+        return .requestFailed(
+            statusCode: statusCode,
+            message: backendError?.message
+                ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
+        )
+    }
 }
 
 nonisolated private enum StoreAuthentication {
@@ -625,7 +667,10 @@ nonisolated private struct StoreHTTPClient {
             throw IronsmithStoreClientError.invalidResponse
         }
         guard (200...299).contains(httpResponse.statusCode) else {
-            throw Self.backendError(statusCode: httpResponse.statusCode, data: data)
+            throw IronsmithStoreClient.backendError(
+                statusCode: httpResponse.statusCode,
+                data: data
+            )
         }
         do {
             return try StoreJSON.decoder.decode(Response.self, from: data)
@@ -677,21 +722,6 @@ nonisolated private struct StoreHTTPClient {
         return request
     }
 
-    private static func backendError(statusCode: Int, data: Data) -> IronsmithStoreClientError {
-        let decoder = StoreJSON.decoder
-        let nestedError = try? decoder.decode(StoreBackendErrorEnvelope.self, from: data).error
-        let topLevelError = try? decoder.decode(StoreBackendError.self, from: data)
-        let backendError = nestedError ?? topLevelError
-
-        if statusCode == 401 {
-            return .missingSession
-        }
-        return .requestFailed(
-            statusCode: statusCode,
-            message: backendError?.message
-                ?? HTTPURLResponse.localizedString(forStatusCode: statusCode)
-        )
-    }
 }
 
 nonisolated private enum StoreJSON {
@@ -715,6 +745,14 @@ nonisolated private struct StoreBackendErrorEnvelope: Decodable {
 nonisolated private struct StoreBackendError: Decodable {
     let code: String
     let message: String
+    let findings: [StoreBackendReviewFinding]?
+}
+
+nonisolated private struct StoreBackendReviewFinding: Decodable {
+    let code: String
+    let summary: String
+    let detail: String?
+    let line: Int?
 }
 
 nonisolated private struct StoreDeletionResponse: Decodable {

--- a/Ironsmith/Features/Store/IronsmithStoreClient.swift
+++ b/Ironsmith/Features/Store/IronsmithStoreClient.swift
@@ -120,7 +120,6 @@ nonisolated struct StoreVersionMetadata: Decodable, Identifiable, Equatable, Sen
     let runtimeVersion: String
     let license: StoreLicenseIdentifier
     let legalAttributions: [StoreLegalAttribution]
-    let scannerVersion: String
     let remixedFromVersionId: String?
     let publishedAt: String
 }
@@ -136,7 +135,6 @@ nonisolated struct StoreVersionDownload: Decodable, Equatable, Sendable {
     let runtimeVersion: String
     let license: StoreLicenseIdentifier
     let legalAttributions: [StoreLegalAttribution]
-    let scannerVersion: String
     let remixedFromVersionId: String?
     let publishedAt: String
     let sourceCode: String

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -9,6 +9,47 @@ import Testing
 
 struct StoreImportTests {
     @Test
+    func storeClientPresentsStructuredReviewRejectionReasons() throws {
+        let data = try #require(
+            """
+            {
+              "error": {
+                "code": "store_review_rejected",
+                "message": "Automated review found content or behavior that is not allowed.",
+                "verdict": "reject",
+                "findings": [
+                  {
+                    "code": "credential_exposure",
+                    "summary": "The app contains an embedded credential or other secret that would be exposed when published.",
+                    "detail": "The source embeds a service credential directly.",
+                    "line": 7
+                  },
+                  {
+                    "code": "deceptive_behavior",
+                    "summary": "The app's behavior may be deceptive or misrepresented.",
+                    "detail": "The listing says data stays local, but the app uploads clipboard contents.",
+                    "line": null
+                  }
+                ]
+              }
+            }
+            """.data(using: .utf8)
+        )
+
+        let error = IronsmithStoreClient.backendError(statusCode: 422, data: data)
+
+        #expect(
+            error == .reviewRejected(reasons: [
+                "The source embeds a service credential directly. (ContentView.swift line 7)",
+                "The listing says data stays local, but the app uploads clipboard contents.",
+            ])
+        )
+        #expect(error.localizedDescription.contains("service credential"))
+        #expect(error.localizedDescription.contains("uploads clipboard contents"))
+        #expect(!error.localizedDescription.contains("HTTP 422"))
+    }
+
+    @Test
     func freshStoreInstallUsesDownloadTitle() {
         #expect(StoreAppInstallDisposition.createCopy.buttonTitle == "Download")
     }

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -1459,7 +1459,6 @@ struct StoreImportTests {
                     license: .mit
                 )
             ],
-            scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: nil,
             publishedAt: "2026-06-27T00:00:00.000Z"
         )
@@ -1526,7 +1525,6 @@ struct StoreImportTests {
                     license: .mit
                 )
             ],
-            scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: nil,
             publishedAt: publishedAt
         )
@@ -1582,7 +1580,6 @@ struct StoreImportTests {
                     license: license
                 )
             ],
-            scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: remixedFromVersionId,
             publishedAt: "2026-06-27T00:00:00.000Z",
             sourceCode: sourceCode

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -888,7 +888,6 @@ extension ToolLibraryTests {
                     license: license
                 )
             ],
-            scannerVersion: "swift-execution-blocklist-v1",
             remixedFromVersionId: remixedFromVersionId,
             publishedAt: "2026-07-28T00:00:00.000Z"
         )

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -8,6 +8,73 @@ import Testing
 
 extension ToolLibraryTests {
     @MainActor
+    @Test(arguments: [false, true])
+    func storePublisherShowsReviewReasonsForInitialAndVersionPublishing(
+        isVersion: Bool
+    ) async throws {
+        let root = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let detail = Self.publisherAppDetail()
+        let expectedReason = isVersion
+            ? "The new version deletes a selected folder without confirmation."
+            : "The app embeds a service credential in its source."
+        var storeClient = IronsmithStoreClient.unconfigured
+        storeClient.publishApp = { _ in
+            throw IronsmithStoreClientError.reviewRejected(
+                reasons: ["The app embeds a service credential in its source."]
+            )
+        }
+        storeClient.publishVersion = { _ in
+            throw IronsmithStoreClientError.reviewRejected(
+                reasons: ["The new version deletes a selected folder without confirmation."]
+            )
+        }
+        let publisher = ToolLibraryStorePublisher(
+            storeClient: storeClient,
+            iconClient: .noOp
+        )
+        publisher.publishShortDescription = "Clean copied text"
+        publisher.publishDescription = "Cleans and reformats text."
+        publisher.isShowingPublishSheet = true
+
+        let tool = Tool(
+            name: "Clipboard Cleaner",
+            executableName: "ClipboardCleaner",
+            packageRootPath: root.appendingPathComponent("ClipboardCleaner").path,
+            storeId: isVersion ? detail.storeId : nil,
+            storeAppId: isVersion ? detail.id : nil,
+            storeVersionId: isVersion ? detail.currentVersion.id : nil,
+            storeVersionNumber: isVersion ? detail.currentVersion.versionNumber : nil
+        )
+        if isVersion {
+            publisher.publishedStoreAppsByID[detail.id] = StoreAppSummary(detail: detail)
+        }
+        try Self.writeSource(Self.publisherSource, to: tool)
+        try FileManager.default.createDirectory(
+            at: tool.packageLayout.packageMetadataDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        try Data([1]).write(to: tool.packageLayout.cachedAppIconMasterJPEGURL)
+        try Data([2]).write(to: tool.packageLayout.cachedAppIconThumbnailJPEGURL)
+
+        let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
+        let context = container.mainContext
+        context.insert(tool)
+
+        await publisher.publish(
+            tool,
+            modelContext: context,
+            inferenceStore: InferenceStore(dependencies: Self.inferenceDependencies()),
+            defaultSettings: .default,
+            routeStore: IronsmithRouteStore(openSettingsWindow: {})
+        )
+
+        #expect(publisher.errorMessage?.contains(expectedReason) == true)
+        #expect(publisher.isShowingPublishSheet)
+    }
+
+    @MainActor
     @Test
     func storePublisherRequestsSignInWithoutShowingGenericError() async {
         let inferenceStore = InferenceStore(


### PR DESCRIPTION
## Summary

- remove the obsolete `scannerVersion` field from Store version metadata
- decode structured Store publication errors returned by the backend
- show concise reviewer rejection reasons for both initial app publication and version publication
- add focused Store client and publisher tests for structured rejection handling

## Why

Store review failures previously surfaced as a generic rejection, leaving creators without enough information to correct their submission. The macOS client now preserves the backend's sanitized policy findings and presents them consistently across publication flows.

## User impact

Creators receive actionable, safe rejection explanations without exposing raw provider output, prompts, scores, source excerpts, or hidden reasoning.

## Validation

- `script/test.sh`
- 563 Swift tests passed across 15 suites
