### PR TITLE
Add automatic app permission planning

### DIFF
--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -121,6 +121,35 @@ enum ToolAppKind: String, Codable, CaseIterable, Equatable, Sendable {
     }
 }
 
+enum ToolAppKindPreference: String, CaseIterable, Equatable, Sendable {
+    case automatic
+    case window
+    case menuBar = "menu_bar"
+
+    var displayName: String {
+        switch self {
+        case .automatic: return "Automatic"
+        case .window: return ToolAppKind.window.displayName
+        case .menuBar: return ToolAppKind.menuBar.displayName
+        }
+    }
+
+    var explicitAppKind: ToolAppKind? {
+        switch self {
+        case .automatic: nil
+        case .window: .window
+        case .menuBar: .menuBar
+        }
+    }
+
+    nonisolated init(_ appKind: ToolAppKind) {
+        switch appKind {
+        case .window: self = .window
+        case .menuBar: self = .menuBar
+        }
+    }
+}
+
 enum ToolMenuBarSymbol {
     nonisolated static let fallback = "hammer"
 
@@ -204,6 +233,34 @@ struct ToolGenerationSettings: Equatable, Sendable {
             sandboxEnabled: sandboxEnabled,
             sandboxPermissions: sandboxPermissions,
             resourcePermissions: resourcePermissions
+        )
+    }
+}
+
+struct ToolGenerationPlanningPolicy: Equatable, Sendable {
+    var appKindPreference: ToolAppKindPreference
+    var automaticallySelectPermissions: Bool
+    var alwaysIncludedSandboxPermissions: GeneratedAppSandboxPermissions
+    var alwaysIncludedResourcePermissions: GeneratedAppResourcePermissions
+
+    nonisolated init(
+        appKindPreference: ToolAppKindPreference,
+        automaticallySelectPermissions: Bool,
+        alwaysIncludedSandboxPermissions: GeneratedAppSandboxPermissions,
+        alwaysIncludedResourcePermissions: GeneratedAppResourcePermissions
+    ) {
+        self.appKindPreference = appKindPreference
+        self.automaticallySelectPermissions = automaticallySelectPermissions
+        self.alwaysIncludedSandboxPermissions = alwaysIncludedSandboxPermissions
+        self.alwaysIncludedResourcePermissions = alwaysIncludedResourcePermissions
+    }
+
+    nonisolated static func manual(settings: ToolGenerationSettings) -> Self {
+        Self(
+            appKindPreference: ToolAppKindPreference(settings.appKind),
+            automaticallySelectPermissions: false,
+            alwaysIncludedSandboxPermissions: .none,
+            alwaysIncludedResourcePermissions: .none
         )
     }
 }
@@ -330,6 +387,8 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static let previousContentViewVersionFilename = "previous-ContentView.swift"
     nonisolated static let pendingBuildSettingsVersionFilename = "pending-build-settings.json"
     nonisolated static let previousBuildSettingsVersionFilename = "previous-build-settings.json"
+    nonisolated static let pendingGenerationSettingsFilename =
+        "pending-generation-settings.json"
 
     let packageRootURL: URL
     let executableName: String
@@ -374,6 +433,10 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
 
     nonisolated var previousBuildSettingsVersionURL: URL {
         Self.previousBuildSettingsVersionURL(for: packageRootURL)
+    }
+
+    nonisolated var pendingGenerationSettingsURL: URL {
+        Self.pendingGenerationSettingsURL(for: packageRootURL)
     }
 
     nonisolated var sourceDirectoryURL: URL {
@@ -500,6 +563,11 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static func previousBuildSettingsVersionURL(for packageRootURL: URL) -> URL {
         versionsDirectoryURL(for: packageRootURL)
             .appendingPathComponent(previousBuildSettingsVersionFilename)
+    }
+
+    nonisolated static func pendingGenerationSettingsURL(for packageRootURL: URL) -> URL {
+        packageMetadataDirectoryURL(for: packageRootURL)
+            .appendingPathComponent(pendingGenerationSettingsFilename)
     }
 
     nonisolated static func sandboxEntitlementsURL(for packageRootURL: URL) -> URL {

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -21,6 +21,7 @@ struct SingleFileToolGenerationRuntime {
         for prompt: String,
         existingTool: Tool? = nil,
         settings: ToolGenerationSettings,
+        planningPolicy: ToolGenerationPlanningPolicy? = nil,
         imageGenerationProvider: ToolImageGenerationProvider = .disabled,
         attachments: [ToolPromptAttachment] = [],
         lifecycle: ToolGenerationLifecycle = .noop
@@ -29,6 +30,8 @@ struct SingleFileToolGenerationRuntime {
         guard !trimmedPrompt.isEmpty else {
             throw ToolGenerationError.emptyPrompt
         }
+
+        let planningPolicy = planningPolicy ?? .manual(settings: settings)
 
         if let existingTool {
             let effectivePrompt = existingTool.isGenerationReady
@@ -39,6 +42,7 @@ struct SingleFileToolGenerationRuntime {
                     prompt: effectivePrompt,
                     existingTool: existingTool,
                     settings: settings,
+                    planningPolicy: planningPolicy,
                     imageGenerationProvider: imageGenerationProvider,
                     attachments: [],
                     lifecycle: lifecycle
@@ -48,6 +52,7 @@ struct SingleFileToolGenerationRuntime {
                 prompt: effectivePrompt,
                 existingTool: existingTool,
                 settings: settings,
+                planningPolicy: planningPolicy,
                 attachments: attachments,
                 lifecycle: lifecycle
             )
@@ -56,6 +61,7 @@ struct SingleFileToolGenerationRuntime {
         return try await createTool(
             prompt: trimmedPrompt,
             settings: settings,
+            planningPolicy: planningPolicy,
             imageGenerationProvider: imageGenerationProvider,
             attachments: attachments,
             lifecycle: lifecycle
@@ -98,7 +104,7 @@ struct SingleFileToolGenerationRuntime {
     }
 
     private func prepareNewCreateSetup(
-        metadata: ToolMetadataSuggestion,
+        metadata: ToolCreationPlan,
         placeholderRootURL: URL,
         prompt: String,
         settings: ToolGenerationSettings,
@@ -186,6 +192,7 @@ struct SingleFileToolGenerationRuntime {
         prompt: String,
         existingTool: Tool? = nil,
         settings: ToolGenerationSettings,
+        planningPolicy: ToolGenerationPlanningPolicy,
         imageGenerationProvider: ToolImageGenerationProvider,
         attachments: [ToolPromptAttachment],
         lifecycle: ToolGenerationLifecycle
@@ -211,17 +218,22 @@ struct SingleFileToolGenerationRuntime {
             }
             try await lifecycle.updatePhase(.generating, .planning, nil)
             try Task.checkCancellation()
-            let metadata = await context.metadataClient.suggestMetadata(
+            let metadata = await context.planningClient.planCreation(
                 userPrompt: prompt,
                 imageGenerationProvider: imageGenerationProvider,
                 invoker: context.languageModelInvoker
             )
             try Task.checkCancellation()
+            let resolvedSettings = Self.resolveCreationSettings(
+                submittedSettings: settings,
+                planningPolicy: planningPolicy,
+                suggestion: metadata
+            )
             setup = try await prepareNewCreateSetup(
                 metadata: metadata,
                 placeholderRootURL: placeholderRootURL,
                 prompt: prompt,
-                settings: settings,
+                settings: resolvedSettings,
                 lifecycle: lifecycle
             )
         }
@@ -414,13 +426,136 @@ struct SingleFileToolGenerationRuntime {
         try await lifecycle.didPersistAttachments(persistedIDs)
     }
 
+    private static func resolveCreationSettings(
+        submittedSettings: ToolGenerationSettings,
+        planningPolicy: ToolGenerationPlanningPolicy,
+        suggestion: ToolCreationPlan
+    ) -> ToolGenerationSettings {
+        let appKind = planningPolicy.appKindPreference.explicitAppKind
+            ?? suggestion.suggestedAppKind
+        let sandboxPermissions: GeneratedAppSandboxPermissions
+        let resourcePermissions: GeneratedAppResourcePermissions
+        if planningPolicy.automaticallySelectPermissions {
+            sandboxPermissions = union(
+                planningPolicy.alwaysIncludedSandboxPermissions,
+                suggestion.suggestedSandboxPermissions
+            )
+            resourcePermissions = union(
+                planningPolicy.alwaysIncludedResourcePermissions,
+                suggestion.suggestedResourcePermissions
+            )
+        } else {
+            sandboxPermissions = submittedSettings.sandboxPermissions
+            resourcePermissions = submittedSettings.resourcePermissions
+        }
+        let resolvedSettings = ToolGenerationSettings(
+            appKind: appKind,
+            menuBarSystemImage: submittedSettings.menuBarSystemImage,
+            sandboxEnabled: submittedSettings.sandboxEnabled,
+            sandboxPermissions: sandboxPermissions,
+            resourcePermissions: resourcePermissions
+        )
+        AgentDiagnosticsLog.append(
+            """
+            Creation planning resolved generation settings.
+            appKind: \(resolvedSettings.appKind.rawValue)
+            sandboxPermissions: \(resolvedSettings.sandboxPermissions.enabledPermissions.map(\.rawValue).joined(separator: ","))
+            resourcePermissions: \(resolvedSettings.resourcePermissions.enabledPermissions.map(\.rawValue).joined(separator: ","))
+            """
+        )
+        return resolvedSettings
+    }
+
+    private func resolveEditSettings(
+        prompt: String,
+        existingTool: Tool,
+        submittedSettings: ToolGenerationSettings,
+        planningPolicy: ToolGenerationPlanningPolicy
+    ) async throws -> ToolGenerationSettings {
+        if let pendingSettings = try context.versionBackupClient.pendingGenerationSettings(
+            existingTool.packageRootURL
+        ) {
+            return pendingSettings
+        }
+        guard planningPolicy.automaticallySelectPermissions else {
+            return submittedSettings
+        }
+
+        let baselineSettings = ToolGenerationSettings(
+            appKind: submittedSettings.appKind,
+            menuBarSystemImage: submittedSettings.menuBarSystemImage,
+            sandboxEnabled: submittedSettings.sandboxEnabled,
+            sandboxPermissions: Self.union(
+                submittedSettings.sandboxPermissions,
+                planningPolicy.alwaysIncludedSandboxPermissions
+            ),
+            resourcePermissions: Self.union(
+                submittedSettings.resourcePermissions,
+                planningPolicy.alwaysIncludedResourcePermissions
+            )
+        )
+        let plan = await context.planningClient.planEdit(
+            userPrompt: prompt,
+            toolName: existingTool.name,
+            currentSettings: baselineSettings,
+            invoker: context.languageModelInvoker
+        )
+        let resolvedSettings = ToolGenerationSettings(
+            appKind: baselineSettings.appKind,
+            menuBarSystemImage: baselineSettings.menuBarSystemImage,
+            sandboxEnabled: baselineSettings.sandboxEnabled,
+            sandboxPermissions: Self.union(
+                baselineSettings.sandboxPermissions,
+                plan.additionalSandboxPermissions
+            ),
+            resourcePermissions: Self.union(
+                baselineSettings.resourcePermissions,
+                plan.additionalResourcePermissions
+            )
+        )
+        AgentDiagnosticsLog.append(
+            """
+            Tool edit planning resolved permissions.
+            tool: \(existingTool.name)
+            sandboxPermissions: \(resolvedSettings.sandboxPermissions.enabledPermissions.map(\.rawValue).joined(separator: ","))
+            resourcePermissions: \(resolvedSettings.resourcePermissions.enabledPermissions.map(\.rawValue).joined(separator: ","))
+            """
+        )
+        try context.versionBackupClient.stagePendingGenerationSettings(
+            existingTool.packageRootURL,
+            resolvedSettings
+        )
+        return resolvedSettings
+    }
+
+    private static func union(
+        _ lhs: GeneratedAppSandboxPermissions,
+        _ rhs: GeneratedAppSandboxPermissions
+    ) -> GeneratedAppSandboxPermissions {
+        GeneratedAppSandboxPermissions(lhs.enabled.union(rhs.enabled))
+    }
+
+    private static func union(
+        _ lhs: GeneratedAppResourcePermissions,
+        _ rhs: GeneratedAppResourcePermissions
+    ) -> GeneratedAppResourcePermissions {
+        GeneratedAppResourcePermissions(lhs.enabled.union(rhs.enabled))
+    }
+
     private func editTool(
         prompt: String,
         existingTool: Tool,
-        settings: ToolGenerationSettings,
+        settings submittedSettings: ToolGenerationSettings,
+        planningPolicy: ToolGenerationPlanningPolicy,
         attachments: [ToolPromptAttachment],
         lifecycle: ToolGenerationLifecycle
     ) async throws -> ToolGenerationResult {
+        let settings = try await resolveEditSettings(
+            prompt: prompt,
+            existingTool: existingTool,
+            submittedSettings: submittedSettings,
+            planningPolicy: planningPolicy
+        )
         let layout = ToolPackageLayout(
             packageRootURL: existingTool.packageRootURL,
             executableName: existingTool.executableName
@@ -438,7 +573,7 @@ struct SingleFileToolGenerationRuntime {
         }
         if !existingTool.isGenerationReady,
            startingPhase == .packaging || startingPhase == .completed {
-            return try await packageTool(
+            let result = try await packageTool(
                 displayName: existingTool.name,
                 executableName: existingTool.executableName,
                 bundleIdentifier: existingTool.bundleIdentifier,
@@ -449,6 +584,10 @@ struct SingleFileToolGenerationRuntime {
                 iconPrompt: nil,
                 lifecycle: lifecycle
             )
+            try context.versionBackupClient.clearPendingGenerationSettings(
+                existingTool.packageRootURL
+            )
+            return result
         }
         let existingSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
         let existingAppEntrySource = try context.readIfPresent(

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationClient.swift
@@ -72,6 +72,7 @@ nonisolated struct ToolGenerationRequest {
     let prompt: String
     let existingTool: Tool?
     let settings: ToolGenerationSettings
+    let planningPolicy: ToolGenerationPlanningPolicy
     let languageModelContext: AgentLanguageModelContext
     let imageGenerationProvider: ToolImageGenerationProvider
     let attachments: [ToolPromptAttachment]
@@ -81,6 +82,7 @@ nonisolated struct ToolGenerationRequest {
         prompt: String,
         existingTool: Tool? = nil,
         settings: ToolGenerationSettings,
+        planningPolicy: ToolGenerationPlanningPolicy? = nil,
         languageModelContext: AgentLanguageModelContext,
         imageGenerationProvider: ToolImageGenerationProvider = .disabled,
         attachments: [ToolPromptAttachment] = [],
@@ -89,6 +91,7 @@ nonisolated struct ToolGenerationRequest {
         self.prompt = prompt
         self.existingTool = existingTool
         self.settings = settings
+        self.planningPolicy = planningPolicy ?? .manual(settings: settings)
         self.languageModelContext = languageModelContext
         self.imageGenerationProvider = imageGenerationProvider
         self.attachments = attachments
@@ -132,6 +135,7 @@ struct ToolGenerationClient {
                     for: request.prompt,
                     existingTool: request.existingTool,
                     settings: request.settings,
+                    planningPolicy: request.planningPolicy,
                     imageGenerationProvider: request.imageGenerationProvider,
                     attachments: request.attachments,
                     lifecycle: request.lifecycle

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
@@ -149,7 +149,7 @@ struct ToolGenerationRuntimeDependencies {
     let appBundleClient: ToolAppBundleClient
     let iconClient: ToolIconClient
     let iconGenerationCoordinator: ToolIconGenerationCoordinator
-    let metadataClient: ToolMetadataClient
+    let planningClient: ToolGenerationPlanningClient
     let promptRefinementClient: ToolPromptRefinementClient
     let versionBackupClient: ToolVersionBackupClient
     let packageMaterializer: ToolPackageMaterializer
@@ -163,7 +163,7 @@ struct ToolGenerationRuntimeDependencies {
         appBundleClient: ToolAppBundleClient,
         iconClient: ToolIconClient = .noOp,
         iconGenerationCoordinator: ToolIconGenerationCoordinator = ToolIconGenerationCoordinator(),
-        metadataClient: ToolMetadataClient = .fallback(),
+        planningClient: ToolGenerationPlanningClient = .fallback(),
         promptRefinementClient: ToolPromptRefinementClient = .disabled(),
         versionBackupClient: ToolVersionBackupClient,
         packageMaterializer: ToolPackageMaterializer? = nil,
@@ -176,7 +176,7 @@ struct ToolGenerationRuntimeDependencies {
         self.appBundleClient = appBundleClient
         self.iconClient = iconClient
         self.iconGenerationCoordinator = iconGenerationCoordinator
-        self.metadataClient = metadataClient
+        self.planningClient = planningClient
         self.promptRefinementClient = promptRefinementClient
         self.versionBackupClient = versionBackupClient
         self.packageMaterializer = packageMaterializer ?? ToolPackageMaterializer(fileClient: fileClient)
@@ -192,7 +192,7 @@ struct ToolGenerationRuntimeDependencies {
         appBundleClient: ToolAppBundleClient? = nil,
         iconClient: ToolIconClient? = nil,
         iconGenerationCoordinator: ToolIconGenerationCoordinator = ToolIconGenerationCoordinator(),
-        metadataClient: ToolMetadataClient? = nil,
+        planningClient: ToolGenerationPlanningClient? = nil,
         promptRefinementClient: ToolPromptRefinementClient? = nil,
         versionBackupClient: ToolVersionBackupClient = .live,
         packageMaterializer: ToolPackageMaterializer? = nil,
@@ -206,7 +206,7 @@ struct ToolGenerationRuntimeDependencies {
             appBundleClient: appBundleClient ?? .live(),
             iconClient: iconClient ?? .live(),
             iconGenerationCoordinator: iconGenerationCoordinator,
-            metadataClient: metadataClient ?? .live(),
+            planningClient: planningClient ?? .live(),
             promptRefinementClient: promptRefinementClient ?? .live(),
             versionBackupClient: versionBackupClient,
             packageMaterializer: packageMaterializer,
@@ -226,7 +226,7 @@ struct ToolGenerationRuntimeContext {
     let appBundleClient: ToolAppBundleClient
     let iconClient: ToolIconClient
     let iconGenerationCoordinator: ToolIconGenerationCoordinator
-    let metadataClient: ToolMetadataClient
+    let planningClient: ToolGenerationPlanningClient
     let promptRefinementClient: ToolPromptRefinementClient
     let promptRefinementEnabled: Bool
     let versionBackupClient: ToolVersionBackupClient
@@ -273,7 +273,7 @@ struct ToolGenerationRuntimeContext {
         self.appBundleClient = dependencies.appBundleClient
         self.iconClient = dependencies.iconClient
         self.iconGenerationCoordinator = dependencies.iconGenerationCoordinator
-        self.metadataClient = dependencies.metadataClient
+        self.planningClient = dependencies.planningClient
         self.promptRefinementClient = dependencies.promptRefinementClient
         self.promptRefinementEnabled = languageModelContext.promptRefinementEnabled
         self.versionBackupClient = dependencies.versionBackupClient

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -384,66 +384,66 @@ struct ToolGenerationPlanningClient: Sendable {
         imageGenerationProvider: ToolImageGenerationProvider
     ) -> String {
         """
-            User request:
-            \(userPrompt)
+        User request:
+        \(userPrompt)
 
-            Image prompt mode:
-            \(imagePromptModeDescription(for: imageGenerationProvider))
+        Image prompt mode:
+        \(imagePromptModeDescription(for: imageGenerationProvider))
 
-            Allowed menuBarSystemImage values:
-            \(ToolMenuBarSymbol.allowedSymbols.joined(separator: ", "))
+        Allowed menuBarSystemImage values:
+        \(ToolMenuBarSymbol.allowedSymbols.joined(separator: ", "))
 
-            Allowed category values:
-            \(StoreAppCategory.allCases.map(\.rawValue).joined(separator: ", "))
+        Allowed category values:
+        \(StoreAppCategory.allCases.map(\.rawValue).joined(separator: ", "))
 
-            Allowed appKind values:
-            \(ToolAppKind.allCases.map(\.rawValue).joined(separator: ", "))
+        Allowed appKind values:
+        \(ToolAppKind.allCases.map(\.rawValue).joined(separator: ", "))
 
-            Allowed sandboxPermissions values:
-            \(GeneratedAppSandboxPermission.allCases.map(\.rawValue).joined(separator: ", "))
+        Allowed sandboxPermissions values:
+        \(GeneratedAppSandboxPermission.allCases.map(\.rawValue).joined(separator: ", "))
 
-            Allowed resourcePermissions values:
-            \(GeneratedAppResourcePermission.allCases.map(\.rawValue).joined(separator: ", "))
-            """
+        Allowed resourcePermissions values:
+        \(GeneratedAppResourcePermission.allCases.map(\.rawValue).joined(separator: ", "))
+        """
     }
 
     nonisolated private static func metadataInstructions(
         for imageGenerationProvider: ToolImageGenerationProvider
     ) -> String {
         """
-            You create compact metadata for a SwiftUI AI coding agent for a macOS app.
+        You create compact metadata for a SwiftUI AI coding agent for a macOS app.
 
-            displayName:
-            - Must be one or two separate words.
-            - Must be Title Case.
-            - Must name the user's requested app, task, or workflow, not the icon artwork or symbol.
-            - Should feel snappy, playful, and useful for a small macOS app.
-            - Do not use punctuation, emoji, or generic suffixes like App or Tool.
+        displayName:
+        - Must be one or two separate words.
+        - Must be Title Case.
+        - Must name the user's requested app, task, or workflow, not the icon artwork or symbol.
+        - Should feel snappy, playful, and useful for a small macOS app.
+        - Do not use punctuation, emoji, or generic suffixes like App or Tool.
 
-            iconPrompt:
-            \(imagePromptInstructions(for: imageGenerationProvider))
+        iconPrompt:
+        \(imagePromptInstructions(for: imageGenerationProvider))
 
-            menuBarSystemImage:
-            - Must be one exact SF Symbol name from the allowed list in the prompt.
-            - Choose the closest symbol for the user's requested app.
-            - Do not invent names or include variants outside that list.
+        menuBarSystemImage:
+        - Must be one exact SF Symbol name from the allowed list in the prompt.
+        - Choose the closest symbol for the user's requested app.
+        - Do not invent names or include variants outside that list.
 
-            category:
-            - Must be one exact raw value from the allowed category list in the prompt.
-            - Choose the category that best represents the app's primary purpose.
-            - Use utilities only when no more specific category applies.
+        category:
+        - Must be one exact raw value from the allowed category list in the prompt.
+        - Choose the category that best represents the app's primary purpose.
+        - Use utilities only when no more specific category applies.
 
-            appKind:
-            - Choose menu_bar only for a compact, glanceable utility centered on a quick interaction.
-            - Choose window for workflows that need substantial content, navigation, editing space, or multiple controls.
-            - Use exactly one allowed raw value.
+        appKind:
+        - Choose menu_bar when the user asks for it or if the app the user requests only makes sense as a menu bar app.
+        - Choose window for everything else.
+        - Use exactly one allowed raw value.
 
-            sandboxPermissions and resourcePermissions:
-            - Select only permissions required to implement the user's explicit request.
-            - Do not add permissions for hypothetical future features.
-            - Use only exact values from the corresponding allowed lists.
-            - Use an empty list when no permission in a group is required.
-            """
+        sandboxPermissions and resourcePermissions:
+        - Select only permissions required to implement the user's explicit request.
+        - Do not add permissions for hypothetical future features.
+        - Use only exact values from the corresponding allowed lists.
+        - Use an empty list when no permission in a group is required.
+        """
     }
 
     nonisolated private static func imagePromptModeDescription(

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -1,27 +1,48 @@
 import AnyLanguageModel
 import Foundation
 
-struct ToolMetadataSuggestion: Equatable, Sendable {
+struct ToolCreationPlan: Equatable, Sendable {
     let displayName: String
     let iconPrompt: String
     let menuBarSystemImage: String
     let category: StoreAppCategory
+    let suggestedAppKind: ToolAppKind
+    let suggestedSandboxPermissions: GeneratedAppSandboxPermissions
+    let suggestedResourcePermissions: GeneratedAppResourcePermissions
 
     nonisolated init(
         displayName: String,
         iconPrompt: String,
         menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
-        category: StoreAppCategory = .utilities
+        category: StoreAppCategory = .utilities,
+        suggestedAppKind: ToolAppKind = .window,
+        suggestedSandboxPermissions: GeneratedAppSandboxPermissions = .none,
+        suggestedResourcePermissions: GeneratedAppResourcePermissions = .none
     ) {
         self.displayName = displayName
         self.iconPrompt = iconPrompt
         self.menuBarSystemImage = ToolMenuBarSymbol.validated(menuBarSystemImage)
         self.category = category
+        self.suggestedAppKind = suggestedAppKind
+        self.suggestedSandboxPermissions = suggestedSandboxPermissions
+        self.suggestedResourcePermissions = suggestedResourcePermissions
     }
 }
 
-@Generable(description: "Metadata for a small generated macOS app.")
-struct GeneratedToolMetadata {
+struct ToolEditPlan: Equatable, Sendable {
+    let additionalSandboxPermissions: GeneratedAppSandboxPermissions
+    let additionalResourcePermissions: GeneratedAppResourcePermissions
+
+    nonisolated static var empty: Self {
+        Self(
+            additionalSandboxPermissions: .none,
+            additionalResourcePermissions: .none
+        )
+    }
+}
+
+@Generable(description: "Creation plan for a generated macOS app.")
+struct GeneratedToolCreationPlan {
     @Guide(description: "A snappy one or two word macOS playful and fun app name in Title Case")
     let displayName: String
 
@@ -40,66 +61,117 @@ struct GeneratedToolMetadata {
         description:
             "One category raw value chosen exactly from Ironsmith's allowed category list.")
     let category: String
+
+    @Guide(description: "One app type raw value chosen from the allowed app type list.")
+    let appKind: String
+
+    @Guide(
+        description:
+            "Exact sandbox permission raw values required by the explicit request, or an empty list."
+    )
+    let sandboxPermissions: [String]
+
+    @Guide(
+        description:
+            "Exact resource permission raw values required by the explicit request, or an empty list."
+    )
+    let resourcePermissions: [String]
 }
 
-extension GeneratedToolMetadata {
-    nonisolated init(displayName: String, iconPrompt: String) {
-        self.init(
-            displayName: displayName,
-            iconPrompt: iconPrompt,
-            menuBarSystemImage: ToolMenuBarSymbol.fallback,
-            category: StoreAppCategory.utilities.rawValue
-        )
-    }
-
+extension GeneratedToolCreationPlan {
     nonisolated init(
         displayName: String,
         iconPrompt: String,
-        menuBarSystemImage: String
+        menuBarSystemImage: String = ToolMenuBarSymbol.fallback,
+        category: String = StoreAppCategory.utilities.rawValue,
+        appKind: String = ToolAppKind.window.rawValue
     ) {
         self.init(
             displayName: displayName,
             iconPrompt: iconPrompt,
             menuBarSystemImage: menuBarSystemImage,
-            category: StoreAppCategory.utilities.rawValue
+            category: category,
+            appKind: appKind,
+            sandboxPermissions: [],
+            resourcePermissions: []
         )
     }
 }
 
-struct ToolMetadataRequest: Sendable {
+@Generable(description: "Plan for editing an existing generated macOS app.")
+struct GeneratedToolEditPlan {
+    @Guide(
+        description:
+            "Exact additional sandbox permission raw values required by this edit, or an empty list."
+    )
+    let additionalSandboxPermissions: [String]
+
+    @Guide(
+        description:
+            "Exact additional resource permission raw values required by this edit, or an empty list."
+    )
+    let additionalResourcePermissions: [String]
+}
+
+struct ToolCreationPlanningRequest: Sendable {
     let userPrompt: String
     let imageGenerationProvider: ToolImageGenerationProvider
     let invoker: ToolLanguageModelInvoker
 }
 
-struct ToolMetadataClient: Sendable {
-    private var suggestMetadataForRequest:
-        @Sendable (_ request: ToolMetadataRequest) async -> ToolMetadataSuggestion
+struct ToolEditPlanningRequest: Sendable {
+    let userPrompt: String
+    let toolName: String
+    let currentSettings: ToolGenerationSettings
+    let invoker: ToolLanguageModelInvoker
+}
+
+struct ToolGenerationPlanningClient: Sendable {
+    private var planCreationForRequest:
+        @Sendable (_ request: ToolCreationPlanningRequest) async -> ToolCreationPlan
+    private var planEditForRequest:
+        @Sendable (_ request: ToolEditPlanningRequest) async -> ToolEditPlan
 
     init(
-        _ suggestMetadata:
-            @escaping @Sendable (_ userPrompt: String) async -> ToolMetadataSuggestion
+        _ planCreation:
+            @escaping @Sendable (_ userPrompt: String) async -> ToolCreationPlan
     ) {
-        self.suggestMetadataForRequest = { request in
-            await suggestMetadata(request.userPrompt)
+        self.planCreationForRequest = { request in
+            await planCreation(request.userPrompt)
         }
+        self.planEditForRequest = { _ in .empty }
+    }
+
+    init(
+        planCreation:
+            @escaping @Sendable (_ userPrompt: String) async -> ToolCreationPlan,
+        planEdit:
+            @escaping @Sendable (_ request: ToolEditPlanningRequest) async -> ToolEditPlan
+    ) {
+        self.planCreationForRequest = { request in
+            await planCreation(request.userPrompt)
+        }
+        self.planEditForRequest = planEdit
     }
 
     private init(
         requestBased: Void,
-        suggestMetadataForRequest:
-            @escaping @Sendable (_ request: ToolMetadataRequest) async -> ToolMetadataSuggestion
+        planCreationForRequest:
+            @escaping @Sendable (_ request: ToolCreationPlanningRequest) async -> ToolCreationPlan,
+        planEditForRequest:
+            @escaping @Sendable (_ request: ToolEditPlanningRequest) async -> ToolEditPlan
     ) {
-        self.suggestMetadataForRequest = suggestMetadataForRequest
+        self.planCreationForRequest = planCreationForRequest
+        self.planEditForRequest = planEditForRequest
     }
 
-    func suggestMetadata(
+    func planCreation(
         userPrompt: String,
         imageGenerationProvider: ToolImageGenerationProvider = .imagePlayground,
         invoker: ToolLanguageModelInvoker
-    ) async -> ToolMetadataSuggestion {
-        await suggestMetadataForRequest(
-            ToolMetadataRequest(
+    ) async -> ToolCreationPlan {
+        await planCreationForRequest(
+            ToolCreationPlanningRequest(
                 userPrompt: userPrompt,
                 imageGenerationProvider: imageGenerationProvider,
                 invoker: invoker
@@ -107,9 +179,25 @@ struct ToolMetadataClient: Sendable {
         )
     }
 
+    func planEdit(
+        userPrompt: String,
+        toolName: String,
+        currentSettings: ToolGenerationSettings,
+        invoker: ToolLanguageModelInvoker
+    ) async -> ToolEditPlan {
+        await planEditForRequest(
+            ToolEditPlanningRequest(
+                userPrompt: userPrompt,
+                toolName: toolName,
+                currentSettings: currentSettings,
+                invoker: invoker
+            )
+        )
+    }
+
     static func fallback() -> Self {
         Self { userPrompt in
-            ToolMetadataSuggestion.fallback(for: userPrompt)
+            ToolCreationPlan.fallback(for: userPrompt)
         }
     }
 
@@ -118,9 +206,9 @@ struct ToolMetadataClient: Sendable {
     ) -> Self {
         Self(
             requestBased: (),
-            suggestMetadataForRequest: { request in
+            planCreationForRequest: { request in
                 let userPrompt = request.userPrompt
-                let fallback = ToolMetadataSuggestion.fallback(for: userPrompt)
+                let fallback = ToolCreationPlan.fallback(for: userPrompt)
 
                 do {
                     return try await Self.generateMetadata(
@@ -171,15 +259,110 @@ struct ToolMetadataClient: Sendable {
                     }
                     return fallback
                 }
-            })
+            },
+            planEditForRequest: { request in
+                do {
+                    return try await Self.generateEditPlan(request, invoker: request.invoker)
+                } catch let primaryError {
+                    AgentDiagnosticsLog.append(
+                        """
+                        Tool edit planning failed with the selected model.
+                        prompt: \(AgentDiagnosticsLog.compact(request.userPrompt, limit: 240))
+                        error:
+                        \(AgentDiagnosticsLog.renderError(primaryError, limit: 500))
+                        """
+                    )
+
+                    if let fallbackLanguageModel, fallbackLanguageModel.isAvailable {
+                        let fallbackConfiguration = ToolGenerationStageConfiguration(
+                            stage: .metadata,
+                            languageModel: fallbackLanguageModel,
+                            generationOptions: GenerationOptions(
+                                maximumResponseTokens: ToolGenerationOptionsResolver
+                                    .metadataMaximumResponseTokens
+                            ),
+                            streaming: ToolGenerationOptionsResolver.defaultStreaming
+                        )
+                        do {
+                            return try await Self.generateEditPlan(
+                                request,
+                                invoker: request.invoker.replacingMetadata(
+                                    with: fallbackConfiguration
+                                )
+                            )
+                        } catch {
+                            AgentDiagnosticsLog.append(
+                                """
+                                Tool edit planning also failed with the system language model; preserving current permissions.
+                                prompt: \(AgentDiagnosticsLog.compact(request.userPrompt, limit: 240))
+                                error:
+                                \(AgentDiagnosticsLog.renderError(error, limit: 500))
+                                """
+                            )
+                        }
+                    }
+                    return .empty
+                }
+            }
+        )
+    }
+
+    private static func generateEditPlan(
+        _ request: ToolEditPlanningRequest,
+        invoker: ToolLanguageModelInvoker
+    ) async throws -> ToolEditPlan {
+        let session = invoker.makeSession(
+            for: .metadata,
+            instructions: """
+                You plan an edit to an existing generated macOS SwiftUI app.
+                Return only permissions newly required by the requested change.
+                Select only permissions required by the explicit request, never hypothetical features.
+                Do not remove or repeat existing permissions. Use only exact values from the allowed lists.
+                Use an empty list when no additional permission in a group is required.
+                """
+        )
+        let response = try await invoker.respond(
+            stage: .metadata,
+            in: session,
+            to: """
+                Existing app: \(request.toolName)
+                Requested change:
+                \(request.userPrompt)
+
+                Existing sandbox permissions:
+                \(request.currentSettings.sandboxPermissions.enabledPermissions.map(\.rawValue).joined(separator: ", "))
+
+                Existing resource permissions:
+                \(request.currentSettings.resourcePermissions.enabledPermissions.map(\.rawValue).joined(separator: ", "))
+
+                Allowed additionalSandboxPermissions values:
+                \(GeneratedAppSandboxPermission.allCases.map(\.rawValue).joined(separator: ", "))
+
+                Allowed additionalResourcePermissions values:
+                \(GeneratedAppResourcePermission.allCases.map(\.rawValue).joined(separator: ", "))
+                """,
+            generating: GeneratedToolEditPlan.self
+        )
+        return ToolEditPlan(
+            additionalSandboxPermissions: GeneratedAppSandboxPermissions(
+                response.additionalSandboxPermissions.compactMap(
+                    GeneratedAppSandboxPermission.init(rawValue:)
+                )
+            ),
+            additionalResourcePermissions: GeneratedAppResourcePermissions(
+                response.additionalResourcePermissions.compactMap(
+                    GeneratedAppResourcePermission.init(rawValue:)
+                )
+            )
+        )
     }
 
     private static func generateMetadata(
         userPrompt: String,
         imageGenerationProvider: ToolImageGenerationProvider,
         invoker: ToolLanguageModelInvoker,
-        fallback: ToolMetadataSuggestion
-    ) async throws -> ToolMetadataSuggestion {
+        fallback: ToolCreationPlan
+    ) async throws -> ToolCreationPlan {
         let session = invoker.makeSession(
             for: .metadata,
             instructions: metadataInstructions(for: imageGenerationProvider)
@@ -191,7 +374,7 @@ struct ToolMetadataClient: Sendable {
                 for: userPrompt,
                 imageGenerationProvider: imageGenerationProvider
             ),
-            generating: GeneratedToolMetadata.self
+            generating: GeneratedToolCreationPlan.self
         )
         return Self.metadataSuggestion(response, fallback: fallback)
     }
@@ -201,46 +384,66 @@ struct ToolMetadataClient: Sendable {
         imageGenerationProvider: ToolImageGenerationProvider
     ) -> String {
         """
-        User request:
-        \(userPrompt)
+            User request:
+            \(userPrompt)
 
-        Image prompt mode:
-        \(imagePromptModeDescription(for: imageGenerationProvider))
+            Image prompt mode:
+            \(imagePromptModeDescription(for: imageGenerationProvider))
 
-        Allowed menuBarSystemImage values:
-        \(ToolMenuBarSymbol.allowedSymbols.joined(separator: ", "))
+            Allowed menuBarSystemImage values:
+            \(ToolMenuBarSymbol.allowedSymbols.joined(separator: ", "))
 
-        Allowed category values:
-        \(StoreAppCategory.allCases.map(\.rawValue).joined(separator: ", "))
-        """
+            Allowed category values:
+            \(StoreAppCategory.allCases.map(\.rawValue).joined(separator: ", "))
+
+            Allowed appKind values:
+            \(ToolAppKind.allCases.map(\.rawValue).joined(separator: ", "))
+
+            Allowed sandboxPermissions values:
+            \(GeneratedAppSandboxPermission.allCases.map(\.rawValue).joined(separator: ", "))
+
+            Allowed resourcePermissions values:
+            \(GeneratedAppResourcePermission.allCases.map(\.rawValue).joined(separator: ", "))
+            """
     }
 
     nonisolated private static func metadataInstructions(
         for imageGenerationProvider: ToolImageGenerationProvider
     ) -> String {
         """
-        You create compact metadata for a SwiftUI AI coding agent for a macOS app.
+            You create compact metadata for a SwiftUI AI coding agent for a macOS app.
 
-        displayName:
-        - Must be one or two separate words.
-        - Must be Title Case.
-        - Must name the user's requested app, task, or workflow, not the icon artwork or symbol.
-        - Should feel snappy, playful, and useful for a small macOS app.
-        - Do not use punctuation, emoji, or generic suffixes like App or Tool.
+            displayName:
+            - Must be one or two separate words.
+            - Must be Title Case.
+            - Must name the user's requested app, task, or workflow, not the icon artwork or symbol.
+            - Should feel snappy, playful, and useful for a small macOS app.
+            - Do not use punctuation, emoji, or generic suffixes like App or Tool.
 
-        iconPrompt:
-        \(imagePromptInstructions(for: imageGenerationProvider))
+            iconPrompt:
+            \(imagePromptInstructions(for: imageGenerationProvider))
 
-        menuBarSystemImage:
-        - Must be one exact SF Symbol name from the allowed list in the prompt.
-        - Choose the closest symbol for the user's requested app.
-        - Do not invent names or include variants outside that list.
+            menuBarSystemImage:
+            - Must be one exact SF Symbol name from the allowed list in the prompt.
+            - Choose the closest symbol for the user's requested app.
+            - Do not invent names or include variants outside that list.
 
-        category:
-        - Must be one exact raw value from the allowed category list in the prompt.
-        - Choose the category that best represents the app's primary purpose.
-        - Use utilities only when no more specific category applies.
-        """
+            category:
+            - Must be one exact raw value from the allowed category list in the prompt.
+            - Choose the category that best represents the app's primary purpose.
+            - Use utilities only when no more specific category applies.
+
+            appKind:
+            - Choose menu_bar only for a compact, glanceable utility centered on a quick interaction.
+            - Choose window for workflows that need substantial content, navigation, editing space, or multiple controls.
+            - Use exactly one allowed raw value.
+
+            sandboxPermissions and resourcePermissions:
+            - Select only permissions required to implement the user's explicit request.
+            - Do not add permissions for hypothetical future features.
+            - Use only exact values from the corresponding allowed lists.
+            - Use an empty list when no permission in a group is required.
+            """
     }
 
     nonisolated private static func imagePromptModeDescription(
@@ -277,9 +480,9 @@ struct ToolMetadataClient: Sendable {
     }
 
     nonisolated private static func metadataSuggestion(
-        _ response: GeneratedToolMetadata,
-        fallback: ToolMetadataSuggestion
-    ) -> ToolMetadataSuggestion {
+        _ response: GeneratedToolCreationPlan,
+        fallback: ToolCreationPlan
+    ) -> ToolCreationPlan {
         let displayName = response.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         let iconPrompt = response.iconPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let menuBarSystemImage = ToolMenuBarSymbol.validated(response.menuBarSystemImage)
@@ -288,11 +491,22 @@ struct ToolMetadataClient: Sendable {
                 rawValue: response.category.trimmingCharacters(in: .whitespacesAndNewlines)
             )
             ?? fallback.category
-        return ToolMetadataSuggestion(
+        return ToolCreationPlan(
             displayName: displayName.isEmpty ? fallback.displayName : displayName,
             iconPrompt: iconPrompt.isEmpty ? fallback.iconPrompt : iconPrompt,
             menuBarSystemImage: menuBarSystemImage,
-            category: category
+            category: category,
+            suggestedAppKind: ToolAppKind(
+                rawValue: response.appKind.trimmingCharacters(in: .whitespacesAndNewlines)
+            ) ?? fallback.suggestedAppKind,
+            suggestedSandboxPermissions: GeneratedAppSandboxPermissions(
+                response.sandboxPermissions.compactMap(
+                    GeneratedAppSandboxPermission.init(rawValue:))
+            ),
+            suggestedResourcePermissions: GeneratedAppResourcePermissions(
+                response.resourcePermissions.compactMap(
+                    GeneratedAppResourcePermission.init(rawValue:))
+            )
         )
     }
 }
@@ -479,10 +693,10 @@ struct ToolPromptRefinementClient: Sendable {
     }
 }
 
-extension ToolMetadataSuggestion {
-    nonisolated static func fallback(for userPrompt: String) -> ToolMetadataSuggestion {
+extension ToolCreationPlan {
+    nonisolated static func fallback(for userPrompt: String) -> ToolCreationPlan {
         let displayName = ToolNameSanitizer.displayName(fromPrompt: userPrompt)
-        return ToolMetadataSuggestion(
+        return ToolCreationPlan(
             displayName: displayName,
             iconPrompt: "",
             menuBarSystemImage: ToolMenuBarSymbol.fallback,

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolVersionBackupClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolVersionBackupClient.swift
@@ -17,6 +17,14 @@ struct ToolVersionBackupClient {
     ) throws -> ToolContentVersionBackup
     var promoteStagedVersion: (_ backup: ToolContentVersionBackup) throws -> Void
     var discardStagedVersion: (_ backup: ToolContentVersionBackup) throws -> Void
+    var stagePendingGenerationSettings: (
+        _ packageRootURL: URL,
+        _ settings: ToolGenerationSettings
+    ) throws -> Void
+    var pendingGenerationSettings: (
+        _ packageRootURL: URL
+    ) throws -> ToolGenerationSettings?
+    var clearPendingGenerationSettings: (_ packageRootURL: URL) throws -> Void
     var hasPreviousVersion: (_ packageRootURL: URL, _ contentViewPath: String) -> Bool
     var restoreStagedVersion: (
         _ packageRootURL: URL,
@@ -68,6 +76,7 @@ struct ToolVersionBackupClient {
                     to: backup.previousBuildSettingsURL
                 )
             }
+            try removePendingGenerationSettings(for: backup.packageRootURL)
         },
         discardStagedVersion: { backup in
             if FileManager.default.fileExists(atPath: backup.pendingURL.path) {
@@ -76,6 +85,26 @@ struct ToolVersionBackupClient {
             if FileManager.default.fileExists(atPath: backup.pendingBuildSettingsURL.path) {
                 try FileManager.default.removeItem(at: backup.pendingBuildSettingsURL)
             }
+            try removePendingGenerationSettings(for: backup.packageRootURL)
+        },
+        stagePendingGenerationSettings: { packageRootURL, settings in
+            let url = ToolPackageLayout.pendingGenerationSettingsURL(for: packageRootURL)
+            let data = try JSONEncoder().encode(ToolVersionBuildSettingsSnapshot(settings: settings))
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+        },
+        pendingGenerationSettings: { packageRootURL in
+            let url = ToolPackageLayout.pendingGenerationSettingsURL(for: packageRootURL)
+            guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(ToolVersionBuildSettingsSnapshot.self, from: data)
+                .settings
+        },
+        clearPendingGenerationSettings: { packageRootURL in
+            try removePendingGenerationSettings(for: packageRootURL)
         },
         hasPreviousVersion: { packageRootURL, contentViewPath in
             guard let backup = try? backupPaths(packageRootURL: packageRootURL, contentViewPath: contentViewPath) else {
@@ -109,6 +138,7 @@ struct ToolVersionBackupClient {
             if FileManager.default.fileExists(atPath: backup.pendingBuildSettingsURL.path) {
                 try FileManager.default.removeItem(at: backup.pendingBuildSettingsURL)
             }
+            try removePendingGenerationSettings(for: packageRootURL)
             return stagedSettings
         },
         restorePreviousVersion: { packageRootURL, contentViewPath, currentSettings in
@@ -186,6 +216,12 @@ private func resolvedContentViewURL(
     contentViewPath: String
 ) throws -> URL {
     try ToolPackageLayout.packageFileURL(for: contentViewPath, packageRootURL: packageRootURL)
+}
+
+private func removePendingGenerationSettings(for packageRootURL: URL) throws {
+    let url = ToolPackageLayout.pendingGenerationSettingsURL(for: packageRootURL)
+    guard FileManager.default.fileExists(atPath: url.path) else { return }
+    try FileManager.default.removeItem(at: url)
 }
 
 nonisolated private struct ToolVersionBuildSettingsSnapshot: Codable, Equatable {

--- a/Ironsmith/Core/Inference/ModelSelection/GenerationPreferencesStore.swift
+++ b/Ironsmith/Core/Inference/ModelSelection/GenerationPreferencesStore.swift
@@ -9,6 +9,8 @@ final class GenerationPreferencesStore {
         static let codingAgentPreference = "generation.agentPipelineProfile"
         static let reasoningEffort = "generation.reasoningEffort"
         static let imageGenerationProvider = "generation.imageGenerationProvider"
+        static let automaticallySelectGeneratedAppPermissions =
+            "generation.automaticallySelectGeneratedAppPermissions"
     }
 
     var generatedPromptRefinementEnabled: Bool {
@@ -29,6 +31,14 @@ final class GenerationPreferencesStore {
     var imageGenerationProvider: ToolImageGenerationProvider {
         didSet {
             userDefaults.set(imageGenerationProvider.rawValue, forKey: Key.imageGenerationProvider)
+        }
+    }
+    var automaticallySelectGeneratedAppPermissions: Bool {
+        didSet {
+            userDefaults.set(
+                automaticallySelectGeneratedAppPermissions,
+                forKey: Key.automaticallySelectGeneratedAppPermissions
+            )
         }
     }
     var generatedAppMicrophoneAccessEnabled: Bool {
@@ -174,6 +184,11 @@ final class GenerationPreferencesStore {
         self.imageGenerationProvider = userDefaults
             .string(forKey: Key.imageGenerationProvider)
             .flatMap(ToolImageGenerationProvider.init(rawValue:)) ?? .automatic
+        self.automaticallySelectGeneratedAppPermissions = userDefaults.object(
+            forKey: Key.automaticallySelectGeneratedAppPermissions
+        ) == nil
+            ? true
+            : userDefaults.bool(forKey: Key.automaticallySelectGeneratedAppPermissions)
         self.generatedAppMicrophoneAccessEnabled = userDefaults.bool(
             forKey: GeneratedAppResourcePermission.microphone.userDefaultsKey
         )

--- a/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
@@ -80,6 +80,25 @@ struct SettingsPreferencesSectionView: View {
 
         Section {
             VStack(alignment: .leading, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle(
+                        "Automatically select permissions",
+                        isOn: binding(\.automaticallySelectGeneratedAppPermissions)
+                    )
+                    .toggleStyle(.switch)
+
+                    Text(
+                        inferenceStore.generationPreferences
+                            .automaticallySelectGeneratedAppPermissions
+                            ? "Ironsmith selects permissions from each prompt. Permissions below are always included."
+                            : "Permissions below provide the defaults shown when generating an app."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
+                Divider()
+
                 VStack(alignment: .leading, spacing: 6) {
                     Text("General access")
                         .font(.caption.weight(.semibold))
@@ -103,7 +122,7 @@ struct SettingsPreferencesSectionView: View {
                 }
             }
         } header: {
-            Text("Default generated app permissions")
+            Text("Generated app permissions")
         }
     }
 

--- a/Ironsmith/Features/Store/StoreAppDetailView.swift
+++ b/Ironsmith/Features/Store/StoreAppDetailView.swift
@@ -432,7 +432,10 @@ nonisolated struct StorePermissionPresentation: Identifiable, Equatable, Sendabl
     let systemImage: String
 
     static func items(for version: StoreVersionMetadata) -> [Self] {
-        let settings = version.generationSettings.toolSettings
+        items(for: version.generationSettings.toolSettings)
+    }
+
+    static func items(for settings: ToolGenerationSettings) -> [Self] {
         let sandbox: [Self] = settings.sandboxEnabled
             ? settings.sandboxPermissions.enabledPermissions.map { permission in
                 switch permission {

--- a/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
@@ -12,13 +12,14 @@ struct PromptComposerView: View {
     @Binding var prompt: String
     @Binding var isExpanded: Bool
     @Binding var sandboxEnabled: Bool
-    @Binding var appKind: ToolAppKind
+    @Binding var appKindPreference: ToolAppKindPreference
     @Binding var sandboxPermissions: GeneratedAppSandboxPermissions
     @Binding var resourcePermissions: GeneratedAppResourcePermissions
     @Binding var codingAgentPreference: ToolCodingAgentPreference
     @Binding var reasoningEffort: ToolReasoningEffort
     let placeholder: String
     let showsSandboxControl: Bool
+    let showsPermissionControls: Bool
     let modelPickerTitle: String
     let isModelPickerEnabled: Bool
     let isSubmitEnabled: Bool
@@ -252,13 +253,13 @@ struct PromptComposerView: View {
 
     private var generationSettingsMenu: some View {
         Menu {
-            Picker("App Type", selection: $appKind) {
-                ForEach(ToolAppKind.allCases, id: \.self) { kind in
+            Picker("App Type", selection: $appKindPreference) {
+                ForEach(ToolAppKindPreference.allCases, id: \.self) { preference in
                     Label(
-                        kind.displayName,
-                        systemImage: kind == .menuBar ? "menubar.rectangle" : "macwindow"
+                        preference.displayName,
+                        systemImage: appKindSystemImage(preference)
                     )
-                    .tag(kind)
+                    .tag(preference)
                 }
             }
 
@@ -311,21 +312,26 @@ struct PromptComposerView: View {
                     .help(sandboxHelpText)
             }
 
-            Divider()
+            if showsPermissionControls {
+                Divider()
 
-            Menu("Permissions") {
-                Section("General Access") {
-                    ForEach(GeneratedAppResourcePermission.allCases) { permission in
-                        Toggle(
-                            permission.displayName, isOn: resourcePermissionBinding(for: permission)
-                        )
+                Menu("Permissions") {
+                    Section("General Access") {
+                        ForEach(GeneratedAppResourcePermission.allCases) { permission in
+                            Toggle(
+                                permission.displayName,
+                                isOn: resourcePermissionBinding(for: permission)
+                            )
+                        }
                     }
-                }
 
-                Section("Sandbox Access") {
-                    ForEach(GeneratedAppSandboxPermission.allCases) { permission in
-                        Toggle(
-                            permission.displayName, isOn: sandboxPermissionBinding(for: permission))
+                    Section("Sandbox Access") {
+                        ForEach(GeneratedAppSandboxPermission.allCases) { permission in
+                            Toggle(
+                                permission.displayName,
+                                isOn: sandboxPermissionBinding(for: permission)
+                            )
+                        }
                     }
                 }
             }
@@ -419,6 +425,14 @@ struct PromptComposerView: View {
 
     private var sandboxHelpText: String {
         "Controls whether generated apps include App Sandbox entitlements."
+    }
+
+    private func appKindSystemImage(_ preference: ToolAppKindPreference) -> String {
+        switch preference {
+        case .automatic: "wand.and.sparkles"
+        case .window: "macwindow"
+        case .menuBar: "menubar.rectangle"
+        }
     }
 
     private func checkedSelectionButton<Value: Equatable>(
@@ -620,7 +634,7 @@ private struct PromptComposerPreview: View {
             prompt: .constant(""),
             isExpanded: $isExpanded,
             sandboxEnabled: .constant(!isEditing),
-            appKind: .constant(isEditing ? .menuBar : .window),
+            appKindPreference: .constant(isEditing ? .menuBar : .automatic),
             sandboxPermissions: .constant(.default),
             resourcePermissions: .constant(
                 isEditing ? GeneratedAppResourcePermissions([.camera]) : .none
@@ -631,6 +645,7 @@ private struct PromptComposerPreview: View {
                 ? "Describe changes for Clipboard Cleaner…"
                 : "Describe a new app to build…",
             showsSandboxControl: isEditing,
+            showsPermissionControls: true,
             modelPickerTitle: "DeepSeek V4 Flash",
             isModelPickerEnabled: true,
             isSubmitEnabled: isEditing,

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -30,7 +30,7 @@ struct ToolLibraryPopoverView: View {
     #endif
     let appUpdateStore: AppUpdateStore
     private let welcomeOnboardingStore: WelcomeOnboardingStore
-    private let remixMetadataClient: ToolMetadataClient
+    private let remixMetadataClient: ToolGenerationPlanningClient
     @State private var toolLibraryStore = ToolLibraryStore()
     @State private var storePublisher: ToolLibraryStorePublisher
     @State private var detailsEditor: ToolAppDetailsEditorStore
@@ -69,7 +69,7 @@ struct ToolLibraryPopoverView: View {
         iconClient: ToolIconClient = .cachedOnly(),
         iconEditingClient: ToolIconEditingClient? = nil,
         iconBuildClient: ToolBuildClient? = nil,
-        remixMetadataClient: ToolMetadataClient? = nil
+        remixMetadataClient: ToolGenerationPlanningClient? = nil
     ) {
         self.appUpdateStore = appUpdateStore
         self.welcomeOnboardingStore = welcomeOnboardingStore ?? WelcomeOnboardingStore()
@@ -335,13 +335,15 @@ struct ToolLibraryPopoverView: View {
                 prompt: $toolLibraryStore.prompt,
                 isExpanded: $isPromptExpanded,
                 sandboxEnabled: sandboxEnabledBinding,
-                appKind: appKindBinding,
+                appKindPreference: appKindPreferenceBinding,
                 sandboxPermissions: sandboxPermissionsBinding,
                 resourcePermissions: resourcePermissionsBinding,
                 codingAgentPreference: codingAgentPreferenceBinding,
                 reasoningEffort: reasoningEffortBinding,
                 placeholder: toolLibraryStore.promptPlaceholder,
                 showsSandboxControl: showSandboxOverride,
+                showsPermissionControls: !inferenceStore.generationPreferences
+                    .automaticallySelectGeneratedAppPermissions,
                 modelPickerTitle: composerModelPickerTitle,
                 isModelPickerEnabled: isComposerModelPickerEnabled,
                 isSubmitEnabled: canSubmitPrompt,
@@ -880,13 +882,10 @@ struct ToolLibraryPopoverView: View {
         )
     }
 
-    private var appKindBinding: Binding<ToolAppKind> {
+    private var appKindPreferenceBinding: Binding<ToolAppKindPreference> {
         Binding(
-            get: { toolLibraryStore.appKind },
-            set: { newValue in
-                toolLibraryStore.appKind = newValue
-                toolLibraryStore.rememberCurrentGenerationSettingsForNextGeneration()
-            }
+            get: { toolLibraryStore.appKindPreference },
+            set: { toolLibraryStore.setAppKindPreference($0) }
         )
     }
 
@@ -1053,7 +1052,7 @@ struct ToolLibraryPopoverView: View {
             )
             let sourceURL = try tool.packageLayout.packageFileURL(for: tool.contentViewSourcePath)
             let source = try String(contentsOf: sourceURL, encoding: .utf8)
-            let suggestion = await remixMetadataClient.suggestMetadata(
+            let suggestion = await remixMetadataClient.planCreation(
                 userPrompt: Self.remixIdentityPrompt(for: tool, source: source),
                 imageGenerationProvider: inferenceStore.effectiveImageGenerationProvider,
                 invoker: languageModelContext.languageModelInvoker

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import Auth
 import Foundation
 import SwiftData
 import SwiftUI
@@ -629,6 +630,9 @@ struct ToolLibraryPopoverView: View {
         if let tool = tools.first(where: { $0.id == storePublisher.publishingToolID }) {
             ToolLibraryStorePublishSheetView(
                 tool: tool,
+                generationSettings: tool.generationSettings(
+                    defaults: defaultGenerationSettings
+                ),
                 isUpdatingPublishedListing: storePublisher.isUpdatingPublishedListing,
                 publishShortDescription: $storePublisher.publishShortDescription,
                 publishDescription: $storePublisher.publishDescription,
@@ -738,7 +742,7 @@ struct ToolLibraryPopoverView: View {
     }
 
     private var publishedStoreLinkRefreshID: String {
-        let session = inferenceStore.ironsmithSession == nil ? "signed-out" : "signed-in"
+        let session = inferenceStore.ironsmithSession?.user.id.uuidString ?? "signed-out"
         let storeFeature = isStoreFeatureEnabled ? "store-on" : "store-off"
         let links =
             tools
@@ -991,7 +995,9 @@ struct ToolLibraryPopoverView: View {
         switch toolLibraryStore.remixIdentitySubmissionAction(
             for: tool,
             generatesIdentity: generatesIdentityForNewRemixes,
-            hasPresentedNotice: hasPresentedRemixIdentityNotice
+            hasPresentedNotice: hasPresentedRemixIdentityNotice,
+            isConfirmedDownloadedFromAnotherUser: storePublisher
+                .isConfirmedDownloadedFromAnotherUser(tool)
         ) {
         case .submit:
             submitCurrentPrompt()

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublishSheetView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct ToolLibraryStorePublishSheetView: View {
     let tool: Tool
+    let generationSettings: ToolGenerationSettings
     let isUpdatingPublishedListing: Bool
     @Binding var publishShortDescription: String
     @Binding var publishDescription: String
@@ -34,6 +35,7 @@ struct ToolLibraryStorePublishSheetView: View {
             .font(.headline)
 
             appIdentitySection
+            permissionsSection
 
             field("Short Description") {
                 TextField(
@@ -222,6 +224,45 @@ struct ToolLibraryStorePublishSheetView: View {
             .padding(10)
             .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
         }
+    }
+
+    private var permissionsSection: some View {
+        field("Permissions") {
+            Group {
+                if publishPermissions.isEmpty {
+                    Text("No additional permissions")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                } else {
+                    LazyVGrid(
+                        columns: [
+                            GridItem(.adaptive(minimum: 180), spacing: 14, alignment: .top)
+                        ],
+                        alignment: .leading,
+                        spacing: 10
+                    ) {
+                        ForEach(publishPermissions) { permission in
+                            HStack(spacing: 7) {
+                                Image(systemName: permission.systemImage)
+                                    .font(.body)
+                                    .foregroundStyle(.blue)
+                                    .frame(width: 18)
+                                Text(permission.title)
+                                    .font(.callout.weight(.medium))
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+            }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 8))
+        }
+    }
+
+    private var publishPermissions: [StorePermissionPresentation] {
+        StorePermissionPresentation.items(for: generationSettings)
     }
 
     @ViewBuilder

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryStorePublisher.swift
@@ -6,6 +6,8 @@ import SwiftData
 @Observable
 final class ToolLibraryStorePublisher {
     var publishedStoreAppsByID: [String: StoreAppSummary] = [:]
+    private(set) var hasResolvedPublishedStoreApps = false
+    private var publishedStoreAppsRefreshGeneration: UInt = 0
     var publishingToolID: UUID?
     var publishShortDescription = ""
     var publishDescription = ""
@@ -63,6 +65,13 @@ final class ToolLibraryStorePublisher {
     func canUpdateStoreVersion(for tool: Tool) -> Bool {
         guard let storeAppId = tool.storeAppId else { return false }
         return publishedStoreAppsByID[storeAppId] != nil
+    }
+
+    func isConfirmedDownloadedFromAnotherUser(_ tool: Tool) -> Bool {
+        guard let storeAppId = tool.storeAppId,
+            hasResolvedPublishedStoreApps
+        else { return false }
+        return publishedStoreAppsByID[storeAppId] == nil
     }
 
     func hasStoreSourceChanges(for tool: Tool) -> Bool {
@@ -130,8 +139,12 @@ final class ToolLibraryStorePublisher {
         isSignedIn: Bool,
         tools: [Tool]
     ) async {
+        publishedStoreAppsRefreshGeneration &+= 1
+        let refreshGeneration = publishedStoreAppsRefreshGeneration
+        publishedStoreAppsByID = [:]
+        hasResolvedPublishedStoreApps = false
+
         guard isSignedIn else {
-            publishedStoreAppsByID = [:]
             return
         }
         let storeIDs = Set(
@@ -141,7 +154,7 @@ final class ToolLibraryStorePublisher {
             }
         )
         guard !storeIDs.isEmpty else {
-            publishedStoreAppsByID = [:]
+            hasResolvedPublishedStoreApps = true
             return
         }
 
@@ -161,6 +174,9 @@ final class ToolLibraryStorePublisher {
                         nil,
                         nil
                     )
+                    guard refreshGeneration == publishedStoreAppsRefreshGeneration else {
+                        return
+                    }
                     for app in page.apps {
                         guard linkedAppIDs.contains(app.id) else { continue }
                         ownedAppsByID[app.id] = app
@@ -169,9 +185,13 @@ final class ToolLibraryStorePublisher {
                     hasMore = page.hasMore
                 } while hasMore
             }
+            guard refreshGeneration == publishedStoreAppsRefreshGeneration else { return }
             publishedStoreAppsByID = ownedAppsByID
+            hasResolvedPublishedStoreApps = true
         } catch {
+            guard refreshGeneration == publishedStoreAppsRefreshGeneration else { return }
             publishedStoreAppsByID = [:]
+            hasResolvedPublishedStoreApps = false
         }
     }
 

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -235,7 +235,7 @@ enum ToolRowGenerationStatusResolver {
         case .initializing:
             return "Initializing"
         case .planning:
-            return "Naming app"
+            return "Generating metadata"
         case .generatingIcon:
             return "Generating icon"
         case .waitingForIcon:

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -65,6 +65,7 @@ final class ToolLibraryStore {
     var isGenerating = false
     var sandboxEnabled = true
     var appKind: ToolAppKind = .window
+    var appKindPreference: ToolAppKindPreference = .automatic
     var menuBarSystemImage = ToolMenuBarSymbol.fallback
     var sandboxPermissions = GeneratedAppSandboxPermissions.default
     var resourcePermissions = GeneratedAppResourcePermissions.none
@@ -79,6 +80,7 @@ final class ToolLibraryStore {
     private(set) var selectedToolName: String?
     private var restorableToolIDs = Set<UUID>()
     @ObservationIgnored private var nextGenerationSettings: ToolGenerationSettings?
+    @ObservationIgnored private var nextGenerationAppKindPreference: ToolAppKindPreference = .automatic
     @ObservationIgnored private var hasCustomizedNextGenerationSettings = false
     @ObservationIgnored private var generationTask: Task<Void, Never>?
     @ObservationIgnored private var generationStopWasRequested = false
@@ -180,13 +182,25 @@ final class ToolLibraryStore {
         guard !hasCustomizedNextGenerationSettings else { return }
         nextGenerationSettings = defaultSettings
         if !hasSelectedTool {
-            applyComposerSettings(defaultSettings)
+            applyComposerSettings(
+                defaultSettings,
+                appKindPreference: nextGenerationAppKindPreference
+            )
         }
     }
 
     func rememberCurrentGenerationSettingsForNextGeneration() {
         nextGenerationSettings = currentComposerSettings
+        nextGenerationAppKindPreference = appKindPreference
         hasCustomizedNextGenerationSettings = true
+    }
+
+    func setAppKindPreference(_ preference: ToolAppKindPreference) {
+        appKindPreference = preference
+        if let explicitAppKind = preference.explicitAppKind {
+            appKind = explicitAppKind
+        }
+        rememberCurrentGenerationSettingsForNextGeneration()
     }
 
     func isSelected(_ tool: Tool) -> Bool {
@@ -363,6 +377,9 @@ final class ToolLibraryStore {
                 } catch ToolVersionBackupError.missingStagedVersion {
                     // Older incomplete edits may not have a staged backup; leave the current package intact.
                 }
+                try? dependencies.versionBackupClient.clearPendingGenerationSettings(
+                    packageRootURL
+                )
                 clearPendingGeneration(on: tool)
                 try modelContext.save()
                 removeCurrentRunAttachments(for: tool)
@@ -456,6 +473,7 @@ final class ToolLibraryStore {
         let submittedSettings = submittedGenerationSettings(
             defaultSettings: Self.defaultGenerationSettings(from: inferenceStore.generationPreferences)
         )
+        let submittedAppKindPreference = appKindPreference
         let submittedAttachments = attachments
         var activeTool: Tool?
         isGenerating = true
@@ -510,6 +528,12 @@ final class ToolLibraryStore {
                     prompt: trimmedPrompt,
                     existingTool: selectedTool,
                     settings: submittedSettings,
+                    planningPolicy: generationPlanningPolicy(
+                        preferences: inferenceStore.generationPreferences,
+                        appKindPreference: selectedTool == nil
+                            ? submittedAppKindPreference
+                            : ToolAppKindPreference(submittedSettings.appKind)
+                    ),
                     languageModelContext: languageModelContext,
                     imageGenerationProvider: inferenceStore.effectiveImageGenerationProvider,
                     attachments: submittedAttachments,
@@ -737,7 +761,10 @@ final class ToolLibraryStore {
     private func clearSelection() {
         selectedToolID = nil
         selectedToolName = nil
-        applyComposerSettings(nextGenerationSettings ?? .default)
+        applyComposerSettings(
+            nextGenerationSettings ?? .default,
+            appKindPreference: nextGenerationAppKindPreference
+        )
     }
 
     private var currentComposerSettings: ToolGenerationSettings {
@@ -750,9 +777,13 @@ final class ToolLibraryStore {
         )
     }
 
-    private func applyComposerSettings(_ settings: ToolGenerationSettings) {
+    private func applyComposerSettings(
+        _ settings: ToolGenerationSettings,
+        appKindPreference: ToolAppKindPreference? = nil
+    ) {
         sandboxEnabled = settings.sandboxEnabled
         appKind = settings.appKind
+        self.appKindPreference = appKindPreference ?? ToolAppKindPreference(settings.appKind)
         menuBarSystemImage = settings.menuBarSystemImage
         sandboxPermissions = settings.sandboxPermissions
         resourcePermissions = settings.resourcePermissions
@@ -771,6 +802,19 @@ final class ToolLibraryStore {
             sandboxEnabled: sandboxEnabled,
             sandboxPermissions: defaultBackedSandboxPermissions,
             resourcePermissions: defaultBackedResourcePermissions
+        )
+    }
+
+    private func generationPlanningPolicy(
+        preferences: GenerationPreferencesStore,
+        appKindPreference: ToolAppKindPreference
+    ) -> ToolGenerationPlanningPolicy {
+        ToolGenerationPlanningPolicy(
+            appKindPreference: appKindPreference,
+            automaticallySelectPermissions: preferences
+                .automaticallySelectGeneratedAppPermissions,
+            alwaysIncludedSandboxPermissions: preferences.generatedAppSandboxPermissions,
+            alwaysIncludedResourcePermissions: preferences.generatedAppResourcePermissions
         )
     }
 
@@ -848,6 +892,10 @@ final class ToolLibraryStore {
                     prompt: resumePrompt,
                     existingTool: tool,
                     settings: settings,
+                    planningPolicy: generationPlanningPolicy(
+                        preferences: inferenceStore.generationPreferences,
+                        appKindPreference: ToolAppKindPreference(settings.appKind)
+                    ),
                     languageModelContext: languageModelContext,
                     imageGenerationProvider: inferenceStore.effectiveImageGenerationProvider,
                     lifecycle: lifecycle

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -1137,9 +1137,13 @@ final class ToolLibraryStore {
     func remixIdentitySubmissionAction(
         for tool: Tool,
         generatesIdentity: Bool,
-        hasPresentedNotice: Bool
+        hasPresentedNotice: Bool,
+        isConfirmedDownloadedFromAnotherUser: Bool
     ) -> ToolRemixIdentitySubmissionAction {
-        guard isFirstEditOfDownloadedApp(tool), generatesIdentity else { return .submit }
+        guard isConfirmedDownloadedFromAnotherUser,
+            isFirstEditOfDownloadedApp(tool),
+            generatesIdentity
+        else { return .submit }
         return hasPresentedNotice ? .generateIdentity : .presentNotice
     }
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineCodexAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineCodexAgentTests.swift
@@ -1117,7 +1117,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .codex(),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: ToolMetadataClient { _ in
+            planningClient: ToolGenerationPlanningClient { _ in
                 let placeholderRoot = toolsDirectory.appendingPathComponent(
                     "new-app",
                     isDirectory: true
@@ -1131,7 +1131,7 @@ extension AgentPipelineTests {
                         .appendingPathComponent("1-reference.txt").path
                 ))
                 #expect(!FileManager.default.fileExists(atPath: placeholderLayout.packageManifestURL.path))
-                return ToolMetadataSuggestion(displayName: "Codex Demo", iconPrompt: "")
+                return ToolCreationPlan(displayName: "Codex Demo", iconPrompt: "")
             },
             promptRefinementClient: ToolPromptRefinementClient { _ in
                 "Refined codex prompt"
@@ -1298,8 +1298,8 @@ extension AgentPipelineTests {
             pipelineConfiguration: .codex(),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Codex Demo", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Codex Demo", iconPrompt: "")
             },
             codexAgentClient: codexAgentClient,
             codingAgentModelIdentifier: "gpt-5.5",

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineDiagnosticWholeFileRewriteTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineDiagnosticWholeFileRewriteTests.swift
@@ -33,8 +33,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.diagnosticRewriteProcessClient(builds: builds, formats: formats),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Disabled Rewrite Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Disabled Rewrite Tool", iconPrompt: "")
             }
         )
 
@@ -83,8 +83,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.diagnosticRewriteProcessClient(builds: builds, formats: formats),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Diagnostic Rewrite Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Diagnostic Rewrite Tool", iconPrompt: "")
             }
         )
 
@@ -146,8 +146,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.diagnosticRewriteProcessClient(builds: builds, formats: formats),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(
                     displayName: "Progressive Diagnostic Rewrite Tool",
                     iconPrompt: ""
                 )
@@ -227,8 +227,8 @@ extension AgentPipelineTests {
                 launch: { _ in },
                 stripQuarantine: { _ in }
             ),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(
                     displayName: "Deterministic Stall Recovery Tool",
                     iconPrompt: ""
                 )
@@ -293,8 +293,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.diagnosticRewriteProcessClient(builds: builds, formats: formats),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Regressed Rewrite Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Regressed Rewrite Tool", iconPrompt: "")
             }
         )
 
@@ -348,8 +348,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.diagnosticRewriteProcessClient(builds: builds, formats: formats),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "One Shot Rewrite Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "One Shot Rewrite Tool", iconPrompt: "")
             }
         )
 
@@ -396,8 +396,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.diagnosticRewriteProcessClient(builds: builds, formats: formats),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Context Window Rewrite Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Context Window Rewrite Tool", iconPrompt: "")
             }
         )
 
@@ -444,8 +444,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.diagnosticRewriteProcessClient(builds: builds, formats: formats),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "High Error Rewrite Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "High Error Rewrite Tool", iconPrompt: "")
             }
         )
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationCreateTests.swift
@@ -70,8 +70,8 @@ extension AgentPipelineTests {
             languageModel: model,
             toolsDirectoryURL: toolsDirectory,
             iconClient: iconClient,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Parallel Icon", iconPrompt: "An anvil")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Parallel Icon", iconPrompt: "An anvil")
             }
         )
 
@@ -195,8 +195,8 @@ extension AgentPipelineTests {
             languageModel: model,
             toolsDirectoryURL: toolsDirectory,
             iconClient: iconClient,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Paused Icon", iconPrompt: "An anvil")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Paused Icon", iconPrompt: "An anvil")
             }
         )
 
@@ -250,8 +250,8 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: .live,
             appBundleClient: .noOp(),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Cancel Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Cancel Tool", iconPrompt: "")
             }
         )
 
@@ -327,8 +327,8 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: .noOp(),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Flame Envelope", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Flame Envelope", iconPrompt: "")
             }
         )
 
@@ -368,7 +368,7 @@ extension AgentPipelineTests {
             processClient: processClient,
             appBundleClient: .noOp(),
             iconClient: .noOp,
-            metadataClient: .fallback()
+            planningClient: .fallback()
         ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
@@ -412,7 +412,7 @@ extension AgentPipelineTests {
 
     @MainActor
     @Test
-    func liveGenerationClientUsesGeneratedMetadataForNameAndIconPrompt() async throws {
+    func liveGenerationClientResolvesAutomaticCreationPlanAndAlwaysIncludedPermissions() async throws {
         let toolsDirectory = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: toolsDirectory) }
 
@@ -448,12 +448,15 @@ extension AgentPipelineTests {
             processClient: processClient,
             appBundleClient: appBundleClient,
             iconClient: .noOp,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(
                     displayName: "Focus Pad",
                     iconPrompt: iconPrompt,
                     menuBarSystemImage: "note.text",
-                    category: .productivity
+                    category: .productivity,
+                    suggestedAppKind: .menuBar,
+                    suggestedSandboxPermissions: GeneratedAppSandboxPermissions([.downloadsFolder]),
+                    suggestedResourcePermissions: GeneratedAppResourcePermissions([.microphone])
                 )
             },
             promptRefinementClient: ToolPromptRefinementClient { _ in
@@ -482,7 +485,6 @@ extension AgentPipelineTests {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
 
-        store.appKind = .menuBar
         store.prompt = "Build a focused notes helper with quick tags"
         await store.submitPrompt(modelContext: context, inferenceStore: inferenceStore)
 
@@ -492,7 +494,10 @@ extension AgentPipelineTests {
         #expect(tool.appKind == .menuBar)
         #expect(tool.validatedMenuBarSystemImage == "note.text")
         #expect(tool.category == .productivity)
-        #expect(tool.storedResourcePermissions?.enabled == [.camera])
+        #expect(tool.storedSandboxPermissions?.enabled == [
+            .outgoingConnections, .userSelectedFiles, .downloadsFolder,
+        ])
+        #expect(tool.storedResourcePermissions?.enabled == [.camera, .microphone])
         #expect(tool.pendingPrompt == nil)
         #expect(tool.packageRootURL.lastPathComponent == "focus-pad")
         let appEntryURL = tool.packageRootURL.appendingPathComponent("Sources/FocusPad/FocusPad.swift")
@@ -545,7 +550,7 @@ extension AgentPipelineTests {
             processClient: processClient,
             appBundleClient: .noOp(),
             iconClient: .noOp,
-            metadataClient: .fallback()
+            planningClient: .fallback()
         ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(
@@ -610,7 +615,7 @@ extension AgentPipelineTests {
             processClient: processClient,
             appBundleClient: .noOp(),
             iconClient: .noOp,
-            metadataClient: .fallback()
+            planningClient: .fallback()
         ))
         let store = ToolLibraryStore(
             dependencies: ToolLibraryDependencies(

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationEditTests.swift
@@ -75,6 +75,7 @@ extension AgentPipelineTests {
             source: Self.originalEditableSource
         )
         let responses = LanguageModelResponseQueue([Self.renameOldToNewUnifiedDiff])
+        let planningCapture = InvocationCapture()
         let runtime = Self.makeRuntime(
             languageModel: StubAgentLanguageModel { _, _ in
                 try await responses.next()
@@ -83,7 +84,13 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: ToolGenerationPlanningClient(
+                planCreation: { ToolCreationPlan.fallback(for: $0) },
+                planEdit: { _ in
+                    await planningCapture.record()
+                    return .empty
+                }
+            )
         )
         let result = try await runtime.generateTool(
             for: "Change old to new",
@@ -100,6 +107,128 @@ extension AgentPipelineTests {
         #expect(!(contentView.contains(#"Text("old")"#)))
         #expect(previousSource.contains(#"Text("old")"#))
         #expect(await responses.count == 1)
+        #expect(await planningCapture.count == 0)
+    }
+
+    @MainActor
+    @Test
+    func automaticEditPlanningOnlyAddsSuggestedAndAlwaysIncludedPermissions() async throws {
+        let toolsDirectory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let tool = try Self.makeExistingTool(
+            toolsDirectory: toolsDirectory,
+            executableName: "Calculator",
+            source: Self.originalEditableSource
+        )
+        let planningCapture = InvocationCapture()
+        let runtime = Self.makeRuntime(
+            languageModel: StubAgentLanguageModel.fixed(Self.renameOldToNewUnifiedDiff),
+            generationOptions: GenerationOptions(),
+            pipelineConfiguration: .ironsmithSpark(
+                repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)
+            ),
+            toolsDirectoryURL: toolsDirectory,
+            processClient: Self.successfulProcessClient(),
+            planningClient: ToolGenerationPlanningClient(
+                planCreation: { ToolCreationPlan.fallback(for: $0) },
+                planEdit: { _ in
+                    await planningCapture.record()
+                    return ToolEditPlan(
+                        additionalSandboxPermissions: GeneratedAppSandboxPermissions([
+                            .downloadsFolder
+                        ]),
+                        additionalResourcePermissions: GeneratedAppResourcePermissions([
+                            .microphone
+                        ])
+                    )
+                }
+            )
+        )
+        let settings = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.outgoingConnections]),
+            resourcePermissions: GeneratedAppResourcePermissions([.camera])
+        )
+        let policy = ToolGenerationPlanningPolicy(
+            appKindPreference: .window,
+            automaticallySelectPermissions: true,
+            alwaysIncludedSandboxPermissions: GeneratedAppSandboxPermissions([
+                .userSelectedFiles
+            ]),
+            alwaysIncludedResourcePermissions: GeneratedAppResourcePermissions([.location])
+        )
+
+        let result = try await runtime.generateTool(
+            for: "Add voice export to Downloads",
+            existingTool: tool,
+            settings: settings,
+            planningPolicy: policy
+        )
+
+        #expect(await planningCapture.count == 1)
+        #expect(result.settings.appKind == .window)
+        #expect(result.settings.sandboxPermissions.enabled == [
+            .outgoingConnections, .userSelectedFiles, .downloadsFolder,
+        ])
+        #expect(result.settings.resourcePermissions.enabled == [.camera, .location, .microphone])
+    }
+
+    @MainActor
+    @Test
+    func resumedAutomaticEditReusesPreviouslyResolvedPermissions() async throws {
+        let toolsDirectory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let tool = try Self.makeExistingTool(
+            toolsDirectory: toolsDirectory,
+            executableName: "Calculator",
+            source: Self.originalEditableSource
+        )
+        tool.generationState = .stopped
+        tool.generationPhase = .generatingEditDiff
+        tool.generationMode = .edit
+        let pendingSettings = ToolGenerationSettings(
+            sandboxPermissions: GeneratedAppSandboxPermissions([.downloadsFolder]),
+            resourcePermissions: GeneratedAppResourcePermissions([.microphone])
+        )
+        try ToolVersionBackupClient.live.stagePendingGenerationSettings(
+            tool.packageRootURL,
+            pendingSettings
+        )
+
+        let planningCapture = InvocationCapture()
+        let runtime = Self.makeRuntime(
+            languageModel: StubAgentLanguageModel.fixed(Self.renameOldToNewUnifiedDiff),
+            generationOptions: GenerationOptions(),
+            pipelineConfiguration: .ironsmithSpark(
+                repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)
+            ),
+            toolsDirectoryURL: toolsDirectory,
+            processClient: Self.successfulProcessClient(),
+            planningClient: ToolGenerationPlanningClient(
+                planCreation: { ToolCreationPlan.fallback(for: $0) },
+                planEdit: { _ in
+                    await planningCapture.record()
+                    return .empty
+                }
+            )
+        )
+
+        let result = try await runtime.generateTool(
+            for: "Change old to new",
+            existingTool: tool,
+            settings: .default,
+            planningPolicy: ToolGenerationPlanningPolicy(
+                appKindPreference: .window,
+                automaticallySelectPermissions: true,
+                alwaysIncludedSandboxPermissions: .none,
+                alwaysIncludedResourcePermissions: .none
+            )
+        )
+
+        #expect(await planningCapture.count == 0)
+        #expect(result.settings == pendingSettings)
+        #expect(!(FileManager.default.fileExists(atPath: tool.packageLayout.pendingGenerationSettingsURL.path)))
     }
 
     @MainActor
@@ -127,7 +256,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -177,7 +306,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithFlame(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: ToolGenerationRepairPolicy.largeModelPatchBlocksPerTurn)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -228,7 +357,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithFlame(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: ToolGenerationRepairPolicy.largeModelPatchBlocksPerTurn)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -279,7 +408,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -318,7 +447,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -368,7 +497,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
         let remoteRuntime = Self.makeRuntime(
             languageModel: model,
@@ -376,7 +505,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithFlame(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: ToolGenerationRepairPolicy.largeModelPatchBlocksPerTurn)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         _ = try await localRuntime.generateTool(
@@ -440,7 +569,7 @@ extension AgentPipelineTests {
                 launch: { _ in },
                 stripQuarantine: { _ in }
             ),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         do {

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationRepairLoopTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineGenerationRepairLoopTests.swift
@@ -54,7 +54,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .deterministicOnly),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -132,7 +132,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -200,7 +200,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -268,7 +268,7 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: 1)),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: .fallback(),
+            planningClient: .fallback(),
             afterLanguageModelInvocation: {
                 await invocationCapture.record()
             }
@@ -354,8 +354,8 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Model Conversation Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Model Conversation Tool", iconPrompt: "")
             }
         )
 
@@ -446,8 +446,8 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithFlame(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: ToolGenerationRepairPolicy.largeModelPatchBlocksPerTurn)),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Build A Large Model Repair", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Build A Large Model Repair", iconPrompt: "")
             }
         )
 
@@ -652,8 +652,8 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithFlame(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: ToolGenerationRepairPolicy.largeModelPatchBlocksPerTurn)),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Build Safety Limit Repair", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Build Safety Limit Repair", iconPrompt: "")
             }
         )
 
@@ -752,8 +752,8 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithFlame(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: ToolGenerationRepairPolicy.largeModelPatchBlocksPerTurn)),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Temporary Increase Repair", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Temporary Increase Repair", iconPrompt: "")
             }
         )
 
@@ -835,7 +835,7 @@ extension AgentPipelineTests {
             ),
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -895,7 +895,7 @@ extension AgentPipelineTests {
                 launch: { _ in },
                 stripQuarantine: { _ in }
             ),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineMetadataAndPromptTests.swift
@@ -8,27 +8,103 @@ import Testing
 extension AgentPipelineTests {
     @MainActor
     @Test
-    func generatedMetadataSchemaIncludesNameIconMenuBarSymbolAndCategory() throws {
-        let data = try JSONEncoder().encode(GeneratedToolMetadata.generationSchema)
+    func generatedCreationPlanSchemaIncludesMetadataAppKindAndPermissions() throws {
+        let data = try JSONEncoder().encode(GeneratedToolCreationPlan.generationSchema)
         let schema = try #require(String(data: data, encoding: .utf8))
 
         #expect(schema.contains("displayName"))
         #expect(schema.contains("iconPrompt"))
         #expect(schema.contains("menuBarSystemImage"))
         #expect(schema.contains("category"))
+        #expect(schema.contains("appKind"))
+        #expect(schema.contains("sandboxPermissions"))
+        #expect(schema.contains("resourcePermissions"))
+        #expect(schema.contains("Exact sandbox permission raw values"))
+        #expect(schema.contains("Exact resource permission raw values"))
         #expect(!(schema.contains("refinedPrompt")))
     }
 
     @MainActor
     @Test
+    func creationPlanningRequestsAndValidatesPermissions() async throws {
+        let response = StructuredMetadataResponse(
+            creationPlan: GeneratedToolCreationPlan(
+                displayName: "Camera Dot",
+                iconPrompt: "Camera with dot",
+                menuBarSystemImage: "camera",
+                category: StoreAppCategory.utilities.rawValue,
+                appKind: ToolAppKind.menuBar.rawValue,
+                sandboxPermissions: [
+                    GeneratedAppSandboxPermission.outgoingConnections.rawValue,
+                    "unknown-sandbox-permission",
+                ],
+                resourcePermissions: [
+                    GeneratedAppResourcePermission.camera.rawValue,
+                    "unknown-resource-permission",
+                ]
+            )
+        )
+
+        let suggestion = await ToolGenerationPlanningClient.live().planCreation(
+            userPrompt: "Show a camera status dot in the menu bar",
+            invoker: Self.makeInvoker(
+                languageModel: StructuredMetadataLanguageModel(response: response),
+                generationOptions: GenerationOptions(maximumResponseTokens: 4096)
+            )
+        )
+
+        #expect(suggestion.suggestedAppKind == .menuBar)
+        #expect(suggestion.suggestedSandboxPermissions.enabled == [.outgoingConnections])
+        #expect(suggestion.suggestedResourcePermissions.enabled == [.camera])
+        let prompt = try #require(await response.prompts.first)
+        #expect(prompt.contains("Allowed sandboxPermissions values:"))
+        #expect(prompt.contains("Allowed resourcePermissions values:"))
+    }
+
+    @MainActor
+    @Test
+    func editPlanningRequestsOnlyAdditionalValidatedPermissions() async throws {
+        let response = StructuredMetadataResponse(
+            editPlan: GeneratedToolEditPlan(
+                additionalSandboxPermissions: [
+                    GeneratedAppSandboxPermission.downloadsFolder.rawValue,
+                    "unknown-sandbox-permission",
+                ],
+                additionalResourcePermissions: [
+                    GeneratedAppResourcePermission.microphone.rawValue,
+                    "unknown-resource-permission",
+                ]
+            )
+        )
+        let plan = await ToolGenerationPlanningClient.live().planEdit(
+            userPrompt: "Add voice note export to Downloads",
+            toolName: "Notes",
+            currentSettings: ToolGenerationSettings(
+                resourcePermissions: GeneratedAppResourcePermissions([.camera])
+            ),
+            invoker: Self.makeInvoker(
+                languageModel: StructuredMetadataLanguageModel(response: response),
+                generationOptions: GenerationOptions(maximumResponseTokens: 4096)
+            )
+        )
+
+        #expect(plan.additionalSandboxPermissions.enabled == [.downloadsFolder])
+        #expect(plan.additionalResourcePermissions.enabled == [.microphone])
+        let prompt = try #require(await response.prompts.first)
+        #expect(prompt.contains("Existing app: Notes"))
+        #expect(prompt.contains("Existing resource permissions:\ncamera"))
+    }
+
+    @MainActor
+    @Test
     func liveMetadataClientUsesStructuredGenerationForNameAndIcon() async throws {
-        let metadata = GeneratedToolMetadata(
+        let metadata = GeneratedToolCreationPlan(
             displayName: "Recipe Board",
             iconPrompt: "Recipe cards"
         )
-        let response = StructuredMetadataResponse(metadata: metadata)
+        let response = StructuredMetadataResponse(creationPlan: metadata)
 
-        let suggestion = await ToolMetadataClient.live().suggestMetadata(
+        let suggestion = await ToolGenerationPlanningClient.live().planCreation(
             userPrompt: "recipes",
             invoker: Self.makeInvoker(
                 languageModel: StructuredMetadataLanguageModel(response: response),
@@ -45,6 +121,8 @@ extension AgentPipelineTests {
         #expect(prompt.contains("Allowed menuBarSystemImage values:"))
         #expect(prompt.contains("Allowed category values:"))
         #expect(prompt.contains(StoreAppCategory.graphicsDesign.rawValue))
+        #expect(prompt.contains("Allowed sandboxPermissions values:"))
+        #expect(prompt.contains("Allowed resourcePermissions values:"))
         #expect(!(prompt.contains("Planning budget:")))
         #expect(!(prompt.contains("Refined prompt:")))
         #expect(!(prompt.contains("backend")))
@@ -55,13 +133,13 @@ extension AgentPipelineTests {
     @Test
     func liveMetadataClientSelectsConceptOnlyPromptModeForHostedImages() async throws {
         let response = StructuredMetadataResponse(
-            metadata: GeneratedToolMetadata(
+            creationPlan: GeneratedToolCreationPlan(
                 displayName: "Mortgage Calc",
                 iconPrompt: "A small house sheltering a calculator, with one coin orbiting the roofline."
             )
         )
 
-        _ = await ToolMetadataClient.live().suggestMetadata(
+        _ = await ToolGenerationPlanningClient.live().planCreation(
             userPrompt: "Make a mortgage calculator",
             imageGenerationProvider: .openAI,
             invoker: Self.makeInvoker(
@@ -78,14 +156,14 @@ extension AgentPipelineTests {
     @Test
     func metadataSuggestionValidatesMenuBarSymbolAgainstAllowlist() async throws {
         let response = StructuredMetadataResponse(
-            metadata: GeneratedToolMetadata(
+            creationPlan: GeneratedToolCreationPlan(
                 displayName: "Timer",
                 iconPrompt: "Small timer",
                 menuBarSystemImage: "not.a.real.allowed.symbol"
             )
         )
 
-        let suggestion = await ToolMetadataClient.live().suggestMetadata(
+        let suggestion = await ToolGenerationPlanningClient.live().planCreation(
             userPrompt: "Build a timer",
             invoker: Self.makeInvoker(
                 languageModel: StructuredMetadataLanguageModel(response: response),
@@ -100,7 +178,7 @@ extension AgentPipelineTests {
     @Test
     func metadataSuggestionUsesValidatedStoreCategory() async throws {
         let response = StructuredMetadataResponse(
-            metadata: GeneratedToolMetadata(
+            creationPlan: GeneratedToolCreationPlan(
                 displayName: "Budget Board",
                 iconPrompt: "Ledger with coins",
                 menuBarSystemImage: ToolMenuBarSymbol.fallback,
@@ -108,7 +186,7 @@ extension AgentPipelineTests {
             )
         )
 
-        let suggestion = await ToolMetadataClient.live().suggestMetadata(
+        let suggestion = await ToolGenerationPlanningClient.live().planCreation(
             userPrompt: "Build a budget planner",
             invoker: Self.makeInvoker(
                 languageModel: StructuredMetadataLanguageModel(response: response),
@@ -121,17 +199,18 @@ extension AgentPipelineTests {
 
     @MainActor
     @Test
-    func metadataSuggestionFallsBackForInvalidStoreCategory() async throws {
+    func metadataSuggestionFallsBackForInvalidCategoryAndAppKind() async throws {
         let response = StructuredMetadataResponse(
-            metadata: GeneratedToolMetadata(
+            creationPlan: GeneratedToolCreationPlan(
                 displayName: "Budget Board",
                 iconPrompt: "Ledger with coins",
                 menuBarSystemImage: ToolMenuBarSymbol.fallback,
-                category: "not-a-category"
+                category: "not-a-category",
+                appKind: "not-an-app-kind"
             )
         )
 
-        let suggestion = await ToolMetadataClient.live().suggestMetadata(
+        let suggestion = await ToolGenerationPlanningClient.live().planCreation(
             userPrompt: "Build a budget planner",
             invoker: Self.makeInvoker(
                 languageModel: StructuredMetadataLanguageModel(response: response),
@@ -140,6 +219,7 @@ extension AgentPipelineTests {
         )
 
         #expect(suggestion.category == .utilities)
+        #expect(suggestion.suggestedAppKind == .window)
     }
 
     @MainActor
@@ -147,7 +227,7 @@ extension AgentPipelineTests {
     func liveMetadataClientFallsBackWhenStructuredGenerationFails() async throws {
         let response = StructuredMetadataResponse(error: FakeAgentError.expected)
 
-        let suggestion = await ToolMetadataClient.live(fallbackLanguageModel: nil).suggestMetadata(
+        let suggestion = await ToolGenerationPlanningClient.live(fallbackLanguageModel: nil).planCreation(
             userPrompt: "Build a pantry tracker",
             invoker: Self.makeInvoker(
                 languageModel: StructuredMetadataLanguageModel(response: response),
@@ -162,18 +242,39 @@ extension AgentPipelineTests {
 
     @MainActor
     @Test
+    func liveEditPlanningPreservesPermissionsWhenStructuredGenerationFails() async {
+        let response = StructuredMetadataResponse(error: FakeAgentError.expected)
+
+        let plan = await ToolGenerationPlanningClient.live(fallbackLanguageModel: nil).planEdit(
+            userPrompt: "Add a label",
+            toolName: "Pantry",
+            currentSettings: ToolGenerationSettings(
+                resourcePermissions: GeneratedAppResourcePermissions([.camera])
+            ),
+            invoker: Self.makeInvoker(
+                languageModel: StructuredMetadataLanguageModel(response: response),
+                generationOptions: GenerationOptions(maximumResponseTokens: 4096)
+            )
+        )
+
+        #expect(plan == .empty)
+        #expect(await response.prompts.count == 1)
+    }
+
+    @MainActor
+    @Test
     func liveMetadataClientUsesSystemModelAfterSelectedModelFails() async throws {
         let primaryResponse = StructuredMetadataResponse(error: FakeAgentError.expected)
         let fallbackResponse = StructuredMetadataResponse(
-            metadata: GeneratedToolMetadata(
+            creationPlan: GeneratedToolCreationPlan(
                 displayName: "Pantry Pal",
                 iconPrompt: "Pantry shelves"
             )
         )
 
-        let suggestion = await ToolMetadataClient.live(
+        let suggestion = await ToolGenerationPlanningClient.live(
             fallbackLanguageModel: StructuredMetadataLanguageModel(response: fallbackResponse)
-        ).suggestMetadata(
+        ).planCreation(
             userPrompt: "Build a pantry tracker",
             invoker: Self.makeInvoker(
                 languageModel: StructuredMetadataLanguageModel(response: primaryResponse),
@@ -329,8 +430,8 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .deterministicOnly),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(
                     displayName: "Timer Desk",
                     iconPrompt: ""
                 )
@@ -371,8 +472,8 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithSpark(repairStrategy: .deterministicOnly),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(
                     displayName: "Habit Desk",
                     iconPrompt: ""
                 )
@@ -415,9 +516,9 @@ extension AgentPipelineTests {
             pipelineConfiguration: .ironsmithFlame(repairStrategy: .modelSearchReplace(maxPatchBlocksPerTurn: ToolGenerationRepairPolicy.largeModelPatchBlocksPerTurn)),
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
-            metadataClient: ToolMetadataClient { _ in
+            planningClient: ToolGenerationPlanningClient { _ in
                 await metadataCapture.record()
-                return ToolMetadataSuggestion(
+                return ToolCreationPlan(
                     displayName: "Should Not Use",
                     iconPrompt: ""
                 )

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineResumableGenerationTests.swift
@@ -23,9 +23,9 @@ extension AgentPipelineTests {
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
             iconClient: .noOp,
-            metadataClient: ToolMetadataClient { _ in
+            planningClient: ToolGenerationPlanningClient { _ in
                 await metadataGate.waitForRelease()
-                return ToolMetadataSuggestion(displayName: "Named Later", iconPrompt: "")
+                return ToolCreationPlan(displayName: "Named Later", iconPrompt: "")
             },
             promptRefinementClient: .disabled()
         ))
@@ -85,8 +85,8 @@ extension AgentPipelineTests {
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
             iconClient: .noOp,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(displayName: "Paused Tool", iconPrompt: "")
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Paused Tool", iconPrompt: "")
             },
             promptRefinementClient: .disabled()
         ))
@@ -177,7 +177,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -258,7 +258,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let result = try await runtime.generateTool(
@@ -337,7 +337,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
-            metadataClient: .fallback(),
+            planningClient: .fallback(),
             versionBackupClient: .live
         )
 
@@ -401,7 +401,7 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: Self.successfulProcessClient(),
             appBundleClient: .noOp(),
-            metadataClient: .fallback()
+            planningClient: .fallback()
         )
 
         let task = Task {

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineSingleFileRuntimeTests.swift
@@ -51,8 +51,8 @@ extension AgentPipelineTests {
             toolsDirectoryURL: toolsDirectory,
             processClient: processClient,
             appBundleClient: appBundleClient,
-            metadataClient: ToolMetadataClient { _ in
-                ToolMetadataSuggestion(
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(
                     displayName: "Tiny Tool",
                     iconPrompt: "",
                     menuBarSystemImage: "timer"

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
@@ -19,7 +19,7 @@ extension AgentPipelineTests {
         processClient: SwiftPackageProcessClient = .live,
         appBundleClient: ToolAppBundleClient = .noOp(),
         iconClient: ToolIconClient = .noOp,
-        metadataClient: ToolMetadataClient = .fallback(),
+        planningClient: ToolGenerationPlanningClient = .fallback(),
         promptRefinementClient: ToolPromptRefinementClient = .disabled(),
         promptRefinementEnabled: Bool = true,
         versionBackupClient: ToolVersionBackupClient = .live,
@@ -43,7 +43,7 @@ extension AgentPipelineTests {
             processClient: processClient,
             appBundleClient: appBundleClient,
             iconClient: iconClient,
-            metadataClient: metadataClient,
+            planningClient: planningClient,
             promptRefinementClient: promptRefinementClient,
             versionBackupClient: versionBackupClient,
             codexAgentClient: codexAgentClient
@@ -456,13 +456,19 @@ actor InvocationCapture {
 }
 
 actor StructuredMetadataResponse {
-    private let metadata: GeneratedToolMetadata?
+    private let creationPlan: GeneratedToolCreationPlan?
+    private let editPlan: GeneratedToolEditPlan?
     private let error: (any Error)?
     private(set) var prompts: [String] = []
     private(set) var options: [GenerationOptions] = []
 
-    init(metadata: GeneratedToolMetadata? = nil, error: (any Error)? = nil) {
-        self.metadata = metadata
+    init(
+        creationPlan: GeneratedToolCreationPlan? = nil,
+        editPlan: GeneratedToolEditPlan? = nil,
+        error: (any Error)? = nil
+    ) {
+        self.creationPlan = creationPlan
+        self.editPlan = editPlan
         self.error = error
     }
 
@@ -478,15 +484,21 @@ actor StructuredMetadataResponse {
             throw error
         }
 
-        guard type == GeneratedToolMetadata.self, let metadata else {
-            throw FakeAgentError.unsupportedStructuredGeneration
+        if type == GeneratedToolCreationPlan.self, let creationPlan {
+            return LanguageModelSession.Response(
+                content: creationPlan as! Content,
+                rawContent: creationPlan.generatedContent,
+                transcriptEntries: []
+            )
         }
-
-        return LanguageModelSession.Response(
-            content: metadata as! Content,
-            rawContent: metadata.generatedContent,
-            transcriptEntries: []
-        )
+        if type == GeneratedToolEditPlan.self, let editPlan {
+            return LanguageModelSession.Response(
+                content: editPlan as! Content,
+                rawContent: editPlan.generatedContent,
+                transcriptEntries: []
+            )
+        }
+        throw FakeAgentError.unsupportedStructuredGeneration
     }
 }
 

--- a/IronsmithTests/Core/Inference/InferenceGenerationPreferenceTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceGenerationPreferenceTests.swift
@@ -382,6 +382,23 @@ extension InferenceTests {
 
     @MainActor
     @Test
+    func automaticGeneratedAppPermissionsDefaultOnAndPersist() {
+        let suiteName = "IronsmithTests.AutomaticGeneratedAppPermissions.\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+
+        let preferences = GenerationPreferencesStore(userDefaults: userDefaults)
+        #expect(preferences.automaticallySelectGeneratedAppPermissions)
+
+        preferences.automaticallySelectGeneratedAppPermissions = false
+        #expect(
+            !GenerationPreferencesStore(userDefaults: userDefaults)
+                .automaticallySelectGeneratedAppPermissions
+        )
+    }
+
+    @MainActor
+    @Test
     func generatedAppResourcePermissionPreferencesDefaultOffAndPersist() {
         let suiteName = "IronsmithTests.GeneratedAppResourcePermissions.\(UUID().uuidString)"
         let userDefaults = UserDefaults(suiteName: suiteName)!

--- a/IronsmithTests/Features/Store/StoreImportTests.swift
+++ b/IronsmithTests/Features/Store/StoreImportTests.swift
@@ -1306,6 +1306,12 @@ struct StoreImportTests {
             )
         )
         let items = StorePermissionPresentation.items(for: permissionVersion)
+        #expect(
+            items
+                == StorePermissionPresentation.items(
+                    for: permissionVersion.generationSettings.toolSettings
+                )
+        )
 
         #expect(items.map(\.title) == [
             "Incoming connections (server)",

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
@@ -35,21 +35,32 @@ extension ToolLibraryTests {
             store.remixIdentitySubmissionAction(
                 for: tool,
                 generatesIdentity: true,
-                hasPresentedNotice: false
+                hasPresentedNotice: false,
+                isConfirmedDownloadedFromAnotherUser: true
             ) == .presentNotice
         )
         #expect(
             store.remixIdentitySubmissionAction(
                 for: tool,
                 generatesIdentity: true,
-                hasPresentedNotice: true
+                hasPresentedNotice: true,
+                isConfirmedDownloadedFromAnotherUser: true
             ) == .generateIdentity
         )
         #expect(
             store.remixIdentitySubmissionAction(
                 for: tool,
                 generatesIdentity: false,
-                hasPresentedNotice: false
+                hasPresentedNotice: false,
+                isConfirmedDownloadedFromAnotherUser: true
+            ) == .submit
+        )
+        #expect(
+            store.remixIdentitySubmissionAction(
+                for: tool,
+                generatesIdentity: true,
+                hasPresentedNotice: false,
+                isConfirmedDownloadedFromAnotherUser: false
             ) == .submit
         )
         try (source + "// changed\n").write(
@@ -62,7 +73,8 @@ extension ToolLibraryTests {
             store.remixIdentitySubmissionAction(
                 for: tool,
                 generatesIdentity: true,
-                hasPresentedNotice: false
+                hasPresentedNotice: false,
+                isConfirmedDownloadedFromAnotherUser: true
             ) == .submit
         )
 
@@ -422,6 +434,13 @@ extension ToolLibraryTests {
 
     @Test
     func toolRowStatusUsesCodexWorkingTextOnlyForCodexOwnedPhases() {
+        #expect(
+            ToolRowGenerationStatusResolver.statusText(
+                phase: .planning,
+                repairErrorCount: nil,
+                activeCodingAgent: nil
+            ) == "Generating metadata"
+        )
         #expect(
             ToolRowGenerationStatusResolver.statusText(
                 phase: .generatingSource,

--- a/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibrarySelectionAndActionsTests.swift
@@ -14,11 +14,13 @@ extension ToolLibraryTests {
         let otherTool = Tool(name: "Notes", packageRootPath: "/tmp/notes")
 
         #expect(toolLibraryState.promptPlaceholder == "Describe a new app to build…")
+        #expect(toolLibraryState.appKindPreference == .automatic)
         #expect(!(toolLibraryState.isSelected(tool)))
 
         toolLibraryState.selectForEditing(tool)
 
         #expect(toolLibraryState.isSelected(tool))
+        #expect(toolLibraryState.appKindPreference == .window)
         #expect(toolLibraryState.promptPlaceholder == "Describe changes for Calculator…")
 
         toolLibraryState.handleDeletedTool(otherTool)
@@ -26,6 +28,7 @@ extension ToolLibraryTests {
         #expect(toolLibraryState.isSelected(tool))
         toolLibraryState.syncSelection(with: [otherTool])
         #expect(!(toolLibraryState.isSelected(tool)))
+        #expect(toolLibraryState.appKindPreference == .automatic)
         #expect(toolLibraryState.promptPlaceholder == "Describe a new app to build…")
     }
 
@@ -113,7 +116,7 @@ extension ToolLibraryTests {
         )
 
         toolLibraryState.initializeNextGenerationSettingsIfNeeded(defaults)
-        toolLibraryState.appKind = .menuBar
+        toolLibraryState.setAppKindPreference(.menuBar)
         toolLibraryState.sandboxEnabled = false
         toolLibraryState.sandboxPermissions = GeneratedAppSandboxPermissions([.outgoingConnections])
         toolLibraryState.resourcePermissions = GeneratedAppResourcePermissions([.camera])
@@ -123,6 +126,7 @@ extension ToolLibraryTests {
 
         #expect(toolLibraryState.isSelected(tool))
         #expect(toolLibraryState.appKind == .window)
+        #expect(toolLibraryState.appKindPreference == .window)
         #expect(toolLibraryState.sandboxEnabled)
         #expect(toolLibraryState.sandboxPermissions.enabled.isEmpty)
         #expect(toolLibraryState.resourcePermissions.enabled.isEmpty)
@@ -131,6 +135,7 @@ extension ToolLibraryTests {
 
         #expect(!(toolLibraryState.isSelected(tool)))
         #expect(toolLibraryState.appKind == .menuBar)
+        #expect(toolLibraryState.appKindPreference == .menuBar)
         #expect(!(toolLibraryState.sandboxEnabled))
         #expect(toolLibraryState.sandboxPermissions.enabled == [.outgoingConnections])
         #expect(toolLibraryState.resourcePermissions.enabled == [.camera])
@@ -852,6 +857,12 @@ extension ToolLibraryTests {
         try #"Text("failed edit progress")"#.write(to: contentViewURL, atomically: true, encoding: .utf8)
         try #"Text("last ready")"#.write(to: layout.pendingContentViewVersionURL, atomically: true, encoding: .utf8)
         try "partial patch".write(to: layout.pendingContentViewDraftURL, atomically: true, encoding: .utf8)
+        try ToolVersionBackupClient.live.stagePendingGenerationSettings(
+            packageRoot,
+            ToolGenerationSettings(
+                resourcePermissions: GeneratedAppResourcePermissions([.microphone])
+            )
+        )
         try FileManager.default.createDirectory(
             at: layout.currentRunAttachmentsDirectoryURL,
             withIntermediateDirectories: true
@@ -897,6 +908,7 @@ extension ToolLibraryTests {
         #expect(FileManager.default.fileExists(atPath: packageRoot.path))
         #expect(!(FileManager.default.fileExists(atPath: layout.pendingContentViewDraftURL.path)))
         #expect(!(FileManager.default.fileExists(atPath: layout.pendingContentViewVersionURL.path)))
+        #expect(!(FileManager.default.fileExists(atPath: layout.pendingGenerationSettingsURL.path)))
         #expect(!(FileManager.default.fileExists(atPath: layout.currentRunAttachmentsDirectoryURL.path)))
         #expect(cleanupCapture.removedLayout == layout)
         #expect(try String(contentsOf: contentViewURL, encoding: .utf8) == #"Text("last ready")"#)

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryStorePublisherTests.swift
@@ -8,6 +8,103 @@ import Testing
 
 extension ToolLibraryTests {
     @MainActor
+    @Test
+    func storePublisherConfirmsRemixesOnlyForAppsNotOwnedByCurrentUser() async {
+        let ownedApp = Self.publisherAppDetail()
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, _, _, _, _, _, _ in
+            StoreAppPage(apps: [StoreAppSummary(detail: ownedApp)], hasMore: false)
+        }
+        let publisher = ToolLibraryStorePublisher(
+            storeClient: client,
+            iconClient: .noOp
+        )
+        let ownedTool = Tool(
+            name: "Owned",
+            packageRootPath: "/tmp/owned",
+            storeId: ownedApp.storeId,
+            storeAppId: ownedApp.id,
+            storeVersionId: ownedApp.currentVersion.id
+        )
+        let downloadedTool = Tool(
+            name: "Downloaded",
+            packageRootPath: "/tmp/downloaded",
+            storeId: ownedApp.storeId,
+            storeAppId: "00000000-0000-4000-8000-000000000999",
+            storeVersionId: "00000000-0000-4000-8000-000000000998"
+        )
+
+        #expect(!publisher.isConfirmedDownloadedFromAnotherUser(ownedTool))
+        #expect(!publisher.isConfirmedDownloadedFromAnotherUser(downloadedTool))
+
+        await publisher.refreshPublishedStoreApps(
+            isSignedIn: true,
+            tools: [ownedTool, downloadedTool]
+        )
+
+        #expect(!publisher.isConfirmedDownloadedFromAnotherUser(ownedTool))
+        #expect(publisher.isConfirmedDownloadedFromAnotherUser(downloadedTool))
+
+        await publisher.refreshPublishedStoreApps(
+            isSignedIn: false,
+            tools: [ownedTool, downloadedTool]
+        )
+        #expect(!publisher.isConfirmedDownloadedFromAnotherUser(downloadedTool))
+    }
+
+    @MainActor
+    @Test
+    func storePublisherIgnoresStaleOwnershipRefreshesAcrossAccountChanges() async {
+        let ownedApp = Self.publisherAppDetail()
+        let refreshPages = PublisherOwnershipRefreshPages()
+        var client = IronsmithStoreClient.unconfigured
+        client.listApps = { _, _, _, _, _, _, _ in
+            await refreshPages.nextPage()
+        }
+        let publisher = ToolLibraryStorePublisher(
+            storeClient: client,
+            iconClient: .noOp
+        )
+        let tool = Tool(
+            name: "Downloaded",
+            packageRootPath: "/tmp/downloaded",
+            storeId: ownedApp.storeId,
+            storeAppId: ownedApp.id,
+            storeVersionId: ownedApp.currentVersion.id
+        )
+
+        await publisher.refreshPublishedStoreApps(isSignedIn: true, tools: [tool])
+        #expect(publisher.isConfirmedDownloadedFromAnotherUser(tool))
+
+        let staleRefresh = Task {
+            await publisher.refreshPublishedStoreApps(isSignedIn: true, tools: [tool])
+        }
+        await refreshPages.waitForRequestCount(2)
+        #expect(!publisher.isConfirmedDownloadedFromAnotherUser(tool))
+
+        let currentRefresh = Task {
+            await publisher.refreshPublishedStoreApps(isSignedIn: true, tools: [tool])
+        }
+        await refreshPages.waitForRequestCount(3)
+        await refreshPages.resolve(
+            request: 2,
+            with: StoreAppPage(
+                apps: [StoreAppSummary(detail: ownedApp)],
+                hasMore: false
+            )
+        )
+        await currentRefresh.value
+        #expect(!publisher.isConfirmedDownloadedFromAnotherUser(tool))
+
+        await refreshPages.resolve(
+            request: 1,
+            with: StoreAppPage(apps: [], hasMore: false)
+        )
+        await staleRefresh.value
+        #expect(!publisher.isConfirmedDownloadedFromAnotherUser(tool))
+    }
+
+    @MainActor
     @Test(arguments: [false, true])
     func storePublisherShowsReviewReasonsForInitialAndVersionPublishing(
         isVersion: Bool
@@ -1058,6 +1155,38 @@ private actor PublisherBuildCapture {
     func record(category: StoreAppCategory, versionNumber: Int) {
         categories.append(category)
         versionNumbers.append(versionNumber)
+    }
+}
+
+private actor PublisherOwnershipRefreshPages {
+    private var requestCount = 0
+    private var pageContinuations: [Int: CheckedContinuation<StoreAppPage, Never>] = [:]
+    private var requestWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    func nextPage() async -> StoreAppPage {
+        let request = requestCount
+        requestCount += 1
+        let readyWaiters = requestWaiters.filter { requestCount >= $0.count }
+        requestWaiters.removeAll { requestCount >= $0.count }
+        readyWaiters.forEach { $0.continuation.resume() }
+
+        guard request > 0 else {
+            return StoreAppPage(apps: [], hasMore: false)
+        }
+        return await withCheckedContinuation { continuation in
+            pageContinuations[request] = continuation
+        }
+    }
+
+    func waitForRequestCount(_ expectedCount: Int) async {
+        guard requestCount < expectedCount else { return }
+        await withCheckedContinuation { continuation in
+            requestWaiters.append((expectedCount, continuation))
+        }
+    }
+
+    func resolve(request: Int, with page: StoreAppPage) {
+        pageContinuations.removeValue(forKey: request)?.resume(returning: page)
     }
 }
 


### PR DESCRIPTION
## Summary
- default automatic permission planning on and hide manual permission controls while enabled
- always request creation permissions from metadata planning, apply them only in automatic mode, and use edit planning for permission additions
- show effective permissions in a compact publish-sheet grid and improve metadata-stage labeling
- treat edits as remixes only when Store ownership confirms the current user does not own the downloaded app

## Validation
- `script/test.sh` (571 tests across 15 suites)
- focused Store permission presentation test
- focused stale ownership refresh regression test
- `git diff --check`