### PR TITLE
Add configurable custom coding agent runners

### DIFF
--- a/Ironsmith/App/Controllers/IronsmithAgentOutputWindowController.swift
+++ b/Ironsmith/App/Controllers/IronsmithAgentOutputWindowController.swift
@@ -4,20 +4,36 @@ import SwiftUI
 
 @MainActor
 final class IronsmithAgentOutputWindowController: NSWindowController {
+    private let rootViewBuilder: @MainActor (UUID) -> AnyView
+    private var agentOutputWindow: NSWindow?
     private var hasCenteredWindow = false
-    private let modelContainer: ModelContainer
 
-    init(modelContainer: ModelContainer) {
-        self.modelContainer = modelContainer
+    var hasCreatedWindow: Bool { agentOutputWindow != nil }
 
+    convenience init(modelContainer: ModelContainer) {
+        self.init { toolID in
+            AnyView(
+                AgentOutputWindowView(toolID: toolID)
+                    .modelContainer(modelContainer)
+            )
+        }
+    }
+
+    init(rootViewBuilder: @escaping @MainActor (UUID) -> AnyView) {
+        self.rootViewBuilder = rootViewBuilder
+        super.init(window: nil)
+    }
+
+    private func loadAgentOutputWindowIfNeeded() {
+        guard agentOutputWindow == nil else { return }
         let window = NSWindow()
         window.title = "Agent Output"
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.isReleasedWhenClosed = false
         window.minSize = NSSize(width: 560, height: 420)
         window.setContentSize(NSSize(width: 680, height: 560))
-
-        super.init(window: window)
+        self.window = window
+        agentOutputWindow = window
     }
 
     @available(*, unavailable)
@@ -26,12 +42,10 @@ final class IronsmithAgentOutputWindowController: NSWindowController {
     }
 
     func show(toolID: UUID) {
-        guard let window else { return }
+        loadAgentOutputWindowIfNeeded()
+        guard let window = agentOutputWindow else { return }
         window.contentViewController = NSHostingController(
-            rootView: AnyView(
-                AgentOutputWindowView(toolID: toolID)
-                    .modelContainer(modelContainer)
-            )
+            rootView: rootViewBuilder(toolID)
         )
 
         if !hasCenteredWindow {
@@ -44,6 +58,5 @@ final class IronsmithAgentOutputWindowController: NSWindowController {
         window.orderFrontRegardless()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        NSRunningApplication.current.activate(options: [.activateAllWindows])
     }
 }

--- a/Ironsmith/App/Controllers/IronsmithMenuBarController.swift
+++ b/Ironsmith/App/Controllers/IronsmithMenuBarController.swift
@@ -8,12 +8,24 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
     private let hostingController: NSHostingController<AnyView>
     private let presentationStore: MenuBarPopoverPresentationStore?
 
-    init(
+    convenience init(
         rootView: AnyView,
         presentationStore: MenuBarPopoverPresentationStore? = nil
     ) {
+        self.init(
+            rootView: rootView,
+            presentationStore: presentationStore,
+            popover: NSPopover()
+        )
+    }
+
+    init(
+        rootView: AnyView,
+        presentationStore: MenuBarPopoverPresentationStore?,
+        popover: NSPopover
+    ) {
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        popover = NSPopover()
+        self.popover = popover
         hostingController = NSHostingController(rootView: rootView)
         self.presentationStore = presentationStore
 
@@ -50,9 +62,7 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
 
     @objc private func togglePopover(_ sender: Any?) {
         if popover.isShown {
-            presentationStore?.willClose()
-            dismissAttachedSheetIfNeeded()
-            popover.performClose(sender)
+            closePopover(sender)
         } else {
             showPopover()
         }
@@ -60,6 +70,10 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
 
     func show() {
         showPopover()
+    }
+
+    func applicationDidResignActive() {
+        closePopover(nil)
     }
 
     private func showPopover() {
@@ -75,13 +89,19 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
             popoverWindow.level = .normal
             popoverWindow.makeKey()
         }
-        NSRunningApplication.current.activate(options: [.activateAllWindows])
         button.state = .on
         presentationStore?.didShow()
     }
 
     func popoverDidClose(_ notification: Notification) {
         statusItem.button?.state = .off
+    }
+
+    private func closePopover(_ sender: Any?) {
+        guard popover.isShown else { return }
+        presentationStore?.willClose()
+        dismissAttachedSheetIfNeeded()
+        popover.performClose(sender)
     }
 
     private func dismissAttachedSheetIfNeeded() {

--- a/Ironsmith/App/Controllers/IronsmithSettingsWindowController.swift
+++ b/Ironsmith/App/Controllers/IronsmithSettingsWindowController.swift
@@ -4,28 +4,44 @@ import SwiftUI
 
 @MainActor
 final class IronsmithSettingsWindowController: NSWindowController {
+    private let rootViewBuilder: @MainActor () -> AnyView
+    private var settingsWindow: NSWindow?
     private var hasCenteredWindow = false
 
-    init(
+    var hasCreatedWindow: Bool { settingsWindow != nil }
+
+    convenience init(
         modelContainer: ModelContainer,
         inferenceStore: InferenceStore,
         routeStore: IronsmithRouteStore
     ) {
-        let hostingController = NSHostingController(
-            rootView: AnyView(
+        self.init {
+            AnyView(
                 SettingsWindowView()
                     .modelContainer(modelContainer)
                     .environment(inferenceStore)
                     .environment(routeStore)
             )
+        }
+    }
+
+    init(rootViewBuilder: @escaping @MainActor () -> AnyView) {
+        self.rootViewBuilder = rootViewBuilder
+        super.init(window: nil)
+    }
+
+    private func loadSettingsWindowIfNeeded() {
+        guard settingsWindow == nil else { return }
+        let hostingController = NSHostingController(
+            rootView: rootViewBuilder()
         )
         let window = NSWindow(contentViewController: hostingController)
         window.title = "Settings"
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.isReleasedWhenClosed = false
         window.minSize = NSSize(width: 680, height: 720)
-
-        super.init(window: window)
+        self.window = window
+        settingsWindow = window
     }
 
     @available(*, unavailable)
@@ -34,7 +50,8 @@ final class IronsmithSettingsWindowController: NSWindowController {
     }
 
     func show() {
-        guard let window else { return }
+        loadSettingsWindowIfNeeded()
+        guard let window = settingsWindow else { return }
 
         if !hasCenteredWindow {
             window.center()
@@ -46,6 +63,5 @@ final class IronsmithSettingsWindowController: NSWindowController {
         window.orderFrontRegardless()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        NSRunningApplication.current.activate(options: [.activateAllWindows])
     }
 }

--- a/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
+++ b/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
@@ -49,6 +49,7 @@ final class IronsmithStoreWindowController: NSWindowController {
     }
 
     func show() {
+        guard IronsmithFeatureFlags.isStoreEnabled() else { return }
         guard let window else { return }
         if !hasCenteredWindow {
             window.center()

--- a/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
+++ b/Ironsmith/App/Controllers/IronsmithStoreWindowController.swift
@@ -7,21 +7,42 @@ final class IronsmithStoreWindowController: NSWindowController {
     private static let initialContentSize = NSSize(width: 1000, height: 660)
     private static let minimumContentSize = NSSize(width: 600, height: 400)
 
+    private let rootViewBuilder: @MainActor () -> AnyView
+    private let isStoreFeatureEnabled: @MainActor () -> Bool
+    private var storeWindow: NSWindow?
     private var hasCenteredWindow = false
 
-    init(
+    var hasCreatedWindow: Bool { storeWindow != nil }
+
+    convenience init(
         modelContainer: ModelContainer,
         inferenceStore: InferenceStore,
         routeStore: IronsmithRouteStore
     ) {
-        let hostingController = NSHostingController(
-            rootView: AnyView(
+        self.init {
+            AnyView(
                 StoreWindowView()
                     .modelContainer(modelContainer)
                     .environment(inferenceStore)
                     .environment(routeStore)
             )
-        )
+        }
+    }
+
+    init(
+        rootViewBuilder: @escaping @MainActor () -> AnyView,
+        isStoreFeatureEnabled: @escaping @MainActor () -> Bool = {
+            IronsmithFeatureFlags.isStoreEnabled()
+        }
+    ) {
+        self.rootViewBuilder = rootViewBuilder
+        self.isStoreFeatureEnabled = isStoreFeatureEnabled
+        super.init(window: nil)
+    }
+
+    private func loadStoreWindowIfNeeded() {
+        guard storeWindow == nil else { return }
+        let hostingController = NSHostingController(rootView: rootViewBuilder())
         hostingController.sceneBridgingOptions = [.toolbars]
         let window = NSWindow()
         window.title = "Ironsmith Store"
@@ -39,8 +60,8 @@ final class IronsmithStoreWindowController: NSWindowController {
         window.contentViewController = hostingController
         window.minSize = Self.minimumContentSize
         window.setContentSize(Self.initialContentSize)
-
-        super.init(window: window)
+        self.window = window
+        storeWindow = window
     }
 
     @available(*, unavailable)
@@ -49,8 +70,9 @@ final class IronsmithStoreWindowController: NSWindowController {
     }
 
     func show() {
-        guard IronsmithFeatureFlags.isStoreEnabled() else { return }
-        guard let window else { return }
+        guard isStoreFeatureEnabled() else { return }
+        loadStoreWindowIfNeeded()
+        guard let window = storeWindow else { return }
         if !hasCenteredWindow {
             window.center()
             hasCenteredWindow = true
@@ -61,6 +83,5 @@ final class IronsmithStoreWindowController: NSWindowController {
         window.orderFrontRegardless()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        NSRunningApplication.current.activate(options: [.activateAllWindows])
     }
 }

--- a/Ironsmith/App/IronsmithApp.swift
+++ b/Ironsmith/App/IronsmithApp.swift
@@ -23,6 +23,10 @@ final class IronsmithAppDelegate: NSObject, NSApplicationDelegate {
         applicationController?.applicationDidBecomeActive()
     }
 
+    func applicationDidResignActive(_ notification: Notification) {
+        applicationController?.applicationDidResignActive()
+    }
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
     }
@@ -176,6 +180,10 @@ final class IronsmithApplicationController {
         Task {
             await inferenceStore.refreshIronsmithAccountSummaryIfNeededAfterCheckout()
         }
+    }
+
+    func applicationDidResignActive() {
+        menuBarController?.applicationDidResignActive()
     }
 
     func showToolLibraryPopover() {

--- a/Ironsmith/App/Routing/IronsmithAppRouter.swift
+++ b/Ironsmith/App/Routing/IronsmithAppRouter.swift
@@ -120,7 +120,9 @@ final class IronsmithRouteStore {
         openSettingsWindow: @escaping @MainActor @Sendable () -> Void,
         openStoreWindow: @escaping @MainActor @Sendable () -> Void = {},
         openToolLibraryPopover: @escaping @MainActor @Sendable () -> Void = {},
-        isStoreFeatureEnabled: @escaping @MainActor @Sendable () -> Bool = { true }
+        isStoreFeatureEnabled: @escaping @MainActor @Sendable () -> Bool = {
+            IronsmithFeatureFlags.isStoreEnabled()
+        }
     ) {
         self.openAgentOutputWindow = openAgentOutputWindow
         self.openSettingsWindow = openSettingsWindow
@@ -141,6 +143,9 @@ final class IronsmithRouteStore {
             pendingStoreRoute = storeRoute
             openStoreWindow()
         case .toolLibrary(let toolLibraryRoute):
+            if case .publishTool = toolLibraryRoute {
+                guard isStoreFeatureEnabled() else { return }
+            }
             pendingToolLibraryRoute = toolLibraryRoute
             openToolLibraryPopover()
         }

--- a/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
+++ b/Ironsmith/Core/AgentPipeline/Artifacts/AgentArtifacts.swift
@@ -12,6 +12,7 @@ nonisolated struct AgentLanguageModelContext {
     let codingAgentModelFamily: ToolModelFamily
     let codingAgentContextWindowTokens: Int?
     let codexAgentAuthentication: CodexAgentAuthentication?
+    let customCodingAgent: CustomCodingAgent?
     let codingAgentSupportsImageInput: Bool
     let reasoningEffort: ToolReasoningEffort
 
@@ -37,6 +38,7 @@ nonisolated struct AgentLanguageModelContext {
         codingAgentModelFamily: ToolModelFamily = .other,
         codingAgentContextWindowTokens: Int? = nil,
         codexAgentAuthentication: CodexAgentAuthentication? = nil,
+        customCodingAgent: CustomCodingAgent? = nil,
         codingAgentSupportsImageInput: Bool = false,
         reasoningEffort: ToolReasoningEffort = .default,
         afterLanguageModelInvocation: @escaping @MainActor @Sendable () async -> Void = {}
@@ -56,6 +58,7 @@ nonisolated struct AgentLanguageModelContext {
         self.codingAgentModelFamily = codingAgentModelFamily
         self.codingAgentContextWindowTokens = codingAgentContextWindowTokens
         self.codexAgentAuthentication = codexAgentAuthentication
+        self.customCodingAgent = customCodingAgent
         self.codingAgentSupportsImageInput = codingAgentSupportsImageInput
         self.reasoningEffort = reasoningEffort
     }
@@ -72,6 +75,7 @@ nonisolated struct AgentLanguageModelContext {
         codingAgentModelFamily: ToolModelFamily = .other,
         codingAgentContextWindowTokens: Int? = nil,
         codexAgentAuthentication: CodexAgentAuthentication? = nil,
+        customCodingAgent: CustomCodingAgent? = nil,
         codingAgentSupportsImageInput: Bool = false,
         reasoningEffort: ToolReasoningEffort = .default,
         afterLanguageModelInvocation: @escaping @MainActor @Sendable () async -> Void = {}
@@ -102,6 +106,7 @@ nonisolated struct AgentLanguageModelContext {
             codingAgentModelFamily: codingAgentModelFamily,
             codingAgentContextWindowTokens: codingAgentContextWindowTokens,
             codexAgentAuthentication: codexAgentAuthentication,
+            customCodingAgent: customCodingAgent,
             codingAgentSupportsImageInput: codingAgentSupportsImageInput,
             reasoningEffort: reasoningEffort,
             afterLanguageModelInvocation: afterLanguageModelInvocation
@@ -379,6 +384,7 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static let packageMetadataDirectoryName = ".ironsmith"
     nonisolated static let attachmentsDirectoryName = "attachments"
     nonisolated static let currentRunAttachmentsDirectoryName = "current-run"
+    nonisolated static let customAgentTranscriptsDirectoryName = "custom-agent-transcripts"
     nonisolated static let versionsDirectoryName = "versions"
     nonisolated static let pendingContentViewDraftFilename = "pending-ContentView.swift"
     nonisolated static let pendingContentViewDraftPath =
@@ -413,6 +419,10 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
     nonisolated var currentRunAttachmentsDirectoryURL: URL {
         attachmentsDirectoryURL
             .appendingPathComponent(Self.currentRunAttachmentsDirectoryName, isDirectory: true)
+    }
+
+    nonisolated var customAgentTranscriptsDirectoryURL: URL {
+        Self.customAgentTranscriptsDirectoryURL(for: packageRootURL)
     }
 
     nonisolated var pendingContentViewDraftURL: URL {
@@ -538,6 +548,11 @@ nonisolated struct ToolPackageLayout: Equatable, Sendable {
     nonisolated static func versionsDirectoryURL(for packageRootURL: URL) -> URL {
         packageMetadataDirectoryURL(for: packageRootURL)
             .appendingPathComponent(versionsDirectoryName, isDirectory: true)
+    }
+
+    nonisolated static func customAgentTranscriptsDirectoryURL(for packageRootURL: URL) -> URL {
+        packageMetadataDirectoryURL(for: packageRootURL)
+            .appendingPathComponent(customAgentTranscriptsDirectoryName, isDirectory: true)
     }
 
     nonisolated static func pendingContentViewDraftURL(for packageRootURL: URL) -> URL {

--- a/Ironsmith/Core/AgentPipeline/Clients/CodexAgentClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CodexAgentClient.swift
@@ -832,8 +832,6 @@ enum CodexAgentError: LocalizedError, Equatable {
     case unsupportedProvider
     case missingAuthenticationForRuntime
     case commandFailed(status: Int32, stderr: String, transcriptURL: URL)
-    case protectedFileChanged(String)
-    case missingContentView
 
     var errorDescription: String? {
         switch self {
@@ -846,7 +844,7 @@ enum CodexAgentError: LocalizedError, Equatable {
         case .commandFailed(let status, let stderr, let transcriptURL):
             if status == 1 {
                 return
-                    "Codex couldn't continue. You might be out of Codex usage. Check your usage in Codex and try again after it resets. Transcript: \(transcriptURL.path)"
+                    "The coding agent couldn't continue. You might be out of usage, but this can also be caused by another agent error. Check your usage and the transcript, then try again. Transcript: \(transcriptURL.path)"
             }
             let output = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
             if output.isEmpty {
@@ -854,11 +852,6 @@ enum CodexAgentError: LocalizedError, Equatable {
             }
             return
                 "Codex exited with status \(status): \(AgentDiagnosticsLog.compact(redactSecrets(output), limit: 1_500)). Transcript: \(transcriptURL.path)"
-        case .protectedFileChanged(let path):
-            return
-                "Codex changed \(path), but Ironsmith only allows Codex to edit ContentView.swift."
-        case .missingContentView:
-            return "Codex did not create ContentView.swift."
         }
     }
 

--- a/Ironsmith/Core/AgentPipeline/Clients/CodingAgentError.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CodingAgentError.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum CodingAgentError: LocalizedError, Equatable {
+    case protectedFileChanged(String)
+    case missingContentView
+
+    var errorDescription: String? {
+        switch self {
+        case .protectedFileChanged(let path):
+            return
+                "The coding agent changed \(path), but Ironsmith only allows the agent to edit ContentView.swift."
+        case .missingContentView:
+            return "The coding agent did not create ContentView.swift."
+        }
+    }
+}

--- a/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
@@ -393,6 +393,75 @@ nonisolated enum CustomCodingAgentTranscriptReader {
             try? decoder.decode(CustomCodingAgentOutput.self, from: Data(line.utf8))
         }
     }
+
+    static func displayEntries(for packageRootURL: URL) throws -> [CustomCodingAgentOutput] {
+        displayEntries(from: try entries(for: packageRootURL))
+    }
+
+    static func displayEntries(
+        from entries: [CustomCodingAgentOutput]
+    ) -> [CustomCodingAgentOutput] {
+        entries.flatMap { entry in
+            guard entry.stream == .stdout,
+                  let event = try? JSONDecoder().decode(
+                      ClaudeStreamEvent.self,
+                      from: Data(entry.text.utf8)
+                  ),
+                  event.isClaudeStreamEvent
+            else {
+                return [entry]
+            }
+
+            guard event.type == "assistant" else { return [] }
+            return event.message?.content.compactMap { block in
+                guard block.type == "text",
+                      let text = block.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !text.isEmpty
+                else { return nil }
+                return CustomCodingAgentOutput(
+                    timestamp: entry.timestamp,
+                    runner: entry.runner,
+                    stream: entry.stream,
+                    text: text
+                )
+            } ?? []
+        }
+    }
+}
+
+private nonisolated struct ClaudeStreamEvent: Decodable {
+    struct Message: Decodable {
+        struct Content: Decodable {
+            let type: String
+            let text: String?
+        }
+
+        let role: String
+        let content: [Content]
+    }
+
+    let type: String
+    let subtype: String?
+    let sessionID: String?
+    let message: Message?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case subtype
+        case sessionID = "session_id"
+        case message
+    }
+
+    var isClaudeStreamEvent: Bool {
+        switch type {
+        case "assistant":
+            message?.role == "assistant"
+        case "system", "user", "result":
+            sessionID != nil
+        default:
+            false
+        }
+    }
 }
 
 private nonisolated struct CustomCodingAgentTranscriptFile: Sendable {

--- a/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
@@ -1,0 +1,435 @@
+import Foundation
+import Darwin
+
+nonisolated struct CustomCodingAgentRequest: Sendable {
+    let agent: CustomCodingAgent
+    let packageRootURL: URL
+    let prompt: String
+    let onOutput: @Sendable (CustomCodingAgentOutput) async -> Void
+
+    init(
+        agent: CustomCodingAgent,
+        packageRootURL: URL,
+        prompt: String,
+        onOutput: @escaping @Sendable (CustomCodingAgentOutput) async -> Void = { _ in }
+    ) {
+        self.agent = agent
+        self.packageRootURL = packageRootURL
+        self.prompt = prompt
+        self.onOutput = onOutput
+    }
+}
+
+nonisolated struct CustomCodingAgentOutput: Codable, Equatable, Sendable {
+    enum Stream: String, Codable, Sendable {
+        case stdout
+        case stderr
+    }
+
+    let timestamp: Date
+    let runner: String
+    let stream: Stream
+    let text: String
+}
+
+nonisolated struct CustomCodingAgentResult: Equatable, Sendable {
+    let terminationStatus: Int32
+    let transcriptURL: URL
+}
+
+enum CustomCodingAgentError: LocalizedError {
+    case commandFailed(status: Int32, transcriptURL: URL)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed(let status, let transcriptURL):
+            "The custom coding agent exited with status \(status). Transcript: \(transcriptURL.path)"
+        }
+    }
+}
+
+nonisolated struct CustomCodingAgentClient: Sendable {
+    var run: @Sendable (CustomCodingAgentRequest) async throws -> CustomCodingAgentResult
+
+    nonisolated static let live = Self { request in
+        let transcript = try CustomCodingAgentTranscriptFile(
+            packageRootURL: request.packageRootURL,
+            agentName: request.agent.name
+        )
+        let writer = try CustomCodingAgentTranscriptWriter(url: transcript.url)
+        let processReference = CustomCodingAgentProcessReference()
+
+        let result = try await withTaskCancellationHandler {
+            let task = Task.detached(priority: .utility) {
+                let process = Process()
+                let stdoutURL = transcript.url.appendingPathExtension("stdout")
+                let stderrURL = transcript.url.appendingPathExtension("stderr")
+                try Data().write(to: stdoutURL, options: .atomic)
+                try Data().write(to: stderrURL, options: .atomic)
+                let stdout = try FileHandle(forWritingTo: stdoutURL)
+                let stderr = try FileHandle(forWritingTo: stderrURL)
+                let tailCompletion = CustomCodingAgentTailCompletion()
+                defer {
+                    try? stdout.close()
+                    try? stderr.close()
+                    tailCompletion.finish()
+                    try? FileManager.default.removeItem(at: stdoutURL)
+                    try? FileManager.default.removeItem(at: stderrURL)
+                }
+                let stdin = request.agent.promptDelivery == .standardInput ? Pipe() : nil
+
+                process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+                process.arguments = shellArguments(for: request)
+                process.environment = ProcessInfo.processInfo.environment
+                process.currentDirectoryURL = request.packageRootURL
+                process.standardOutput = stdout
+                process.standardError = stderr
+                process.standardInput = stdin
+
+                guard !processReference.set(process) else {
+                    throw CancellationError()
+                }
+                defer { processReference.clear(process) }
+
+                try process.run()
+                processReference.didLaunch(process)
+
+                let stdoutTask = Task.detached(priority: .utility) {
+                    try await tailLines(
+                        from: stdoutURL,
+                        completion: tailCompletion
+                    ) { line in
+                        let output = CustomCodingAgentOutput(
+                            timestamp: .now,
+                            runner: request.agent.name,
+                            stream: .stdout,
+                            text: line
+                        )
+                        await writer.append(output)
+                        await request.onOutput(output)
+                    }
+                }
+
+                let stderrTask = Task.detached(priority: .utility) {
+                    try await tailLines(
+                        from: stderrURL,
+                        completion: tailCompletion
+                    ) { line in
+                        let output = CustomCodingAgentOutput(
+                            timestamp: .now,
+                            runner: request.agent.name,
+                            stream: .stderr,
+                            text: line
+                        )
+                        await writer.append(output)
+                        await request.onOutput(output)
+                    }
+                }
+                let stdinTask = Task.detached(priority: .utility) {
+                    try writeStandardInput(
+                        request.prompt,
+                        to: stdin?.fileHandleForWriting
+                    )
+                }
+
+                try await stdinTask.value
+                process.waitUntilExit()
+                try? stdout.close()
+                try? stderr.close()
+                tailCompletion.finish()
+                _ = try await (stdoutTask.value, stderrTask.value)
+                await writer.close()
+                return process.terminationStatus
+            }
+            let status = try await task.value
+            try Task.checkCancellation()
+            return status
+        } onCancel: {
+            processReference.terminate()
+        }
+
+        guard result == 0 else {
+            throw CustomCodingAgentError.commandFailed(
+                status: result,
+                transcriptURL: transcript.url
+            )
+        }
+        return CustomCodingAgentResult(
+            terminationStatus: result,
+            transcriptURL: transcript.url
+        )
+    }
+
+    nonisolated static let unconfigured = Self { _ in
+        throw CocoaError(.executableNotLoadable)
+    }
+
+    nonisolated static func shellArguments(for request: CustomCodingAgentRequest) -> [String] {
+        switch request.agent.promptDelivery {
+        case .placeholder:
+            let command = request.agent.command.replacingOccurrences(
+                of: "{{prompt}}",
+                with: #""$1""#
+            )
+            return ["-lc", command, request.agent.name, request.prompt]
+        case .standardInput:
+            return ["-lc", request.agent.command]
+        }
+    }
+
+    nonisolated private static func writeStandardInput(
+        _ prompt: String,
+        to handle: FileHandle?
+    ) throws {
+        guard let handle else { return }
+        defer { try? handle.close() }
+        try handle.write(contentsOf: Data(prompt.utf8))
+    }
+
+    nonisolated private static func tailLines(
+        from url: URL,
+        completion: CustomCodingAgentTailCompletion,
+        onLine: @escaping @Sendable (String) async -> Void
+    ) async throws {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var lineData = Data()
+
+        while true {
+            try Task.checkCancellation()
+            let data = try handle.read(upToCount: 64 * 1024) ?? Data()
+            if data.isEmpty {
+                if completion.isFinished {
+                    if !lineData.isEmpty {
+                        await onLine(String(decoding: lineData, as: UTF8.self))
+                    }
+                    return
+                }
+                try await Task.sleep(for: .milliseconds(50))
+                continue
+            }
+            for byte in data {
+                if byte == 10 {
+                    let line = String(decoding: lineData, as: UTF8.self)
+                    await onLine(line.hasSuffix("\r") ? String(line.dropLast()) : line)
+                    lineData.removeAll(keepingCapacity: true)
+                } else {
+                    lineData.append(byte)
+                }
+            }
+        }
+    }
+}
+
+private final class CustomCodingAgentTailCompletion: @unchecked Sendable {
+    private let lock = NSLock()
+    nonisolated(unsafe) private var finished = false
+
+    nonisolated init() {}
+
+    nonisolated func finish() {
+        lock.lock()
+        finished = true
+        lock.unlock()
+    }
+
+    nonisolated var isFinished: Bool {
+        lock.lock()
+        let value = finished
+        lock.unlock()
+        return value
+    }
+}
+
+private final class CustomCodingAgentProcessReference: @unchecked Sendable {
+    private let lock = NSLock()
+    nonisolated(unsafe) private var process: Process?
+    nonisolated(unsafe) private var processGroupID: pid_t?
+    nonisolated(unsafe) private var shouldTerminate = false
+
+    nonisolated init() {}
+
+    nonisolated func set(_ process: Process) -> Bool {
+        lock.lock()
+        self.process = process
+        let shouldTerminate = shouldTerminate
+        lock.unlock()
+        return shouldTerminate
+    }
+
+    nonisolated func didLaunch(_ process: Process) {
+        let pid = process.processIdentifier
+        let groupWasCreated = pid > 0 && setpgid(pid, pid) == 0
+        lock.lock()
+        if self.process === process, groupWasCreated {
+            processGroupID = pid
+        }
+        let shouldTerminate = shouldTerminate
+        lock.unlock()
+        if shouldTerminate {
+            terminateRunningProcess(process, groupID: groupWasCreated ? pid : nil)
+        }
+    }
+
+    nonisolated func clear(_ process: Process) {
+        lock.lock()
+        if self.process === process {
+            self.process = nil
+            processGroupID = nil
+        }
+        lock.unlock()
+    }
+
+    nonisolated func terminate() {
+        lock.lock()
+        shouldTerminate = true
+        let process = process
+        let groupID = processGroupID
+        lock.unlock()
+        guard let process else { return }
+        terminateRunningProcess(process, groupID: groupID)
+    }
+
+    nonisolated private func terminateRunningProcess(_ process: Process, groupID: pid_t?) {
+        let pid = process.processIdentifier
+        if let groupID {
+            _ = Darwin.kill(-groupID, SIGTERM)
+        } else if process.isRunning {
+            process.terminate()
+        }
+        guard pid > 0 else { return }
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 2) {
+            guard process.isRunning else { return }
+            if let groupID {
+                _ = Darwin.kill(-groupID, SIGKILL)
+            } else {
+                _ = Darwin.kill(pid, SIGKILL)
+            }
+        }
+    }
+}
+
+nonisolated enum CustomCodingAgentPrompt {
+    static func compose(
+        userPrompt: String,
+        displayName: String,
+        executableName: String,
+        appKind: ToolAppKind,
+        sandboxEnabled: Bool,
+        attachments: [ToolPersistedPromptAttachment]
+    ) -> String {
+        let attachmentContext = attachments.isEmpty ? "" : """
+
+            User-provided attachments:
+            \(attachments.map { "- \($0.fileName): \($0.url.path)" }.joined(separator: "\n"))
+
+            Treat these files strictly as read-only context. Do not modify them, copy binary data into the app, or reference their temporary paths from generated code.
+            """
+        return """
+            You are a coding agent running inside Ironsmith.
+            Build the requested macOS SwiftUI app by editing this generated Swift package.
+
+            User request:
+            \(userPrompt)
+            \(attachmentContext)
+
+            App name: \(displayName)
+            Fixed target and executable name: \(executableName)
+            \(ToolGenerationPrompts.appPresentationContext(appKind: appKind))
+            \(ToolGenerationPrompts.sandboxContext(sandboxEnabled: sandboxEnabled))
+
+            Rules:
+            - Create or edit only Sources/\(executableName)/ContentView.swift.
+            - Do not modify Package.swift or Sources/\(executableName)/\(executableName).swift.
+            - Do not add other source files or package dependencies.
+            - Do not add previews, @main declarations, or App-conforming helper types.
+            - Keep working until ContentView.swift is complete and `swift build --disable-sandbox` succeeds.
+            - Define ContentView as the root View. Helper types may live in the same file.
+            - This is a macOS SwiftUI app. Do not use iOS-only modifiers.
+            - Keep the app local-only; do not add a backend, accounts, analytics, subscriptions, push notifications, or cloud sync.
+            - Make the app feel native to macOS and prefer Apple frameworks over custom or third-party solutions.
+            - Use // MARK: - to separate sections of code.
+            """
+    }
+}
+
+nonisolated enum CustomCodingAgentTranscriptReader {
+    static func directoryURL(for packageRootURL: URL) -> URL {
+        ToolPackageLayout.customAgentTranscriptsDirectoryURL(for: packageRootURL)
+    }
+
+    static func latestTranscriptURL(
+        for packageRootURL: URL,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let directoryURL = directoryURL(for: packageRootURL)
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        ) else { return nil }
+        return urls
+            .filter { $0.pathExtension == "jsonl" }
+            .sorted {
+                let lhs = (try? $0.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                let rhs = (try? $1.resourceValues(forKeys: [.contentModificationDateKey]))?
+                    .contentModificationDate ?? .distantPast
+                return lhs > rhs
+            }
+            .first
+    }
+
+    static func hasTranscript(for packageRootURL: URL) -> Bool {
+        latestTranscriptURL(for: packageRootURL) != nil
+    }
+
+    static func entries(for packageRootURL: URL) throws -> [CustomCodingAgentOutput] {
+        guard let url = latestTranscriptURL(for: packageRootURL) else { return [] }
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return contents.split(separator: "\n").compactMap { line in
+            try? decoder.decode(CustomCodingAgentOutput.self, from: Data(line.utf8))
+        }
+    }
+}
+
+private nonisolated struct CustomCodingAgentTranscriptFile: Sendable {
+    let url: URL
+
+    init(packageRootURL: URL, agentName: String) throws {
+        let directoryURL = CustomCodingAgentTranscriptReader.directoryURL(for: packageRootURL)
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        let timestamp = ISO8601DateFormatter().string(from: .now)
+            .replacingOccurrences(of: ":", with: "-")
+        url = directoryURL.appendingPathComponent(
+            "\(ToolNameSanitizer.slug(from: agentName))-\(timestamp)-\(UUID().uuidString.lowercased()).jsonl"
+        )
+        try Data().write(to: url, options: .atomic)
+    }
+}
+
+private actor CustomCodingAgentTranscriptWriter {
+    private let handle: FileHandle
+    private let encoder: JSONEncoder
+
+    init(url: URL) throws {
+        handle = try FileHandle(forWritingTo: url)
+        encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+    }
+
+    func append(_ output: CustomCodingAgentOutput) {
+        guard var data = try? encoder.encode(output) else { return }
+        data.append(0x0A)
+        try? handle.write(contentsOf: data)
+    }
+
+    func close() {
+        try? handle.close()
+    }
+}

--- a/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
@@ -37,6 +37,56 @@ nonisolated struct CustomCodingAgentResult: Equatable, Sendable {
     let transcriptURL: URL
 }
 
+nonisolated enum CustomCodingAgentTestError: LocalizedError, Equatable {
+    case commandFailed(status: Int32)
+
+    var errorDescription: String? {
+        switch self {
+        case .commandFailed(let status):
+            "The coding agent test exited with status \(status)."
+        }
+    }
+}
+
+nonisolated struct CustomCodingAgentTestClient: Sendable {
+    static let prompt = "This is a test, respond only with 'Test successful!'"
+
+    var run: @Sendable (
+        _ agent: CustomCodingAgent,
+        _ onOutput: @escaping @Sendable (CustomCodingAgentOutput) async -> Void
+    ) async throws -> Void
+
+    static func live(
+        agentClient: CustomCodingAgentClient = .live,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory
+    ) -> Self {
+        Self { agent, onOutput in
+            let packageRootURL = temporaryDirectory.appendingPathComponent(
+                "ironsmith-custom-agent-test-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: packageRootURL,
+                withIntermediateDirectories: true
+            )
+            defer { try? FileManager.default.removeItem(at: packageRootURL) }
+
+            do {
+                _ = try await agentClient.run(
+                    CustomCodingAgentRequest(
+                        agent: agent,
+                        packageRootURL: packageRootURL,
+                        prompt: prompt,
+                        onOutput: onOutput
+                    )
+                )
+            } catch CustomCodingAgentError.commandFailed(let status, _) {
+                throw CustomCodingAgentTestError.commandFailed(status: status)
+            }
+        }
+    }
+}
+
 enum CustomCodingAgentError: LocalizedError {
     case commandFailed(status: Int32, transcriptURL: URL)
 

--- a/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
@@ -401,7 +401,7 @@ nonisolated enum CustomCodingAgentTranscriptReader {
     static func displayEntries(
         from entries: [CustomCodingAgentOutput]
     ) -> [CustomCodingAgentOutput] {
-        entries.flatMap { entry in
+        entries.flatMap { entry -> [CustomCodingAgentOutput] in
             guard entry.stream == .stdout,
                   let event = try? JSONDecoder().decode(
                       ClaudeStreamEvent.self,
@@ -414,8 +414,12 @@ nonisolated enum CustomCodingAgentTranscriptReader {
 
             guard event.type == "assistant" else { return [] }
             return event.message?.content.compactMap { block in
-                guard block.type == "text",
-                      let text = block.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+                let displayText: String? = switch block.type {
+                case "text": block.text
+                case "thinking": block.thinking
+                default: nil
+                }
+                guard let text = displayText?.trimmingCharacters(in: .whitespacesAndNewlines),
                       !text.isEmpty
                 else { return nil }
                 return CustomCodingAgentOutput(
@@ -434,6 +438,7 @@ private nonisolated struct ClaudeStreamEvent: Decodable {
         struct Content: Decodable {
             let type: String
             let text: String?
+            let thinking: String?
         }
 
         let role: String

--- a/Ironsmith/Core/AgentPipeline/RepairPolicy/ToolRepairStrategy.swift
+++ b/Ironsmith/Core/AgentPipeline/RepairPolicy/ToolRepairStrategy.swift
@@ -5,6 +5,7 @@ enum ToolCodingAgentPreference: String, Codable, CaseIterable, Identifiable, Sen
     case ironsmithSpark = "small_model"
     case ironsmithFlame = "large_model"
     case codex
+    case custom
 
     var id: String { rawValue }
 
@@ -18,6 +19,8 @@ enum ToolCodingAgentPreference: String, Codable, CaseIterable, Identifiable, Sen
             return "Ironsmith Flame"
         case .codex:
             return "Codex"
+        case .custom:
+            return "Custom"
         }
     }
 }
@@ -26,6 +29,7 @@ enum ToolCodingAgent: String, Codable, Equatable, Sendable {
     case ironsmithSpark = "small_model"
     case ironsmithFlame = "large_model"
     case codex
+    case custom
 
     var displayName: String {
         switch self {
@@ -35,6 +39,8 @@ enum ToolCodingAgent: String, Codable, Equatable, Sendable {
             return "Ironsmith Flame"
         case .codex:
             return "Codex"
+        case .custom:
+            return "Custom"
         }
     }
 }
@@ -140,6 +146,7 @@ nonisolated enum ToolCodingAgentSupport {
             .automatic,
             .ironsmithSpark,
             .ironsmithFlame,
+            .custom,
         ]
         if supportsCodex(model: model, provider: provider) {
             supported.insert(.codex)
@@ -190,6 +197,8 @@ nonisolated enum ToolCodingAgentResolver {
             return .ironsmithFlame
         case .codex:
             return .codex
+        case .custom:
+            return .custom
         case .automatic:
             if context.requiresAttachmentSupport,
                ToolAttachmentSupport.canUseCodexAttachments(model: model, provider: provider)
@@ -269,6 +278,8 @@ struct ToolGenerationPipelineConfiguration: Equatable, Sendable {
             return .extractModelEnvelope
         case .codex:
             return .none
+        case .custom:
+            return .none
         }
     }
 
@@ -309,6 +320,21 @@ struct ToolGenerationPipelineConfiguration: Equatable, Sendable {
     static func codex() -> Self {
         ToolGenerationPipelineConfiguration(
             codingAgent: .codex,
+            repairStrategy: .deterministicOnly,
+            maximumGenerationAttempts: 1,
+            batchesRepairDiagnostics: false,
+            restoresBestCandidateOnFailure: false,
+            rollsBackModelRepairWhenErrorCountIncreases: false,
+            regeneratesAfterModelRepairStall: false,
+            fallsBackToWholeFileEditAfterInvalidInitialPatch: false,
+            diagnosticWholeFileRewriteEnabled: false,
+            maximumModelRepairAttempts: nil
+        )
+    }
+
+    static func custom() -> Self {
+        ToolGenerationPipelineConfiguration(
+            codingAgent: .custom,
             repairStrategy: .deterministicOnly,
             maximumGenerationAttempts: 1,
             batchesRepairDiagnostics: false,

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -763,7 +763,7 @@ struct SingleFileToolGenerationRuntime {
             prompt: \(AgentDiagnosticsLog.compact(userPrompt, limit: 240))
             """
         )
-        let protectedFileBaselines = try codexProtectedFileBaselines(layout: layout)
+        let protectedFileBaselines = try codingAgentProtectedFileBaselines(layout: layout)
 
         let request = CodexAgentRequest(
             packageRootURL: layout.packageRootURL,
@@ -792,11 +792,11 @@ struct SingleFileToolGenerationRuntime {
                 throw error
             }
             try Task.checkCancellation()
-            try validateCodexProtectedFiles(
+            try validateCodingAgentProtectedFiles(
                 layout: layout,
                 baselines: protectedFileBaselines
             )
-            try await verifyCodexGeneratedSource(
+            try await verifyCodingAgentGeneratedSource(
                 layout: layout,
                 contentViewPath: contentViewPath,
                 lifecycle: lifecycle
@@ -874,7 +874,7 @@ struct SingleFileToolGenerationRuntime {
             attachments: attachments
         )
         try await lifecycle.updatePhase(.generating, .generatingSource, nil)
-        let protectedFileBaselines = try codexProtectedFileBaselines(layout: layout)
+        let protectedFileBaselines = try codingAgentProtectedFileBaselines(layout: layout)
         AgentDiagnosticsLog.append(
             "Custom coding agent started. runner: \(agent.name), packageRoot: \(layout.packageRootURL.path)"
         )
@@ -894,8 +894,8 @@ struct SingleFileToolGenerationRuntime {
                 }
             )
             try Task.checkCancellation()
-            try validateCodexProtectedFiles(layout: layout, baselines: protectedFileBaselines)
-            try await verifyCodexGeneratedSource(
+            try validateCodingAgentProtectedFiles(layout: layout, baselines: protectedFileBaselines)
+            try await verifyCodingAgentGeneratedSource(
                 layout: layout,
                 contentViewPath: contentViewPath,
                 lifecycle: lifecycle
@@ -906,11 +906,11 @@ struct SingleFileToolGenerationRuntime {
         } catch {
             let originalError = error
             do {
-                try validateCodexProtectedFiles(
+                try validateCodingAgentProtectedFiles(
                     layout: layout,
                     baselines: protectedFileBaselines
                 )
-            } catch CodexAgentError.protectedFileChanged(_) {
+            } catch CodingAgentError.protectedFileChanged(_) {
                 // The validator restored all protected files; preserve the runner's failure.
             } catch {
                 throw error
@@ -922,7 +922,7 @@ struct SingleFileToolGenerationRuntime {
         }
     }
 
-    private func codexProtectedFileBaselines(layout: ToolPackageLayout) throws -> [String: String] {
+    private func codingAgentProtectedFileBaselines(layout: ToolPackageLayout) throws -> [String: String] {
         [
             "Package.swift": try context.readIfPresent(
                 "Package.swift",
@@ -967,7 +967,7 @@ struct SingleFileToolGenerationRuntime {
         }
     }
 
-    private func validateCodexProtectedFiles(
+    private func validateCodingAgentProtectedFiles(
         layout: ToolPackageLayout,
         baselines: [String: String]
     ) throws {
@@ -1019,7 +1019,7 @@ struct SingleFileToolGenerationRuntime {
         if let cleanupError {
             throw cleanupError
         }
-        throw CodexAgentError.protectedFileChanged(violation)
+        throw CodingAgentError.protectedFileChanged(violation)
     }
 
     private func swiftSourcePaths(in layout: ToolPackageLayout) throws -> [String] {
@@ -1047,19 +1047,19 @@ struct SingleFileToolGenerationRuntime {
         return paths
     }
 
-    private func verifyCodexGeneratedSource(
+    private func verifyCodingAgentGeneratedSource(
         layout: ToolPackageLayout,
         contentViewPath: String,
         lifecycle: ToolGenerationLifecycle
     ) async throws {
         let contentViewURL = try layout.packageFileURL(for: contentViewPath)
         guard context.fileClient.fileExists(contentViewURL) else {
-            throw CodexAgentError.missingContentView
+            throw CodingAgentError.missingContentView
         }
 
         let generatedSource = try context.readIfPresent(contentViewPath, packageRootURL: layout.packageRootURL)
         guard !generatedSource.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw CodexAgentError.missingContentView
+            throw CodingAgentError.missingContentView
         }
 
         try await lifecycle.updatePhase(.generating, .repairing, nil)
@@ -1079,7 +1079,7 @@ struct SingleFileToolGenerationRuntime {
             )
             AgentDiagnosticsLog.append(
                 """
-                Codex-generated source failed final verification.
+                Coding-agent-generated source failed final verification.
                 packageRoot: \(layout.packageRootURL.path)
                 contentViewErrorCount: \(contentViewErrors.count)
                 diagnostics:

--- a/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/SingleFileToolGenerationRuntime.swift
@@ -305,8 +305,10 @@ struct SingleFileToolGenerationRuntime {
                 )
             }
 
-            if context.pipelineConfiguration.codingAgent == .codex {
-                try await generateWithCodexAgent(
+            if context.pipelineConfiguration.codingAgent == .codex
+                || context.pipelineConfiguration.codingAgent == .custom
+            {
+                try await generateWithWorkspaceAgent(
                     displayName: setup.displayName,
                     layout: setup.layout,
                     contentViewPath: setup.contentViewPath,
@@ -621,8 +623,10 @@ struct SingleFileToolGenerationRuntime {
                 to: layout.appEntrySourcePath,
                 packageRootURL: layout.packageRootURL
             )
-            if context.pipelineConfiguration.codingAgent == .codex {
-                try await generateWithCodexAgent(
+            if context.pipelineConfiguration.codingAgent == .codex
+                || context.pipelineConfiguration.codingAgent == .custom
+            {
+                try await generateWithWorkspaceAgent(
                     displayName: existingTool.name,
                     layout: layout,
                     contentViewPath: contentViewPath,
@@ -814,6 +818,107 @@ struct SingleFileToolGenerationRuntime {
                 """
             )
             throw error
+        }
+    }
+
+    private func generateWithWorkspaceAgent(
+        displayName: String,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        userPrompt: String,
+        settings: ToolGenerationSettings,
+        lifecycle: ToolGenerationLifecycle
+    ) async throws {
+        switch context.pipelineConfiguration.codingAgent {
+        case .codex:
+            try await generateWithCodexAgent(
+                displayName: displayName,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                userPrompt: userPrompt,
+                settings: settings,
+                lifecycle: lifecycle
+            )
+        case .custom:
+            try await generateWithCustomCodingAgent(
+                displayName: displayName,
+                layout: layout,
+                contentViewPath: contentViewPath,
+                userPrompt: userPrompt,
+                settings: settings,
+                lifecycle: lifecycle
+            )
+        case .ironsmithSpark, .ironsmithFlame:
+            preconditionFailure("Only workspace coding agents use this path.")
+        }
+    }
+
+    private func generateWithCustomCodingAgent(
+        displayName: String,
+        layout: ToolPackageLayout,
+        contentViewPath: String,
+        userPrompt: String,
+        settings: ToolGenerationSettings,
+        lifecycle: ToolGenerationLifecycle
+    ) async throws {
+        guard let agent = context.customCodingAgent else {
+            throw InferenceStoreError.missingCustomCodingAgent
+        }
+        let attachments = try context.attachmentStorage.currentRun(layout)
+        let prompt = CustomCodingAgentPrompt.compose(
+            userPrompt: userPrompt,
+            displayName: displayName,
+            executableName: layout.executableName,
+            appKind: settings.appKind,
+            sandboxEnabled: settings.sandboxEnabled,
+            attachments: attachments
+        )
+        try await lifecycle.updatePhase(.generating, .generatingSource, nil)
+        let protectedFileBaselines = try codexProtectedFileBaselines(layout: layout)
+        AgentDiagnosticsLog.append(
+            "Custom coding agent started. runner: \(agent.name), packageRoot: \(layout.packageRootURL.path)"
+        )
+        do {
+            let result = try await context.customCodingAgentClient.run(
+                CustomCodingAgentRequest(
+                    agent: agent,
+                    packageRootURL: layout.packageRootURL,
+                    prompt: prompt
+                ) { output in
+                    guard output.stream == .stderr, !output.text.isEmpty else { return }
+                    try? await lifecycle.updatePhase(
+                        .generating,
+                        .generatingSource,
+                        output.text
+                    )
+                }
+            )
+            try Task.checkCancellation()
+            try validateCodexProtectedFiles(layout: layout, baselines: protectedFileBaselines)
+            try await verifyCodexGeneratedSource(
+                layout: layout,
+                contentViewPath: contentViewPath,
+                lifecycle: lifecycle
+            )
+            AgentDiagnosticsLog.append(
+                "Custom coding agent completed. runner: \(agent.name), transcript: \(result.transcriptURL.path)"
+            )
+        } catch {
+            let originalError = error
+            do {
+                try validateCodexProtectedFiles(
+                    layout: layout,
+                    baselines: protectedFileBaselines
+                )
+            } catch CodexAgentError.protectedFileChanged(_) {
+                // The validator restored all protected files; preserve the runner's failure.
+            } catch {
+                throw error
+            }
+            AgentDiagnosticsLog.append(
+                "Custom coding agent failed. runner: \(agent.name), error: \(AgentDiagnosticsLog.renderError(originalError, limit: 1_500))"
+            )
+            throw originalError
         }
     }
 

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolGenerationRuntimeContext.swift
@@ -155,6 +155,7 @@ struct ToolGenerationRuntimeDependencies {
     let packageMaterializer: ToolPackageMaterializer
     let attachmentStorage: ToolPromptAttachmentStorage
     let codexAgentClient: CodexAgentClient
+    let customCodingAgentClient: CustomCodingAgentClient
 
     init(
         toolsDirectoryURL: URL,
@@ -168,7 +169,8 @@ struct ToolGenerationRuntimeDependencies {
         versionBackupClient: ToolVersionBackupClient,
         packageMaterializer: ToolPackageMaterializer? = nil,
         attachmentStorage: ToolPromptAttachmentStorage = .live,
-        codexAgentClient: CodexAgentClient = .unconfigured
+        codexAgentClient: CodexAgentClient = .unconfigured,
+        customCodingAgentClient: CustomCodingAgentClient = .unconfigured
     ) {
         self.toolsDirectoryURL = toolsDirectoryURL
         self.fileClient = fileClient
@@ -182,6 +184,7 @@ struct ToolGenerationRuntimeDependencies {
         self.packageMaterializer = packageMaterializer ?? ToolPackageMaterializer(fileClient: fileClient)
         self.attachmentStorage = attachmentStorage
         self.codexAgentClient = codexAgentClient
+        self.customCodingAgentClient = customCodingAgentClient
     }
 
     @MainActor
@@ -197,7 +200,8 @@ struct ToolGenerationRuntimeDependencies {
         versionBackupClient: ToolVersionBackupClient = .live,
         packageMaterializer: ToolPackageMaterializer? = nil,
         attachmentStorage: ToolPromptAttachmentStorage = .live,
-        codexAgentClient: CodexAgentClient = .live()
+        codexAgentClient: CodexAgentClient = .live(),
+        customCodingAgentClient: CustomCodingAgentClient = .live
     ) -> Self {
         Self(
             toolsDirectoryURL: toolsDirectoryURL,
@@ -211,7 +215,8 @@ struct ToolGenerationRuntimeDependencies {
             versionBackupClient: versionBackupClient,
             packageMaterializer: packageMaterializer,
             attachmentStorage: attachmentStorage,
-            codexAgentClient: codexAgentClient
+            codexAgentClient: codexAgentClient,
+            customCodingAgentClient: customCodingAgentClient
         )
     }
 }
@@ -233,10 +238,12 @@ struct ToolGenerationRuntimeContext {
     let packageMaterializer: ToolPackageMaterializer
     let attachmentStorage: ToolPromptAttachmentStorage
     let codexAgentClient: CodexAgentClient
+    let customCodingAgentClient: CustomCodingAgentClient
     let codingAgentModelIdentifier: String
     let codingAgentModelFamily: ToolModelFamily
     let codingAgentContextWindowTokens: Int?
     let codexAgentAuthentication: CodexAgentAuthentication?
+    let customCodingAgent: CustomCodingAgent?
     let reasoningEffort: ToolReasoningEffort
     let codingAgentSupportsImageInput: Bool
 
@@ -280,10 +287,12 @@ struct ToolGenerationRuntimeContext {
         self.packageMaterializer = dependencies.packageMaterializer
         self.attachmentStorage = dependencies.attachmentStorage
         self.codexAgentClient = dependencies.codexAgentClient
+        self.customCodingAgentClient = dependencies.customCodingAgentClient
         self.codingAgentModelIdentifier = languageModelContext.codingAgentModelIdentifier
         self.codingAgentModelFamily = languageModelContext.codingAgentModelFamily
         self.codingAgentContextWindowTokens = languageModelContext.codingAgentContextWindowTokens
         self.codexAgentAuthentication = languageModelContext.codexAgentAuthentication
+        self.customCodingAgent = languageModelContext.customCodingAgent
         self.reasoningEffort = languageModelContext.reasoningEffort
         self.codingAgentSupportsImageInput = languageModelContext.codingAgentSupportsImageInput
     }

--- a/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Runtime/ToolMetadataClient.swift
@@ -635,7 +635,7 @@ struct ToolPromptRefinementClient: Sendable {
         switch codingAgent {
         case .ironsmithSpark:
             return sparkPromptRefinementInstructions
-        case .ironsmithFlame, .codex:
+        case .ironsmithFlame, .codex, .custom:
             return additivePromptRefinementInstructions
         }
     }

--- a/Ironsmith/Core/Inference/InferenceStore/Generation.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/Generation.swift
@@ -24,6 +24,15 @@ extension InferenceStore {
             provider: provider
         )
         let shouldRefreshIronsmithCredits = provider?.kind == .ironsmith
+        let customCodingAgent: CustomCodingAgent?
+        if codingAgent == .custom {
+            guard let selectedAgent = customCodingAgents.selectedAgent else {
+                throw InferenceStoreError.missingCustomCodingAgent
+            }
+            customCodingAgent = selectedAgent
+        } else {
+            customCodingAgent = nil
+        }
         return AgentLanguageModelContext(
             codingAgent: ToolGenerationOptionsResolver.stageConfiguration(
                 for: .codingAgent,
@@ -61,6 +70,7 @@ extension InferenceStore {
                 provider: provider,
                 codingAgent: codingAgent
             ),
+            customCodingAgent: customCodingAgent,
             codingAgentSupportsImageInput: ToolAttachmentSupport.isSupported(
                 model: selectedModel,
                 provider: provider,
@@ -168,6 +178,8 @@ extension InferenceStore {
             )
         case .codex:
             return .codex()
+        case .custom:
+            return .custom()
         }
     }
 

--- a/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
@@ -65,6 +65,7 @@ final class InferenceStore {
         }
     }
     var generationPreferences: GenerationPreferencesStore
+    var customCodingAgents: CustomCodingAgentStore
     var modelSelection: ModelSelectionStore
 
     // Internal coordination state shared by the responsibility-focused InferenceStore extensions.
@@ -78,6 +79,7 @@ final class InferenceStore {
     init(
         dependencies: InferenceDependencies? = nil,
         generationPreferences: GenerationPreferencesStore? = nil,
+        customCodingAgents: CustomCodingAgentStore? = nil,
         modelSelection: ModelSelectionStore? = nil,
         appleFoundationModelPreferenceStore: AppleFoundationModelPreferenceStore? = nil
     ) {
@@ -85,6 +87,7 @@ final class InferenceStore {
             appleFoundationModelPreferenceStore ?? AppleFoundationModelPreferenceStore()
         self.dependencies = dependencies ?? .live
         self.generationPreferences = generationPreferences ?? GenerationPreferencesStore()
+        self.customCodingAgents = customCodingAgents ?? CustomCodingAgentStore()
         self.modelSelection = modelSelection ?? ModelSelectionStore()
         self.appleFoundationModelPreferenceStore = appleFoundationModelPreferenceStore
         self.isAppleFoundationModelEnabled = appleFoundationModelPreferenceStore.isEnabled
@@ -186,12 +189,15 @@ final class InferenceStore {
 
 enum InferenceStoreError: LocalizedError {
     case missingSelectedModel
+    case missingCustomCodingAgent
     case insufficientIronsmithCredits
 
     var errorDescription: String? {
         switch self {
         case .missingSelectedModel:
             return InferenceMessages.noAvailableModels
+        case .missingCustomCodingAgent:
+            return "Choose or add a custom coding agent before generating an app."
         case .insufficientIronsmithCredits:
             return
                 "Your AI credits have run out. Buy more below, or switch to a local or API-key model to keep going."

--- a/Ironsmith/Core/Inference/ModelSelection/CustomCodingAgentStore.swift
+++ b/Ironsmith/Core/Inference/ModelSelection/CustomCodingAgentStore.swift
@@ -45,7 +45,8 @@ nonisolated enum CustomCodingAgentPreset: String, CaseIterable, Identifiable, Se
         case .claudeCode:
             CustomCodingAgent(
                 name: displayName,
-                command: "claude -p --permission-mode auto --output-format stream-json --verbose --model sonnet {{prompt}}"
+                command: "claude -p --permission-mode auto --output-format stream-json --verbose --model sonnet",
+                promptDelivery: .standardInput
             )
         case .openCode:
             CustomCodingAgent(

--- a/Ironsmith/Core/Inference/ModelSelection/CustomCodingAgentStore.swift
+++ b/Ironsmith/Core/Inference/ModelSelection/CustomCodingAgentStore.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Observation
+
+nonisolated struct CustomCodingAgent: Codable, Equatable, Identifiable, Sendable {
+    enum PromptDelivery: String, Codable, CaseIterable, Sendable {
+        case placeholder
+        case standardInput = "standard_input"
+    }
+
+    let id: UUID
+    var name: String
+    var command: String
+    var promptDelivery: PromptDelivery
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        command: String,
+        promptDelivery: PromptDelivery = .placeholder
+    ) {
+        self.id = id
+        self.name = name
+        self.command = command
+        self.promptDelivery = promptDelivery
+    }
+}
+
+nonisolated enum CustomCodingAgentPreset: String, CaseIterable, Identifiable, Sendable {
+    case claudeCode = "claude_code"
+    case openCode = "open_code"
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .claudeCode: "Claude Code"
+        case .openCode: "OpenCode"
+        case .custom: "Custom"
+        }
+    }
+
+    var agent: CustomCodingAgent {
+        switch self {
+        case .claudeCode:
+            CustomCodingAgent(
+                name: displayName,
+                command: "claude -p {{prompt}}"
+            )
+        case .openCode:
+            CustomCodingAgent(
+                name: displayName,
+                command: "opencode run {{prompt}}"
+            )
+        case .custom:
+            CustomCodingAgent(name: "", command: "")
+        }
+    }
+}
+
+enum CustomCodingAgentValidationError: LocalizedError, Equatable {
+    case missingName
+    case duplicateName
+    case missingCommand
+    case invalidPlaceholderCount
+    case placeholderNotAllowedWithStandardInput
+
+    var errorDescription: String? {
+        switch self {
+        case .missingName:
+            "Enter a name for this coding agent."
+        case .duplicateName:
+            "Another coding agent already uses this name."
+        case .missingCommand:
+            "Enter the command Ironsmith should run."
+        case .invalidPlaceholderCount:
+            "The command must contain {{prompt}} exactly once."
+        case .placeholderNotAllowedWithStandardInput:
+            "Remove {{prompt}} when sending the prompt through standard input."
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class CustomCodingAgentStore {
+    private enum Key {
+        static let agents = "generation.customCodingAgents"
+        static let selectedAgentID = "generation.selectedCustomCodingAgentID"
+    }
+
+    private(set) var agents: [CustomCodingAgent]
+    var selectedAgentID: UUID? {
+        didSet {
+            if let selectedAgentID {
+                userDefaults.set(selectedAgentID.uuidString, forKey: Key.selectedAgentID)
+            } else {
+                userDefaults.removeObject(forKey: Key.selectedAgentID)
+            }
+        }
+    }
+
+    @ObservationIgnored private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        if let data = userDefaults.data(forKey: Key.agents),
+           let decoded = try? JSONDecoder().decode([CustomCodingAgent].self, from: data)
+        {
+            agents = decoded
+        } else {
+            agents = []
+        }
+        selectedAgentID = userDefaults.string(forKey: Key.selectedAgentID).flatMap {
+            UUID(uuidString: $0)
+        }
+        if selectedAgentID.map({ id in !agents.contains(where: { $0.id == id }) }) == true {
+            selectedAgentID = nil
+        }
+    }
+
+    var selectedAgent: CustomCodingAgent? {
+        guard let selectedAgentID else { return nil }
+        return agents.first { $0.id == selectedAgentID }
+    }
+
+    func validate(_ agent: CustomCodingAgent) throws -> CustomCodingAgent {
+        var validated = agent
+        validated.name = agent.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        validated.command = agent.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !validated.name.isEmpty else {
+            throw CustomCodingAgentValidationError.missingName
+        }
+        guard !agents.contains(where: {
+            $0.id != validated.id
+                && $0.name.compare(validated.name, options: [.caseInsensitive, .diacriticInsensitive])
+                    == .orderedSame
+        }) else {
+            throw CustomCodingAgentValidationError.duplicateName
+        }
+        guard !validated.command.isEmpty else {
+            throw CustomCodingAgentValidationError.missingCommand
+        }
+
+        let placeholderCount = validated.command.components(separatedBy: "{{prompt}}").count - 1
+        switch validated.promptDelivery {
+        case .placeholder:
+            guard placeholderCount == 1 else {
+                throw CustomCodingAgentValidationError.invalidPlaceholderCount
+            }
+        case .standardInput:
+            guard placeholderCount == 0 else {
+                throw CustomCodingAgentValidationError.placeholderNotAllowedWithStandardInput
+            }
+        }
+        return validated
+    }
+
+    @discardableResult
+    func save(_ agent: CustomCodingAgent) throws -> CustomCodingAgent {
+        let validated = try validate(agent)
+        if let index = agents.firstIndex(where: { $0.id == validated.id }) {
+            agents[index] = validated
+        } else {
+            agents.append(validated)
+        }
+        persistAgents()
+        return validated
+    }
+
+    func delete(id: UUID) {
+        agents.removeAll { $0.id == id }
+        if selectedAgentID == id {
+            selectedAgentID = nil
+        }
+        persistAgents()
+    }
+
+    private func persistAgents() {
+        guard let data = try? JSONEncoder().encode(agents) else { return }
+        userDefaults.set(data, forKey: Key.agents)
+    }
+}

--- a/Ironsmith/Core/Inference/ModelSelection/CustomCodingAgentStore.swift
+++ b/Ironsmith/Core/Inference/ModelSelection/CustomCodingAgentStore.swift
@@ -45,7 +45,7 @@ nonisolated enum CustomCodingAgentPreset: String, CaseIterable, Identifiable, Se
         case .claudeCode:
             CustomCodingAgent(
                 name: displayName,
-                command: "claude -p {{prompt}}"
+                command: "claude -p --permission-mode auto --output-format stream-json --verbose --model sonnet {{prompt}}"
             )
         case .openCode:
             CustomCodingAgent(

--- a/Ironsmith/Core/Inference/ToolAttachmentSupport.swift
+++ b/Ironsmith/Core/Inference/ToolAttachmentSupport.swift
@@ -6,7 +6,14 @@ nonisolated enum ToolAttachmentSupport {
         provider: ProviderConfig?,
         codingAgent: ToolCodingAgent
     ) -> Bool {
-        codingAgent == .codex && canUseCodexAttachments(model: model, provider: provider)
+        switch codingAgent {
+        case .custom:
+            return true
+        case .codex:
+            return canUseCodexAttachments(model: model, provider: provider)
+        case .ironsmithSpark, .ironsmithFlame:
+            return false
+        }
     }
 
     static func canUseCodexAttachments(
@@ -33,6 +40,11 @@ nonisolated enum ToolAttachmentSupport {
     static func preferenceAfterAddingAttachments(
         _ preference: ToolCodingAgentPreference
     ) -> ToolCodingAgentPreference {
-        preference == .automatic ? .automatic : .codex
+        switch preference {
+        case .automatic, .custom:
+            return preference
+        case .ironsmithSpark, .ironsmithFlame, .codex:
+            return .codex
+        }
     }
 }

--- a/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsAccountSectionView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct SettingsAccountSectionView: View {
     @Environment(InferenceStore.self) private var inferenceStore
     @Environment(\.webAuthenticationSession) private var webAuthenticationSession
+    @AppStorage(IronsmithPreferenceKeys.featureStoreEnabled) private var isStoreFeatureEnabled =
+        false
     let onManageAccount: () -> Void
     @State private var isSigningIn = false
     #if DEBUG
@@ -41,23 +43,32 @@ struct SettingsAccountSectionView: View {
                     .disabled(isEmailPasswordAuthenticationDisabled)
                 }
                 #endif
-                Text("Sign in to publish apps, manage your creator identity, and use Ironsmith credits.")
+                Text(accountSignInDescription)
                     .foregroundStyle(.secondary)
             } else {
                 if let email = inferenceStore.ironsmithAccountSummary?.user.email {
                     LabeledContent("Email", value: email)
                 }
-                LabeledContent("Display Name") {
-                    Text(displayName ?? "Not set")
-                        .foregroundStyle(displayName == nil ? .secondary : .primary)
-                }
-                LabeledContent("Creator Handle") {
-                    Text(handleText)
-                        .foregroundStyle(handle == nil ? .secondary : .primary)
+                if isStoreFeatureEnabled {
+                    LabeledContent("Display Name") {
+                        Text(displayName ?? "Not set")
+                            .foregroundStyle(displayName == nil ? .secondary : .primary)
+                    }
+                    LabeledContent("Creator Handle") {
+                        Text(handleText)
+                            .foregroundStyle(handle == nil ? .secondary : .primary)
+                    }
                 }
                 Button("Manage Account…", action: onManageAccount)
             }
         }
+    }
+
+    private var accountSignInDescription: String {
+        if isStoreFeatureEnabled {
+            return "Sign in to publish apps, manage your creator identity, and use Ironsmith credits."
+        }
+        return "Sign in to use Ironsmith models and credits."
     }
 
     private var handle: String? {

--- a/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
+++ b/Ironsmith/Features/Settings/Sections/SettingsPreferencesSectionView.swift
@@ -5,6 +5,8 @@ struct SettingsPreferencesSectionView: View {
     @AppStorage(IronsmithPreferenceKeys.showSandboxOverride) private var showSandboxOverride = false
     @AppStorage(IronsmithPreferenceKeys.diagnosticsLoggingEnabled) private
         var diagnosticsLoggingEnabled = false
+    @AppStorage(IronsmithPreferenceKeys.featureStoreEnabled) private var isStoreFeatureEnabled =
+        false
     @AppStorage(IronsmithPreferenceKeys.generatesIdentityForNewRemixes) private
         var generatesIdentityForNewRemixes = true
     @State private var isConfirmingUnsandboxedTools = false
@@ -30,16 +32,18 @@ struct SettingsPreferencesSectionView: View {
                     .foregroundStyle(.secondary)
             }
 
-            VStack(alignment: .leading, spacing: 4) {
-                Toggle(
-                    "Generate a new name and icon for remixes",
-                    isOn: $generatesIdentityForNewRemixes
-                )
-                .toggleStyle(.switch)
+            if isStoreFeatureEnabled {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle(
+                        "Generate a new name and icon for remixes",
+                        isOn: $generatesIdentityForNewRemixes
+                    )
+                    .toggleStyle(.switch)
 
-                Text("Applies when you edit a downloaded app for the first time.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    Text("Applies when you edit a downloaded app for the first time.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Toggle("Allow unsandboxed apps", isOn: sandboxOverrideBinding)
@@ -90,8 +94,8 @@ struct SettingsPreferencesSectionView: View {
                     Text(
                         inferenceStore.generationPreferences
                             .automaticallySelectGeneratedAppPermissions
-                            ? "Ironsmith selects permissions from each prompt. Permissions below are always included."
-                            : "Permissions below provide the defaults shown when generating an app."
+                            ? "Ironsmith chooses permissions for you. Permissions selected below are always included."
+                            : "Apps default to the permissions selected below."
                     )
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/Ironsmith/Features/Settings/Sheets/ManageIronsmithAccountSheetView.swift
+++ b/Ironsmith/Features/Settings/Sheets/ManageIronsmithAccountSheetView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct ManageIronsmithAccountSheetView: View {
     @Environment(InferenceStore.self) private var inferenceStore
     @Environment(\.dismiss) private var dismiss
+    @AppStorage(IronsmithPreferenceKeys.featureStoreEnabled) private var isStoreFeatureEnabled =
+        false
     let onBuyCredits: () -> Void
 
     @State private var displayName = ""
@@ -19,35 +21,37 @@ struct ManageIronsmithAccountSheetView: View {
 
     var body: some View {
         Form {
-            Section("Creator Profile") {
-                TextField(
-                    "Display Name",
-                    text: $displayName,
-                    prompt: Text("Your public creator name")
-                )
-                VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 12) {
-                        Text("Handle")
-                        Spacer(minLength: 12)
-                        if existingHandle != nil {
-                            Text("@\(normalizedHandle)")
-                                .foregroundStyle(.secondary)
-                        } else {
-                            TextField(
-                                "",
-                                text: handleText,
-                                prompt: Text("@your_handle")
-                            )
-                            .labelsHidden()
-                            .multilineTextAlignment(.trailing)
-                            .frame(width: 220)
+            if isStoreFeatureEnabled {
+                Section("Creator Profile") {
+                    TextField(
+                        "Display Name",
+                        text: $displayName,
+                        prompt: Text("Your public creator name")
+                    )
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 12) {
+                            Text("Handle")
+                            Spacer(minLength: 12)
+                            if existingHandle != nil {
+                                Text("@\(normalizedHandle)")
+                                    .foregroundStyle(.secondary)
+                            } else {
+                                TextField(
+                                    "",
+                                    text: handleText,
+                                    prompt: Text("@your_handle")
+                                )
+                                .labelsHidden()
+                                .multilineTextAlignment(.trailing)
+                                .frame(width: 220)
+                            }
                         }
-                    }
-                    if let handleSupportingText {
-                        Text(handleSupportingText)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        if let handleSupportingText {
+                            Text(handleSupportingText)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                     }
                 }
             }
@@ -76,10 +80,12 @@ struct ManageIronsmithAccountSheetView: View {
                 .disabled(isSigningOut || isDeleting)
 
                 Spacer()
-                Button("Cancel") { dismiss() }
-                Button(isSaving ? "Saving…" : "Save") { save() }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(!canSave || isSaving)
+                Button(isStoreFeatureEnabled ? "Cancel" : "Done") { dismiss() }
+                if isStoreFeatureEnabled {
+                    Button(isSaving ? "Saving…" : "Save") { save() }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!canSave || isSaving)
+                }
             }
             .padding(20)
             .background(.bar)
@@ -89,9 +95,11 @@ struct ManageIronsmithAccountSheetView: View {
             await loadThenRefreshProfile()
         }
         .task(id: normalizedHandle) {
+            guard isStoreFeatureEnabled else { return }
             await refreshHandleAvailability()
         }
         .task(id: handle) {
+            guard isStoreFeatureEnabled else { return }
             await refreshHandleRequirementsVisibility()
         }
         .confirmationDialog("Delete Ironsmith Account?", isPresented: $isConfirmingDeletion) {
@@ -245,6 +253,7 @@ struct ManageIronsmithAccountSheetView: View {
     }
 
     private func save() {
+        guard isStoreFeatureEnabled else { return }
         guard canSave else { return }
         if existingHandle == nil {
             isConfirmingHandleClaim = true
@@ -254,6 +263,7 @@ struct ManageIronsmithAccountSheetView: View {
     }
 
     private func saveProfile() {
+        guard isStoreFeatureEnabled else { return }
         isSaving = true
         Task {
             do {

--- a/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
+++ b/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
@@ -166,7 +166,7 @@ struct AgentOutputWindowView: View {
             )
             showsCustomTranscript = Self.isNewer(customURL, than: codexURL)
             if showsCustomTranscript {
-                customEntries = try CustomCodingAgentTranscriptReader.entries(
+                customEntries = try CustomCodingAgentTranscriptReader.displayEntries(
                     for: tool.packageRootURL
                 )
                 snapshot = .empty

--- a/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
+++ b/Ironsmith/Features/ToolLibrary/AgentOutput/AgentOutputWindowView.swift
@@ -7,6 +7,8 @@ struct AgentOutputWindowView: View {
 
     @Query(sort: \Tool.updatedAt, order: .reverse) private var tools: [Tool]
     @State private var snapshot = CodexAgentTranscriptSnapshot.empty
+    @State private var customEntries: [CustomCodingAgentOutput] = []
+    @State private var showsCustomTranscript = false
     @State private var loadError: String?
 
     private var tool: Tool? {
@@ -67,7 +69,7 @@ struct AgentOutputWindowView: View {
     private func timeline(for tool: Tool) -> some View {
         if let loadError {
             emptyState(loadError)
-        } else if snapshot.entries.isEmpty {
+        } else if visibleEntryCount == 0 {
             VStack(spacing: 12) {
                 emptyState(isWorking ? "Waiting for agent output" : "No agent output")
                 if isWorking {
@@ -80,12 +82,19 @@ struct AgentOutputWindowView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 10) {
-                        ForEach(snapshot.entries) { entry in
-                            AgentOutputEventRow(
-                                entry: entry,
-                                packageRootURL: tool.packageRootURL
-                            )
-                            .id(entry.id)
+                        if showsCustomTranscript {
+                            ForEach(Array(customEntries.enumerated()), id: \.offset) { index, entry in
+                                CustomAgentOutputRow(entry: entry)
+                                    .id(index)
+                            }
+                        } else {
+                            ForEach(snapshot.entries) { entry in
+                                AgentOutputEventRow(
+                                    entry: entry,
+                                    packageRootURL: tool.packageRootURL
+                                )
+                                .id(entry.id)
+                            }
                         }
 
                         if isWorking {
@@ -100,7 +109,7 @@ struct AgentOutputWindowView: View {
                 .onAppear {
                     scrollToBottom(proxy)
                 }
-                .onChange(of: snapshot.entries.count) { _, _ in
+                .onChange(of: visibleEntryCount) { _, _ in
                     scrollToBottom(proxy)
                 }
             }
@@ -149,10 +158,26 @@ struct AgentOutputWindowView: View {
         }
 
         do {
-            snapshot = try CodexAgentTranscriptReader.snapshot(for: tool.packageRootURL)
+            let codexURL = CodexAgentTranscriptReader.latestTranscriptURL(
+                for: tool.packageRootURL
+            )
+            let customURL = CustomCodingAgentTranscriptReader.latestTranscriptURL(
+                for: tool.packageRootURL
+            )
+            showsCustomTranscript = Self.isNewer(customURL, than: codexURL)
+            if showsCustomTranscript {
+                customEntries = try CustomCodingAgentTranscriptReader.entries(
+                    for: tool.packageRootURL
+                )
+                snapshot = .empty
+            } else {
+                snapshot = try CodexAgentTranscriptReader.snapshot(for: tool.packageRootURL)
+                customEntries = []
+            }
             loadError = nil
         } catch {
             snapshot = .empty
+            customEntries = []
             loadError = error.localizedDescription
         }
     }
@@ -160,13 +185,55 @@ struct AgentOutputWindowView: View {
     private func scrollToBottom(_ proxy: ScrollViewProxy) {
         guard isWorking else { return }
         Task { @MainActor in
-            if snapshot.entries.isEmpty {
+            if visibleEntryCount == 0 {
                 proxy.scrollTo("working", anchor: .bottom)
             } else {
                 withAnimation(.easeOut(duration: 0.18)) {
                     proxy.scrollTo("working", anchor: .bottom)
                 }
             }
+        }
+    }
+
+    private var visibleEntryCount: Int {
+        showsCustomTranscript ? customEntries.count : snapshot.entries.count
+    }
+
+    nonisolated private static func isNewer(_ lhs: URL?, than rhs: URL?) -> Bool {
+        guard let lhs else { return false }
+        guard let rhs else { return true }
+        let keys: Set<URLResourceKey> = [.contentModificationDateKey]
+        let lhsDate = (try? lhs.resourceValues(forKeys: keys).contentModificationDate)
+            ?? .distantPast
+        let rhsDate = (try? rhs.resourceValues(forKeys: keys).contentModificationDate)
+            ?? .distantPast
+        return lhsDate >= rhsDate
+    }
+}
+
+private struct CustomAgentOutputRow: View {
+    let entry: CustomCodingAgentOutput
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: entry.stream == .stderr ? "exclamationmark.triangle" : "terminal")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(entry.stream == .stderr ? Color.orange : Color.accentColor)
+                .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("\(entry.runner) · \(entry.stream.rawValue)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Text(entry.text)
+                    .font(.system(.callout, design: .monospaced))
+                    .foregroundStyle(entry.stream == .stderr ? Color.orange : Color.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
         }
     }
 }

--- a/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
@@ -1,68 +1,19 @@
 import SwiftUI
 
-struct CustomCodingAgentSheetView: View {
+struct AddCustomCodingAgentSheetView: View {
     @Environment(InferenceStore.self) private var inferenceStore
     @Environment(\.dismiss) private var dismiss
     @Bindable var store: CustomCodingAgentStore
-    let startsWithNewAgent: Bool
-    @State private var draft: CustomCodingAgent?
-    @State private var selectedID: UUID?
+    @State private var draft = CustomCodingAgentPreset.claudeCode.agent
     @State private var errorMessage: String?
-    @State private var selectedPreset = CustomCodingAgentPreset.custom
+    @State private var selectedPreset = CustomCodingAgentPreset.claudeCode
 
     var body: some View {
-        HStack(spacing: 0) {
-            sidebar
-            Divider()
-            editor
-        }
-        .frame(width: 720, height: 440)
-        .onAppear {
-            if startsWithNewAgent {
-                beginAddingAgent()
-            } else {
-                selectedID = store.selectedAgentID ?? store.agents.first?.id
-                loadSelectedDraft()
-            }
-        }
-        .onChange(of: selectedID) { _, _ in loadSelectedDraft() }
-    }
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Add Coding Agent")
+                .font(.headline)
 
-    private var sidebar: some View {
-        VStack(spacing: 10) {
-            List(store.agents, selection: $selectedID) { agent in
-                Text(agent.name).tag(agent.id)
-            }
-            HStack {
-                Button {
-                    beginAddingAgent()
-                } label: {
-                    Image(systemName: "plus")
-                }
-                .help("Add coding agent")
-
-                Button(role: .destructive) {
-                    deleteSelectedAgent()
-                } label: {
-                    Image(systemName: "minus")
-                }
-                .disabled(store.agents.contains(where: { $0.id == selectedID }) == false)
-                .help("Delete coding agent")
-                Spacer()
-            }
-            .buttonStyle(.borderless)
-        }
-        .padding(12)
-        .frame(width: 220)
-    }
-
-    @ViewBuilder
-    private var editor: some View {
-        if draft != nil {
-            VStack(alignment: .leading, spacing: 16) {
-                Text(store.agents.contains(where: { $0.id == draft?.id }) ? "Edit Agent" : "Add Agent")
-                    .font(.title2.weight(.semibold))
-
+            field("Preset") {
                 Picker(
                     "Preset",
                     selection: Binding(
@@ -77,120 +28,235 @@ struct CustomCodingAgentSheetView: View {
                         Text(preset.displayName).tag(preset)
                     }
                 }
-                .pickerStyle(.segmented)
-
-                TextField("Name", text: draftNameBinding)
-                TextField("Command", text: draftCommandBinding, axis: .vertical)
-                    .font(.system(.body, design: .monospaced))
-                    .lineLimit(3...6)
-
-                Picker("Send prompt", selection: draftDeliveryBinding) {
-                    Text("Replace {{prompt}}").tag(CustomCodingAgent.PromptDelivery.placeholder)
-                    Text("Standard input").tag(CustomCodingAgent.PromptDelivery.standardInput)
-                }
-
-                Label(
-                    "This command runs with your normal shell permissions. Ironsmith does not manage its installation, login, model, sandbox, or approvals.",
-                    systemImage: "exclamationmark.triangle.fill"
-                )
-                .font(.caption)
-                .foregroundStyle(.orange)
-
-                if let errorMessage {
-                    Text(errorMessage).font(.caption).foregroundStyle(.red)
-                }
-                Spacer()
-                HStack {
-                    Spacer()
-                    Button("Done") { dismiss() }
-                    Button("Save") { saveDraft() }
-                        .buttonStyle(.borderedProminent)
-                }
+                .labelsHidden()
+                .pickerStyle(.menu)
             }
-            .padding(22)
-        } else {
-            ContentUnavailableView(
-                "No Custom Agents",
-                systemImage: "terminal",
-                description: Text("Add a runner to use any command-line coding agent.")
+
+            CustomCodingAgentEditorFields(
+                draft: $draft,
+                errorMessage: errorMessage
             )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+            HStack {
+                Spacer()
+                Button("Cancel", role: .cancel) { dismiss() }
+                Button("Save") { save() }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+            }
         }
+        .padding(18)
+        .frame(width: 390)
     }
 
     private func applyPreset(_ preset: CustomCodingAgentPreset) {
-        guard let id = draft?.id else { return }
-        var replacement = preset.agent
-        replacement = CustomCodingAgent(
-            id: id,
+        let replacement = preset.agent
+        draft = CustomCodingAgent(
+            id: draft.id,
             name: replacement.name,
             command: replacement.command,
             promptDelivery: replacement.promptDelivery
         )
-        draft = replacement
         errorMessage = nil
     }
 
-    private func loadSelectedDraft() {
-        guard let selectedID,
-              let agent = store.agents.first(where: { $0.id == selectedID })
-        else { return }
-        draft = agent
-        selectedPreset = .custom
-        errorMessage = nil
-    }
-
-    private func beginAddingAgent() {
-        let newAgent = CustomCodingAgentPreset.custom.agent
-        selectedID = newAgent.id
-        draft = newAgent
-        selectedPreset = .custom
-        errorMessage = nil
-    }
-
-    private var draftNameBinding: Binding<String> {
-        Binding(
-            get: { draft?.name ?? "" },
-            set: { draft?.name = $0 }
-        )
-    }
-
-    private var draftCommandBinding: Binding<String> {
-        Binding(
-            get: { draft?.command ?? "" },
-            set: { draft?.command = $0 }
-        )
-    }
-
-    private var draftDeliveryBinding: Binding<CustomCodingAgent.PromptDelivery> {
-        Binding(
-            get: { draft?.promptDelivery ?? .placeholder },
-            set: { draft?.promptDelivery = $0 }
-        )
-    }
-
-    private func saveDraft() {
-        guard let draft else { return }
+    private func save() {
         do {
             let saved = try store.save(draft)
-            selectedID = saved.id
             store.selectedAgentID = saved.id
             inferenceStore.generationPreferences.codingAgentPreference = .custom
-            self.draft = saved
-            errorMessage = nil
+            dismiss()
         } catch {
             errorMessage = error.localizedDescription
         }
     }
 
-    private func deleteSelectedAgent() {
+    private func field<Content: View>(
+        _ label: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.subheadline.weight(.medium))
+            content()
+        }
+    }
+}
+
+struct ManageCustomCodingAgentsSheetView: View {
+    @Environment(InferenceStore.self) private var inferenceStore
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var store: CustomCodingAgentStore
+    @State private var draft: CustomCodingAgent?
+    @State private var selectedID: UUID?
+    @State private var errorMessage: String?
+    @State private var isConfirmingRemoval = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Manage Coding Agents")
+                .font(.headline)
+
+            if let draft {
+                field("Agent") {
+                    Picker("Agent", selection: $selectedID) {
+                        ForEach(store.agents) { agent in
+                            Text(agent.name).tag(Optional(agent.id))
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                }
+
+                CustomCodingAgentEditorFields(
+                    draft: draftBinding(fallback: draft),
+                    errorMessage: errorMessage
+                )
+            } else {
+                ContentUnavailableView(
+                    "No Custom Agents",
+                    systemImage: "terminal",
+                    description: Text("Add a coding agent before managing one.")
+                )
+            }
+
+            HStack {
+                Button("Remove", role: .destructive) {
+                    isConfirmingRemoval = true
+                }
+                .buttonStyle(.bordered)
+                .tint(.red)
+                .disabled(draft == nil)
+
+                Spacer()
+
+                Button("Cancel", role: .cancel) { dismiss() }
+                Button("Save") { save() }
+                    .buttonStyle(.borderedProminent)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(draft == nil)
+            }
+        }
+        .padding(18)
+        .frame(width: 390)
+        .onAppear { selectInitialAgent() }
+        .onChange(of: selectedID) { _, _ in loadSelectedDraft() }
+        .confirmationDialog(
+            "Remove \(draft?.name ?? "Coding Agent")?",
+            isPresented: $isConfirmingRemoval
+        ) {
+            Button("Remove Agent", role: .destructive) { removeSelectedAgent() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the coding agent configuration from Ironsmith.")
+        }
+    }
+
+    private func selectInitialAgent() {
+        let persistedSelection = store.selectedAgentID.flatMap { selectedID in
+            store.agents.contains(where: { $0.id == selectedID }) ? selectedID : nil
+        }
+        selectedID = persistedSelection ?? store.agents.first?.id
+        loadSelectedDraft()
+    }
+
+    private func loadSelectedDraft() {
+        draft = selectedID.flatMap { id in store.agents.first { $0.id == id } }
+        errorMessage = nil
+    }
+
+    private func draftBinding(fallback: CustomCodingAgent) -> Binding<CustomCodingAgent> {
+        Binding(
+            get: { draft ?? fallback },
+            set: { draft = $0 }
+        )
+    }
+
+    private func save() {
+        guard let draft else { return }
+        do {
+            let saved = try store.save(draft)
+            store.selectedAgentID = saved.id
+            inferenceStore.generationPreferences.codingAgentPreference = .custom
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func removeSelectedAgent() {
         guard let selectedID else { return }
-        let deletedSelectedRunner = store.selectedAgentID == selectedID
+        let removedSelectedAgent = store.selectedAgentID == selectedID
         store.delete(id: selectedID)
-        if deletedSelectedRunner {
+        if removedSelectedAgent {
             inferenceStore.generationPreferences.codingAgentPreference = .automatic
         }
-        self.selectedID = store.agents.first?.id
-        draft = self.selectedID.flatMap { id in store.agents.first { $0.id == id } }
+        dismiss()
+    }
+
+    private func field<Content: View>(
+        _ label: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.subheadline.weight(.medium))
+            content()
+        }
+    }
+}
+
+private struct CustomCodingAgentEditorFields: View {
+    @Binding var draft: CustomCodingAgent
+    let errorMessage: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            field("Name") {
+                TextField("Agent name", text: $draft.name)
+            }
+
+            field("Command") {
+                TextField(
+                    CustomCodingAgentPreset.openCode.agent.command,
+                    text: $draft.command,
+                    axis: .vertical
+                )
+                .font(.system(.body, design: .monospaced))
+                .lineLimit(3...6)
+            }
+
+            field("Send Prompt") {
+                Picker("Send Prompt", selection: $draft.promptDelivery) {
+                    Text("Replace {{prompt}}").tag(CustomCodingAgent.PromptDelivery.placeholder)
+                    Text("Standard input").tag(CustomCodingAgent.PromptDelivery.standardInput)
+                }
+                .labelsHidden()
+            }
+
+            Label(
+                "This command runs with your normal shell permissions. Ironsmith does not manage its installation, login, model, sandbox, or approvals.",
+                systemImage: "exclamationmark.triangle.fill"
+            )
+            .font(.caption)
+            .foregroundStyle(.orange)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func field<Content: View>(
+        _ label: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.subheadline.weight(.medium))
+            content()
+        }
     }
 }

--- a/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+
+struct CustomCodingAgentSheetView: View {
+    @Environment(InferenceStore.self) private var inferenceStore
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var store: CustomCodingAgentStore
+    let startsWithNewAgent: Bool
+    @State private var draft: CustomCodingAgent?
+    @State private var selectedID: UUID?
+    @State private var errorMessage: String?
+    @State private var selectedPreset = CustomCodingAgentPreset.custom
+
+    var body: some View {
+        HStack(spacing: 0) {
+            sidebar
+            Divider()
+            editor
+        }
+        .frame(width: 720, height: 440)
+        .onAppear {
+            if startsWithNewAgent {
+                beginAddingAgent()
+            } else {
+                selectedID = store.selectedAgentID ?? store.agents.first?.id
+                loadSelectedDraft()
+            }
+        }
+        .onChange(of: selectedID) { _, _ in loadSelectedDraft() }
+    }
+
+    private var sidebar: some View {
+        VStack(spacing: 10) {
+            List(store.agents, selection: $selectedID) { agent in
+                Text(agent.name).tag(agent.id)
+            }
+            HStack {
+                Button {
+                    beginAddingAgent()
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .help("Add coding agent")
+
+                Button(role: .destructive) {
+                    deleteSelectedAgent()
+                } label: {
+                    Image(systemName: "minus")
+                }
+                .disabled(store.agents.contains(where: { $0.id == selectedID }) == false)
+                .help("Delete coding agent")
+                Spacer()
+            }
+            .buttonStyle(.borderless)
+        }
+        .padding(12)
+        .frame(width: 220)
+    }
+
+    @ViewBuilder
+    private var editor: some View {
+        if draft != nil {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(store.agents.contains(where: { $0.id == draft?.id }) ? "Edit Agent" : "Add Agent")
+                    .font(.title2.weight(.semibold))
+
+                Picker(
+                    "Preset",
+                    selection: Binding(
+                        get: { selectedPreset },
+                        set: { preset in
+                            selectedPreset = preset
+                            applyPreset(preset)
+                        }
+                    )
+                ) {
+                    ForEach(CustomCodingAgentPreset.allCases) { preset in
+                        Text(preset.displayName).tag(preset)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                TextField("Name", text: draftNameBinding)
+                TextField("Command", text: draftCommandBinding, axis: .vertical)
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(3...6)
+
+                Picker("Send prompt", selection: draftDeliveryBinding) {
+                    Text("Replace {{prompt}}").tag(CustomCodingAgent.PromptDelivery.placeholder)
+                    Text("Standard input").tag(CustomCodingAgent.PromptDelivery.standardInput)
+                }
+
+                Label(
+                    "This command runs with your normal shell permissions. Ironsmith does not manage its installation, login, model, sandbox, or approvals.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+
+                if let errorMessage {
+                    Text(errorMessage).font(.caption).foregroundStyle(.red)
+                }
+                Spacer()
+                HStack {
+                    Spacer()
+                    Button("Done") { dismiss() }
+                    Button("Save") { saveDraft() }
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+            .padding(22)
+        } else {
+            ContentUnavailableView(
+                "No Custom Agents",
+                systemImage: "terminal",
+                description: Text("Add a runner to use any command-line coding agent.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func applyPreset(_ preset: CustomCodingAgentPreset) {
+        guard let id = draft?.id else { return }
+        var replacement = preset.agent
+        replacement = CustomCodingAgent(
+            id: id,
+            name: replacement.name,
+            command: replacement.command,
+            promptDelivery: replacement.promptDelivery
+        )
+        draft = replacement
+        errorMessage = nil
+    }
+
+    private func loadSelectedDraft() {
+        guard let selectedID,
+              let agent = store.agents.first(where: { $0.id == selectedID })
+        else { return }
+        draft = agent
+        selectedPreset = .custom
+        errorMessage = nil
+    }
+
+    private func beginAddingAgent() {
+        let newAgent = CustomCodingAgentPreset.custom.agent
+        selectedID = newAgent.id
+        draft = newAgent
+        selectedPreset = .custom
+        errorMessage = nil
+    }
+
+    private var draftNameBinding: Binding<String> {
+        Binding(
+            get: { draft?.name ?? "" },
+            set: { draft?.name = $0 }
+        )
+    }
+
+    private var draftCommandBinding: Binding<String> {
+        Binding(
+            get: { draft?.command ?? "" },
+            set: { draft?.command = $0 }
+        )
+    }
+
+    private var draftDeliveryBinding: Binding<CustomCodingAgent.PromptDelivery> {
+        Binding(
+            get: { draft?.promptDelivery ?? .placeholder },
+            set: { draft?.promptDelivery = $0 }
+        )
+    }
+
+    private func saveDraft() {
+        guard let draft else { return }
+        do {
+            let saved = try store.save(draft)
+            selectedID = saved.id
+            store.selectedAgentID = saved.id
+            inferenceStore.generationPreferences.codingAgentPreference = .custom
+            self.draft = saved
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private func deleteSelectedAgent() {
+        guard let selectedID else { return }
+        let deletedSelectedRunner = store.selectedAgentID == selectedID
+        store.delete(id: selectedID)
+        if deletedSelectedRunner {
+            inferenceStore.generationPreferences.codingAgentPreference = .automatic
+        }
+        self.selectedID = store.agents.first?.id
+        draft = self.selectedID.flatMap { id in store.agents.first { $0.id == id } }
+    }
+}

--- a/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
@@ -34,7 +34,8 @@ struct AddCustomCodingAgentSheetView: View {
 
             CustomCodingAgentEditorFields(
                 draft: $draft,
-                errorMessage: errorMessage
+                errorMessage: errorMessage,
+                validate: store.validate
             )
 
             Label(
@@ -117,8 +118,10 @@ struct ManageCustomCodingAgentsSheetView: View {
 
                 CustomCodingAgentEditorFields(
                     draft: draftBinding(fallback: draft),
-                    errorMessage: errorMessage
+                    errorMessage: errorMessage,
+                    validate: store.validate
                 )
+                .id(draft.id)
             } else {
                 ContentUnavailableView(
                     "No Custom Agents",
@@ -216,6 +219,8 @@ struct ManageCustomCodingAgentsSheetView: View {
 private struct CustomCodingAgentEditorFields: View {
     @Binding var draft: CustomCodingAgent
     let errorMessage: String?
+    let validate: (CustomCodingAgent) throws -> CustomCodingAgent
+    @State private var testStore = CustomCodingAgentTestStore()
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -241,12 +246,56 @@ private struct CustomCodingAgentEditorFields: View {
                 .labelsHidden()
             }
 
+            field("Test Agent") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Button {
+                        testStore.run(agent: draft, validate: validate)
+                    } label: {
+                        HStack(spacing: 6) {
+                            if testStore.isRunning {
+                                ProgressView()
+                                    .controlSize(.small)
+                            }
+                            Text(testStore.isRunning ? "Testing…" : "Test")
+                        }
+                    }
+                    .disabled(testStore.isRunning)
+
+                    if let output = testStore.output {
+                        ScrollView {
+                            Text(output)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                        .frame(height: 82)
+                        .padding(8)
+                        .background(
+                            .quaternary.opacity(0.3),
+                            in: RoundedRectangle(cornerRadius: 7)
+                        )
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 7)
+                                .strokeBorder(.secondary.opacity(0.15))
+                        }
+                    }
+
+                    if let testError = testStore.errorMessage {
+                        Text(testError)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+
             if let errorMessage {
                 Text(errorMessage)
                     .font(.caption)
                     .foregroundStyle(.red)
             }
         }
+        .onChange(of: draft) { _, _ in testStore.reset() }
+        .onDisappear { testStore.reset() }
     }
 
     private func field<Content: View>(

--- a/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
@@ -37,6 +37,13 @@ struct AddCustomCodingAgentSheetView: View {
                 errorMessage: errorMessage
             )
 
+            Label(
+                "Ironsmith doesn't manage your custom agent's active model or installation. A selected Ironsmith model is still required to generate app metadata.",
+                systemImage: "exclamationmark.triangle.fill"
+            )
+            .font(.caption)
+            .foregroundStyle(.orange)
+
             HStack {
                 Spacer()
                 Button("Cancel", role: .cancel) { dismiss() }
@@ -233,13 +240,6 @@ private struct CustomCodingAgentEditorFields: View {
                 }
                 .labelsHidden()
             }
-
-            Label(
-                "This command runs with your normal shell permissions. Ironsmith does not manage its installation, login, model, sandbox, or approvals.",
-                systemImage: "exclamationmark.triangle.fill"
-            )
-            .font(.caption)
-            .foregroundStyle(.orange)
 
             if let errorMessage {
                 Text(errorMessage)

--- a/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentSheetView.swift
@@ -44,6 +44,8 @@ struct AddCustomCodingAgentSheetView: View {
             )
             .font(.caption)
             .foregroundStyle(.orange)
+            .lineLimit(nil)
+            .fixedSize(horizontal: false, vertical: true)
 
             HStack {
                 Spacer()

--- a/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentTestStore.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/CustomCodingAgentTestStore.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class CustomCodingAgentTestStore {
+    private(set) var output: String?
+    private(set) var errorMessage: String?
+    private(set) var isRunning = false
+
+    @ObservationIgnored private let client: CustomCodingAgentTestClient
+    @ObservationIgnored private var task: Task<Void, Never>?
+    @ObservationIgnored private var activeRunID: UUID?
+
+    init(client: CustomCodingAgentTestClient = .live()) {
+        self.client = client
+    }
+
+    func run(
+        agent: CustomCodingAgent,
+        validate: (CustomCodingAgent) throws -> CustomCodingAgent
+    ) {
+        let validatedAgent: CustomCodingAgent
+        do {
+            validatedAgent = try validate(agent)
+        } catch {
+            reset()
+            errorMessage = error.localizedDescription
+            return
+        }
+
+        task?.cancel()
+        let runID = UUID()
+        activeRunID = runID
+        output = nil
+        errorMessage = nil
+        isRunning = true
+
+        task = Task { [client] in
+            do {
+                try await client.run(validatedAgent) { entry in
+                    await self.append(entry, for: runID)
+                }
+                self.finish(runID: runID)
+            } catch is CancellationError {
+                self.finish(runID: runID)
+            } catch {
+                self.finish(runID: runID, error: error)
+            }
+        }
+    }
+
+    func reset() {
+        task?.cancel()
+        task = nil
+        activeRunID = nil
+        output = nil
+        errorMessage = nil
+        isRunning = false
+    }
+
+    private func append(_ entry: CustomCodingAgentOutput, for runID: UUID) {
+        guard activeRunID == runID else { return }
+        let text = CustomCodingAgentTranscriptReader.displayEntries(from: [entry])
+            .map(\.text)
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            .joined(separator: "\n")
+        guard !text.isEmpty else { return }
+        if let output {
+            self.output = output + "\n" + text
+        } else {
+            output = text
+        }
+    }
+
+    private func finish(runID: UUID, error: Error? = nil) {
+        guard activeRunID == runID else { return }
+        activeRunID = nil
+        task = nil
+        isRunning = false
+        errorMessage = error?.localizedDescription
+    }
+}

--- a/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
@@ -260,11 +260,8 @@ struct PromptComposerView: View {
         Menu {
             Picker("App Type", selection: $appKindPreference) {
                 ForEach(ToolAppKindPreference.allCases, id: \.self) { preference in
-                    Label(
-                        preference.displayName,
-                        systemImage: appKindSystemImage(preference)
-                    )
-                    .tag(preference)
+                    Text(preference.displayName)
+                        .tag(preference)
                 }
             }
 
@@ -451,14 +448,6 @@ struct PromptComposerView: View {
 
     private var sandboxHelpText: String {
         "Controls whether generated apps include App Sandbox entitlements."
-    }
-
-    private func appKindSystemImage(_ preference: ToolAppKindPreference) -> String {
-        switch preference {
-        case .automatic: "wand.and.sparkles"
-        case .window: "macwindow"
-        case .menuBar: "menubar.rectangle"
-        }
     }
 
     private func checkedSelectionButton<Value: Equatable>(

--- a/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
@@ -25,6 +25,8 @@ struct PromptComposerView: View {
     let isSubmitEnabled: Bool
     let isSubmitting: Bool
     let isCodexAgentSupported: Bool
+    let customCodingAgents: [CustomCodingAgent]
+    let selectedCustomCodingAgentID: UUID?
     let showsAttachmentControls: Bool
     let supportsAttachments: Bool
     let attachments: [ToolPromptAttachment]
@@ -35,6 +37,9 @@ struct PromptComposerView: View {
     let onCancel: () -> Void
     let onAddAttachments: ([URL]) -> Void
     let onRemoveAttachment: (UUID) -> Void
+    let onSelectCustomCodingAgent: (UUID) -> Void
+    let onAddCustomCodingAgent: () -> Void
+    let onManageCustomCodingAgents: () -> Void
     @State private var pendingPermission: GeneratedAppResourcePermission?
     @State private var isAttachmentDropTargeted = false
 
@@ -285,6 +290,26 @@ struct PromptComposerView: View {
                     displayName: ToolCodingAgentPreference.codex.displayName,
                     isEnabled: isCodexAgentSupported
                 )
+                Menu("Custom") {
+                    ForEach(customCodingAgents) { agent in
+                        Button {
+                            onSelectCustomCodingAgent(agent.id)
+                        } label: {
+                            if codingAgentPreference == .custom
+                                && selectedCustomCodingAgentID == agent.id
+                            {
+                                Label(agent.name, systemImage: "checkmark")
+                            } else {
+                                Text(agent.name)
+                            }
+                        }
+                    }
+                    if !customCodingAgents.isEmpty {
+                        Divider()
+                    }
+                    Button("Add Agent…", action: onAddCustomCodingAgent)
+                    Button("Manage Agents…", action: onManageCustomCodingAgents)
+                }
             }
 
             if !supportedReasoningEfforts.isEmpty {
@@ -651,6 +676,8 @@ private struct PromptComposerPreview: View {
             isSubmitEnabled: isEditing,
             isSubmitting: false,
             isCodexAgentSupported: true,
+            customCodingAgents: [],
+            selectedCustomCodingAgentID: nil,
             showsAttachmentControls: true,
             supportsAttachments: true,
             attachments: [],
@@ -660,7 +687,10 @@ private struct PromptComposerPreview: View {
             onSubmit: {},
             onCancel: {},
             onAddAttachments: { _ in },
-            onRemoveAttachment: { _ in }
+            onRemoveAttachment: { _ in },
+            onSelectCustomCodingAgent: { _ in },
+            onAddCustomCodingAgent: {},
+            onManageCustomCodingAgents: {}
         )
         .padding()
         .frame(width: 360, height: 440)

--- a/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/PromptComposerView.swift
@@ -309,6 +309,7 @@ struct PromptComposerView: View {
                     }
                     Button("Add Agent…", action: onAddCustomCodingAgent)
                     Button("Manage Agents…", action: onManageCustomCodingAgents)
+                        .disabled(customCodingAgents.isEmpty)
                 }
             }
 

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -4,6 +4,13 @@ import Foundation
 import SwiftData
 import SwiftUI
 
+private enum CustomCodingAgentSheet: String, Identifiable {
+    case add
+    case manage
+
+    var id: String { rawValue }
+}
+
 struct ToolLibraryPopoverView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(InferenceStore.self) private var inferenceStore
@@ -39,8 +46,7 @@ struct ToolLibraryPopoverView: View {
     @State private var hasCheckedWelcomeOnboarding = false
     @State private var isShowingWelcomeOnboarding = false
     @State private var isShowingModelPicker = false
-    @State private var isShowingCustomCodingAgents = false
-    @State private var startsCustomCodingAgentSheetWithNewAgent = false
+    @State private var customCodingAgentSheet: CustomCodingAgentSheet?
     @State private var isSigningInToIronsmith = false
     @State private var isSearchPresented = false
     @State private var isPromptExpanded = false
@@ -298,11 +304,13 @@ struct ToolLibraryPopoverView: View {
         .sheet(isPresented: $isShowingModelPicker) {
             ModelPickerSheetView()
         }
-        .sheet(isPresented: $isShowingCustomCodingAgents) {
-            CustomCodingAgentSheetView(
-                store: inferenceStore.customCodingAgents,
-                startsWithNewAgent: startsCustomCodingAgentSheetWithNewAgent
-            )
+        .sheet(item: $customCodingAgentSheet) { sheet in
+            switch sheet {
+            case .add:
+                AddCustomCodingAgentSheetView(store: inferenceStore.customCodingAgents)
+            case .manage:
+                ManageCustomCodingAgentsSheetView(store: inferenceStore.customCodingAgents)
+            }
         }
     }
 
@@ -394,12 +402,10 @@ struct ToolLibraryPopoverView: View {
                     inferenceStore.generationPreferences.codingAgentPreference = .custom
                 },
                 onAddCustomCodingAgent: {
-                    startsCustomCodingAgentSheetWithNewAgent = true
-                    isShowingCustomCodingAgents = true
+                    customCodingAgentSheet = .add
                 },
                 onManageCustomCodingAgents: {
-                    startsCustomCodingAgentSheetWithNewAgent = false
-                    isShowingCustomCodingAgents = true
+                    customCodingAgentSheet = .manage
                 }
             )
             .frame(maxHeight: isPromptExpanded ? .infinity : nil)

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -39,6 +39,8 @@ struct ToolLibraryPopoverView: View {
     @State private var hasCheckedWelcomeOnboarding = false
     @State private var isShowingWelcomeOnboarding = false
     @State private var isShowingModelPicker = false
+    @State private var isShowingCustomCodingAgents = false
+    @State private var startsCustomCodingAgentSheetWithNewAgent = false
     @State private var isSigningInToIronsmith = false
     @State private var isSearchPresented = false
     @State private var isPromptExpanded = false
@@ -296,6 +298,12 @@ struct ToolLibraryPopoverView: View {
         .sheet(isPresented: $isShowingModelPicker) {
             ModelPickerSheetView()
         }
+        .sheet(isPresented: $isShowingCustomCodingAgents) {
+            CustomCodingAgentSheetView(
+                store: inferenceStore.customCodingAgents,
+                startsWithNewAgent: startsCustomCodingAgentSheetWithNewAgent
+            )
+        }
     }
 
     // The menu bar popover stays intentionally small: tool list first, prompt last.
@@ -350,7 +358,10 @@ struct ToolLibraryPopoverView: View {
                 isSubmitEnabled: canSubmitPrompt,
                 isSubmitting: toolLibraryStore.isGenerating || remixIdentityGeneratingToolID != nil,
                 isCodexAgentSupported: inferenceStore.selectedModelSupportsCodingAgentPreference(.codex),
-                showsAttachmentControls: selectedModelCanUseCodexAttachments,
+                customCodingAgents: inferenceStore.customCodingAgents.agents,
+                selectedCustomCodingAgentID: inferenceStore.customCodingAgents.selectedAgentID,
+                showsAttachmentControls: selectedModelCanUseCodexAttachments
+                    || inferenceStore.generationPreferences.codingAgentPreference == .custom,
                 supportsAttachments: selectedModelSupportsAttachments,
                 attachments: toolLibraryStore.attachments,
                 supportedReasoningEfforts: inferenceStore.selectedModelSupportedReasoningEfforts,
@@ -377,6 +388,18 @@ struct ToolLibraryPopoverView: View {
                 },
                 onRemoveAttachment: { id in
                     toolLibraryStore.removeAttachment(id: id)
+                },
+                onSelectCustomCodingAgent: { id in
+                    inferenceStore.customCodingAgents.selectedAgentID = id
+                    inferenceStore.generationPreferences.codingAgentPreference = .custom
+                },
+                onAddCustomCodingAgent: {
+                    startsCustomCodingAgentSheetWithNewAgent = true
+                    isShowingCustomCodingAgents = true
+                },
+                onManageCustomCodingAgents: {
+                    startsCustomCodingAgentSheetWithNewAgent = false
+                    isShowingCustomCodingAgents = true
                 }
             )
             .frame(maxHeight: isPromptExpanded ? .infinity : nil)

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -286,6 +286,7 @@ struct ToolLibraryPopoverView: View {
                     storePublisher.pendingCreatorProfileToolID = nil
                 },
                 onSave: {
+                    guard isStoreFeatureEnabled else { return }
                     Task {
                         await storePublisher.saveCreatorProfile(
                             inferenceStore: inferenceStore,
@@ -688,6 +689,7 @@ struct ToolLibraryPopoverView: View {
                     storePublisher.isShowingPublishSheet = false
                 },
                 onPublish: {
+                    guard isStoreFeatureEnabled else { return }
                     Task {
                         await storePublisher.publish(
                             tool,
@@ -983,6 +985,7 @@ struct ToolLibraryPopoverView: View {
                 )
             }
             guard let resumePublishingToolID,
+                isStoreFeatureEnabled,
                 inferenceStore.ironsmithSession != nil,
                 let tool = tools.first(where: { $0.id == resumePublishingToolID })
             else { return }
@@ -1023,6 +1026,7 @@ struct ToolLibraryPopoverView: View {
         }
         switch toolLibraryStore.remixIdentitySubmissionAction(
             for: tool,
+            isStoreFeatureEnabled: isStoreFeatureEnabled,
             generatesIdentity: generatesIdentityForNewRemixes,
             hasPresentedNotice: hasPresentedRemixIdentityNotice,
             isConfirmedDownloadedFromAnotherUser: storePublisher
@@ -1038,7 +1042,7 @@ struct ToolLibraryPopoverView: View {
     }
 
     private func startRemixIdentityGeneration(for tool: Tool) {
-        guard remixIdentityGenerationTask == nil else { return }
+        guard isStoreFeatureEnabled, remixIdentityGenerationTask == nil else { return }
         let operationID = UUID()
         remixIdentityGeneratingToolID = tool.id
         remixIdentityGenerationOperationID = operationID

--- a/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
+++ b/Ironsmith/Features/ToolLibrary/Rows/ToolRowView.swift
@@ -227,7 +227,9 @@ enum ToolRowGenerationStatusResolver {
         repairErrorCount: Int?,
         activeCodingAgent: ToolCodingAgent?
     ) -> String {
-        if activeCodingAgent == .codex && isCodexOwnedPhase(phase) {
+        if (activeCodingAgent == .codex || activeCodingAgent == .custom)
+            && isCodexOwnedPhase(phase)
+        {
             return "Agent is working"
         }
 

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -1138,11 +1138,13 @@ final class ToolLibraryStore {
 
     func remixIdentitySubmissionAction(
         for tool: Tool,
+        isStoreFeatureEnabled: Bool,
         generatesIdentity: Bool,
         hasPresentedNotice: Bool,
         isConfirmedDownloadedFromAnotherUser: Bool
     ) -> ToolRemixIdentitySubmissionAction {
-        guard isConfirmedDownloadedFromAnotherUser,
+        guard isStoreFeatureEnabled,
+            isConfirmedDownloadedFromAnotherUser,
             isFirstEditOfDownloadedApp(tool),
             generatesIdentity
         else { return .submit }

--- a/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
+++ b/Ironsmith/Features/ToolLibrary/ToolLibraryStore.swift
@@ -278,7 +278,9 @@ final class ToolLibraryStore {
 
     func canShowAgentOutput(for tool: Tool) -> Bool {
         activeCodingAgentByToolID[tool.id] == .codex
+            || activeCodingAgentByToolID[tool.id] == .custom
             || CodexAgentTranscriptReader.hasTranscript(for: tool.packageRootURL)
+            || CustomCodingAgentTranscriptReader.hasTranscript(for: tool.packageRootURL)
     }
 
     func refreshRestoreAvailability(for tools: [Tool]) async {

--- a/IronsmithTests/App/AppRoutingTests.swift
+++ b/IronsmithTests/App/AppRoutingTests.swift
@@ -111,7 +111,8 @@ struct AppRoutingTests {
             },
             openToolLibraryPopover: {
                 popoverCapture.open()
-            }
+            },
+            isStoreFeatureEnabled: { true }
         )
 
         store.open(.store(.publishedApp("app-1")))
@@ -142,6 +143,30 @@ struct AppRoutingTests {
 
         #expect(storeCapture.openCount == 0)
         #expect(store.pendingStoreRoute == nil)
+    }
+
+    @MainActor
+    @Test
+    func routeStoreIgnoresPublishingButKeepsToolSelectionWhenStoreFeatureIsDisabled() throws {
+        let popoverCapture = SettingsWindowOpenCapture()
+        let toolID = try #require(UUID(uuidString: "11111111-2222-4333-8444-555555555555"))
+        let store = IronsmithRouteStore(
+            openSettingsWindow: {},
+            openToolLibraryPopover: {
+                popoverCapture.open()
+            },
+            isStoreFeatureEnabled: { false }
+        )
+
+        store.open(.toolLibrary(.publishTool(toolID)))
+
+        #expect(popoverCapture.openCount == 0)
+        #expect(store.pendingToolLibraryRoute == nil)
+
+        store.open(.toolLibrary(.selectTool(id: toolID, focusPrompt: true)))
+
+        #expect(popoverCapture.openCount == 1)
+        #expect(store.consumeToolLibraryRoute() == .selectTool(id: toolID, focusPrompt: true))
     }
 
     @MainActor

--- a/IronsmithTests/App/AuxiliaryWindowControllerTests.swift
+++ b/IronsmithTests/App/AuxiliaryWindowControllerTests.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import Testing
+@testable import Ironsmith
+
+struct AuxiliaryWindowControllerTests {
+    @MainActor
+    @Test
+    func settingsContentIsNotCreatedUntilSettingsAreShown() {
+        var rootViewBuildCount = 0
+        let controller = IronsmithSettingsWindowController {
+            rootViewBuildCount += 1
+            return AnyView(EmptyView())
+        }
+
+        #expect(!controller.hasCreatedWindow)
+        #expect(rootViewBuildCount == 0)
+    }
+
+    @MainActor
+    @Test
+    func agentOutputContentIsNotCreatedUntilAgentOutputIsShown() {
+        var rootViewBuildCount = 0
+        let controller = IronsmithAgentOutputWindowController { _ in
+            rootViewBuildCount += 1
+            return AnyView(EmptyView())
+        }
+
+        #expect(!controller.hasCreatedWindow)
+        #expect(rootViewBuildCount == 0)
+    }
+}

--- a/IronsmithTests/App/MenuBarControllerTests.swift
+++ b/IronsmithTests/App/MenuBarControllerTests.swift
@@ -1,0 +1,66 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import Ironsmith
+
+struct MenuBarControllerTests {
+    @MainActor
+    @Test
+    func applicationDeactivationClosesShownPopover() {
+        let popover = TestPopover(isShown: true)
+        let presentationStore = MenuBarPopoverPresentationStore()
+        presentationStore.didShow()
+        let controller = IronsmithMenuBarController(
+            rootView: AnyView(EmptyView()),
+            presentationStore: presentationStore,
+            popover: popover
+        )
+
+        controller.applicationDidResignActive()
+
+        #expect(popover.closeCount == 1)
+        #expect(!presentationStore.isShown)
+        #expect(presentationStore.closeCount == 1)
+    }
+
+    @MainActor
+    @Test
+    func applicationDeactivationDoesNothingWhenPopoverIsClosed() {
+        let popover = TestPopover(isShown: false)
+        let presentationStore = MenuBarPopoverPresentationStore()
+        let controller = IronsmithMenuBarController(
+            rootView: AnyView(EmptyView()),
+            presentationStore: presentationStore,
+            popover: popover
+        )
+
+        controller.applicationDidResignActive()
+
+        #expect(popover.closeCount == 0)
+        #expect(presentationStore.closeCount == 0)
+    }
+}
+
+private final class TestPopover: NSPopover {
+    private var reportsShown: Bool
+    private(set) var closeCount = 0
+
+    init(isShown: Bool) {
+        reportsShown = isShown
+        super.init()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isShown: Bool {
+        reportsShown
+    }
+
+    override func performClose(_ sender: Any?) {
+        closeCount += 1
+        reportsShown = false
+    }
+}

--- a/IronsmithTests/App/StoreWindowControllerTests.swift
+++ b/IronsmithTests/App/StoreWindowControllerTests.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import Testing
+@testable import Ironsmith
+
+struct StoreWindowControllerTests {
+    @MainActor
+    @Test
+    func disabledStoreDoesNotLoadStoreContent() {
+        var rootViewBuildCount = 0
+        let controller = IronsmithStoreWindowController(
+            rootViewBuilder: {
+                rootViewBuildCount += 1
+                return AnyView(EmptyView())
+            },
+            isStoreFeatureEnabled: { false }
+        )
+
+        controller.show()
+
+        #expect(!controller.hasCreatedWindow)
+        #expect(rootViewBuildCount == 0)
+    }
+}

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineCodexAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineCodexAgentTests.swift
@@ -1053,7 +1053,7 @@ extension AgentPipelineTests {
     }
 
     @Test
-    func codexAgentStatusOneSuggestsUsageLimit() {
+    func codexAgentStatusOnePresentsUsageAsOnePossibleCause() {
         let transcriptURL = URL(fileURLWithPath: "/tmp/agent.jsonl")
         let error = CodexAgentError.commandFailed(
             status: 1,
@@ -1063,7 +1063,19 @@ extension AgentPipelineTests {
 
         #expect(
             error.errorDescription
-                == "Codex couldn't continue. You might be out of Codex usage. Check your usage in Codex and try again after it resets. Transcript: /tmp/agent.jsonl"
+                == "The coding agent couldn't continue. You might be out of usage, but this can also be caused by another agent error. Check your usage and the transcript, then try again. Transcript: /tmp/agent.jsonl"
+        )
+    }
+
+    @Test
+    func sharedCodingAgentErrorsUseGenericAgentLanguage() {
+        #expect(
+            CodingAgentError.protectedFileChanged("Package.swift").errorDescription
+                == "The coding agent changed Package.swift, but Ironsmith only allows the agent to edit ContentView.swift."
+        )
+        #expect(
+            CodingAgentError.missingContentView.errorDescription
+                == "The coding agent did not create ContentView.swift."
         )
     }
 
@@ -1306,7 +1318,7 @@ extension AgentPipelineTests {
             codexAgentAuthentication: .apiKey("sk-test")
         )
 
-        await #expect(throws: CodexAgentError.protectedFileChanged("Package.swift")) {
+        await #expect(throws: CodingAgentError.protectedFileChanged("Package.swift")) {
             _ = try await runtime.generateTool(for: "Make a Codex demo", settings: .default)
         }
 

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineTestSupport.swift
@@ -24,8 +24,10 @@ extension AgentPipelineTests {
         promptRefinementEnabled: Bool = true,
         versionBackupClient: ToolVersionBackupClient = .live,
         codexAgentClient: CodexAgentClient = .unconfigured,
+        customCodingAgentClient: CustomCodingAgentClient = .unconfigured,
         codingAgentModelIdentifier: String = "",
         codexAgentAuthentication: CodexAgentAuthentication? = nil,
+        customCodingAgent: CustomCodingAgent? = nil,
         afterLanguageModelInvocation: @escaping @MainActor @Sendable () async -> Void = {}
     ) -> SingleFileToolGenerationRuntime {
         let languageModelContext = AgentLanguageModelContext(
@@ -35,6 +37,7 @@ extension AgentPipelineTests {
             promptRefinementEnabled: promptRefinementEnabled,
             codingAgentModelIdentifier: codingAgentModelIdentifier,
             codexAgentAuthentication: codexAgentAuthentication,
+            customCodingAgent: customCodingAgent,
             afterLanguageModelInvocation: afterLanguageModelInvocation
         )
         let dependencies = ToolGenerationRuntimeDependencies(
@@ -46,7 +49,8 @@ extension AgentPipelineTests {
             planningClient: planningClient,
             promptRefinementClient: promptRefinementClient,
             versionBackupClient: versionBackupClient,
-            codexAgentClient: codexAgentClient
+            codexAgentClient: codexAgentClient,
+            customCodingAgentClient: customCodingAgentClient
         )
         return SingleFileToolGenerationRuntime(
             context: ToolGenerationRuntimeContext(

--- a/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
@@ -9,7 +9,10 @@ struct CustomCodingAgentTests {
     func presetsAreEditableRunnerConfigurations() {
         let claude = CustomCodingAgentPreset.claudeCode.agent
         #expect(claude.name == "Claude Code")
-        #expect(claude.command == "claude -p {{prompt}}")
+        #expect(
+            claude.command
+                == "claude -p --permission-mode auto --output-format stream-json --verbose --model sonnet {{prompt}}"
+        )
         #expect(claude.promptDelivery == .placeholder)
 
         let openCode = CustomCodingAgentPreset.openCode.agent
@@ -130,6 +133,51 @@ struct CustomCodingAgentTests {
         let persisted = try CustomCodingAgentTranscriptReader.entries(for: packageRoot)
         #expect(persisted.count == 2)
         #expect(CustomCodingAgentTranscriptReader.hasTranscript(for: packageRoot))
+    }
+
+    @Test
+    func displayEntriesShowOnlyClaudeAssistantTextWhilePreservingOtherOutput() {
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let entries = [
+            CustomCodingAgentOutput(
+                timestamp: timestamp,
+                runner: "Claude Code",
+                stream: .stdout,
+                text: #"{"type":"system","subtype":"init","session_id":"session"}"#
+            ),
+            CustomCodingAgentOutput(
+                timestamp: timestamp,
+                runner: "Claude Code",
+                stream: .stdout,
+                text: #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"private"},{"type":"text","text":"Now I'll write the ContentView."},{"type":"tool_use","name":"Write"}]}}"#
+            ),
+            CustomCodingAgentOutput(
+                timestamp: timestamp,
+                runner: "Claude Code",
+                stream: .stdout,
+                text: #"{"type":"result","session_id":"session","result":"Duplicate final text"}"#
+            ),
+            CustomCodingAgentOutput(
+                timestamp: timestamp,
+                runner: "Other Runner",
+                stream: .stdout,
+                text: #"{"status":"ordinary JSON"}"#
+            ),
+            CustomCodingAgentOutput(
+                timestamp: timestamp,
+                runner: "Claude Code",
+                stream: .stderr,
+                text: "warning"
+            ),
+        ]
+
+        let displayed = CustomCodingAgentTranscriptReader.displayEntries(from: entries)
+
+        #expect(displayed.map(\.text) == [
+            "Now I'll write the ContentView.",
+            #"{"status":"ordinary JSON"}"#,
+            "warning",
+        ])
     }
 
     @Test(.timeLimit(.minutes(1)))

--- a/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
@@ -97,6 +97,94 @@ struct CustomCodingAgentTests {
     }
 
     @Test
+    func testClientUsesExactPromptAndRemovesItsIsolatedWorkspace() async throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "custom-agent-test-client-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let requestRecorder = CustomAgentTestRequestRecorder()
+        let outputRecorder = CustomOutputRecorder()
+        let agent = CustomCodingAgent(
+            name: "Test Runner",
+            command: "runner {{prompt}}"
+        )
+        let agentClient = CustomCodingAgentClient { request in
+            await requestRecorder.record(request)
+            await request.onOutput(
+                CustomCodingAgentOutput(
+                    timestamp: .now,
+                    runner: request.agent.name,
+                    stream: .stdout,
+                    text: "Test successful!"
+                )
+            )
+            return CustomCodingAgentResult(
+                terminationStatus: 0,
+                transcriptURL: request.packageRootURL.appendingPathComponent("test.jsonl")
+            )
+        }
+        let client = CustomCodingAgentTestClient.live(
+            agentClient: agentClient,
+            temporaryDirectory: temporaryDirectory
+        )
+
+        try await client.run(agent) { output in
+            await outputRecorder.append(output)
+        }
+
+        let captured = try #require(await requestRecorder.request)
+        #expect(captured.agent == agent)
+        #expect(captured.prompt == "This is a test, respond only with 'Test successful!'")
+        #expect(captured.packageRootExisted)
+        #expect(!FileManager.default.fileExists(atPath: captured.packageRootURL.path))
+        #expect(await outputRecorder.outputs.map(\.text) == ["Test successful!"])
+    }
+
+    @MainActor
+    @Test
+    func testStoreRevealsOnlyDisplayableAgentOutput() async {
+        let client = CustomCodingAgentTestClient { _, onOutput in
+            await onOutput(
+                CustomCodingAgentOutput(
+                    timestamp: .now,
+                    runner: "Claude Code",
+                    stream: .stdout,
+                    text: #"{"type":"system","subtype":"init","session_id":"session"}"#
+                )
+            )
+            await onOutput(
+                CustomCodingAgentOutput(
+                    timestamp: .now,
+                    runner: "Claude Code",
+                    stream: .stdout,
+                    text: #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Test successful!"}]}}"#
+                )
+            )
+        }
+        let testStore = CustomCodingAgentTestStore(client: client)
+        let agent = CustomCodingAgent(
+            name: "Claude Code",
+            command: "claude",
+            promptDelivery: .standardInput
+        )
+
+        #expect(testStore.output == nil)
+        testStore.run(agent: agent) { $0 }
+        await AgentPipelineTests.eventually {
+            await MainActor.run { !testStore.isRunning }
+        }
+
+        #expect(testStore.output == "Test successful!")
+        #expect(testStore.errorMessage == nil)
+    }
+
+    @Test
     func liveClientStreamsBothOutputsAndWritesJSONL() async throws {
         let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
             "custom-agent-test-\(UUID().uuidString)",
@@ -359,5 +447,25 @@ private actor CustomOutputRecorder {
 
     func append(_ output: CustomCodingAgentOutput) {
         outputs.append(output)
+    }
+}
+
+private actor CustomAgentTestRequestRecorder {
+    struct Request: Sendable {
+        let agent: CustomCodingAgent
+        let prompt: String
+        let packageRootURL: URL
+        let packageRootExisted: Bool
+    }
+
+    private(set) var request: Request?
+
+    func record(_ request: CustomCodingAgentRequest) {
+        self.request = Request(
+            agent: request.agent,
+            prompt: request.prompt,
+            packageRootURL: request.packageRootURL,
+            packageRootExisted: FileManager.default.fileExists(atPath: request.packageRootURL.path)
+        )
     }
 }

--- a/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
@@ -11,9 +11,9 @@ struct CustomCodingAgentTests {
         #expect(claude.name == "Claude Code")
         #expect(
             claude.command
-                == "claude -p --permission-mode auto --output-format stream-json --verbose --model sonnet {{prompt}}"
+                == "claude -p --permission-mode auto --output-format stream-json --verbose --model sonnet"
         )
-        #expect(claude.promptDelivery == .placeholder)
+        #expect(claude.promptDelivery == .standardInput)
 
         let openCode = CustomCodingAgentPreset.openCode.agent
         #expect(openCode.name == "OpenCode")
@@ -149,7 +149,7 @@ struct CustomCodingAgentTests {
                 timestamp: timestamp,
                 runner: "Claude Code",
                 stream: .stdout,
-                text: #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"private"},{"type":"text","text":"Now I'll write the ContentView."},{"type":"tool_use","name":"Write"}]}}"#
+                text: #"{"type":"assistant","message":{"role":"assistant","content":[{"type":"thinking","thinking":"Considering the simplest layout.","signature":"opaque-signature"},{"type":"thinking","thinking":"","signature":"encrypted-only"},{"type":"text","text":"Now I'll write the ContentView."},{"type":"tool_use","name":"Write"}]}}"#
             ),
             CustomCodingAgentOutput(
                 timestamp: timestamp,
@@ -174,6 +174,7 @@ struct CustomCodingAgentTests {
         let displayed = CustomCodingAgentTranscriptReader.displayEntries(from: entries)
 
         #expect(displayed.map(\.text) == [
+            "Considering the simplest layout.",
             "Now I'll write the ContentView.",
             #"{"status":"ordinary JSON"}"#,
             "warning",

--- a/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
@@ -1,0 +1,314 @@
+import Foundation
+import Testing
+@testable import Ironsmith
+
+@Suite(.serialized)
+struct CustomCodingAgentTests {
+    @MainActor
+    @Test
+    func presetsAreEditableRunnerConfigurations() {
+        let claude = CustomCodingAgentPreset.claudeCode.agent
+        #expect(claude.name == "Claude Code")
+        #expect(claude.command == "claude -p {{prompt}}")
+        #expect(claude.promptDelivery == .placeholder)
+
+        let openCode = CustomCodingAgentPreset.openCode.agent
+        #expect(openCode.name == "OpenCode")
+        #expect(openCode.command == "opencode run {{prompt}}")
+    }
+
+    @MainActor
+    @Test
+    func storeValidatesPersistsAndClearsDeletedSelection() throws {
+        let suiteName = "CustomCodingAgentTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let store = CustomCodingAgentStore(userDefaults: defaults)
+        let saved = try store.save(
+            CustomCodingAgent(
+                name: "  My Agent  ",
+                command: "  runner {{prompt}}  "
+            )
+        )
+        store.selectedAgentID = saved.id
+        #expect(saved.name == "My Agent")
+        #expect(saved.command == "runner {{prompt}}")
+
+        let reloaded = CustomCodingAgentStore(userDefaults: defaults)
+        #expect(reloaded.agents == [saved])
+        #expect(reloaded.selectedAgent == saved)
+
+        #expect(throws: CustomCodingAgentValidationError.duplicateName) {
+            try reloaded.save(CustomCodingAgent(name: "my agent", command: "other {{prompt}}"))
+        }
+        #expect(throws: CustomCodingAgentValidationError.invalidPlaceholderCount) {
+            try reloaded.save(CustomCodingAgent(name: "Bad", command: "runner"))
+        }
+        #expect(throws: CustomCodingAgentValidationError.placeholderNotAllowedWithStandardInput) {
+            try reloaded.save(
+                CustomCodingAgent(
+                    name: "Stdin",
+                    command: "runner {{prompt}}",
+                    promptDelivery: .standardInput
+                )
+            )
+        }
+
+        reloaded.delete(id: saved.id)
+        #expect(reloaded.agents.isEmpty)
+        #expect(reloaded.selectedAgentID == nil)
+    }
+
+    @Test
+    func placeholderPromptIsPassedAsAQuotedPositionalArgument() {
+        let prompt = #"hello $(touch /tmp/should-not-run) ' " world"#
+        let agent = CustomCodingAgent(name: "Runner", command: "tool --prompt {{prompt}}")
+        let request = CustomCodingAgentRequest(
+            agent: agent,
+            packageRootURL: URL(fileURLWithPath: "/tmp"),
+            prompt: prompt
+        )
+
+        #expect(CustomCodingAgentClient.shellArguments(for: request) == [
+            "-lc",
+            #"tool --prompt "$1""#,
+            "Runner",
+            prompt,
+        ])
+    }
+
+    @Test
+    func standardInputDoesNotPutPromptInShellArguments() {
+        let agent = CustomCodingAgent(
+            name: "Runner",
+            command: "tool --stdin",
+            promptDelivery: .standardInput
+        )
+        let request = CustomCodingAgentRequest(
+            agent: agent,
+            packageRootURL: URL(fileURLWithPath: "/tmp"),
+            prompt: "secret prompt"
+        )
+        #expect(CustomCodingAgentClient.shellArguments(for: request) == ["-lc", "tool --stdin"])
+    }
+
+    @Test
+    func liveClientStreamsBothOutputsAndWritesJSONL() async throws {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "custom-agent-test-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: packageRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: packageRoot) }
+
+        let recorder = CustomOutputRecorder()
+        let agent = CustomCodingAgent(
+            name: "Test Runner",
+            command: "read prompt; printf 'out:%s\\n' \"$prompt\"; printf 'err:%s\\n' \"$prompt\" >&2",
+            promptDelivery: .standardInput
+        )
+        let result = try await CustomCodingAgentClient.live.run(
+            CustomCodingAgentRequest(
+                agent: agent,
+                packageRootURL: packageRoot,
+                prompt: "hello stdin"
+            ) { output in
+                await recorder.append(output)
+            }
+        )
+
+        #expect(result.terminationStatus == 0)
+        #expect(
+            result.transcriptURL.deletingLastPathComponent()
+                == ToolPackageLayout.customAgentTranscriptsDirectoryURL(for: packageRoot)
+        )
+        #expect(result.transcriptURL.lastPathComponent.hasPrefix("test-runner-"))
+        let streamed = await recorder.outputs
+        #expect(streamed.contains { $0.stream == .stdout && $0.text == "out:hello stdin" })
+        #expect(streamed.contains { $0.stream == .stderr && $0.text == "err:hello stdin" })
+        let persisted = try CustomCodingAgentTranscriptReader.entries(for: packageRoot)
+        #expect(persisted.count == 2)
+        #expect(CustomCodingAgentTranscriptReader.hasTranscript(for: packageRoot))
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func liveClientDrainsOutputBeforeSendingStandardInput() async throws {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "custom-agent-pipe-test-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: packageRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: packageRoot) }
+
+        let agent = CustomCodingAgent(
+            name: "Pipe Runner",
+            command: "dd if=/dev/zero bs=1024 count=128 2>/dev/null | tr '\\0' x; printf '\\n'; read prompt; printf 'received:%s\\n' \"$prompt\"",
+            promptDelivery: .standardInput
+        )
+        _ = try await CustomCodingAgentClient.live.run(
+            CustomCodingAgentRequest(
+                agent: agent,
+                packageRootURL: packageRoot,
+                prompt: "after output"
+            )
+        )
+        let entries = try CustomCodingAgentTranscriptReader.entries(for: packageRoot)
+        #expect(entries.contains { $0.text == "received:after output" })
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func cancellingLiveClientTerminatesCompoundCommandGroup() async throws {
+        let packageRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "custom-agent-cancel-test-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: packageRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: packageRoot) }
+
+        let agent = CustomCodingAgent(
+            name: "Compound Runner",
+            command: "trap '' TERM; (trap '' TERM; sleep 30) & wait",
+            promptDelivery: .standardInput
+        )
+        let task = Task {
+            try await CustomCodingAgentClient.live.run(
+                CustomCodingAgentRequest(
+                    agent: agent,
+                    packageRootURL: packageRoot,
+                    prompt: "cancel"
+                )
+            )
+        }
+        try await Task.sleep(for: .milliseconds(100))
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+    }
+
+    @Test
+    func workspacePromptIncludesReadOnlyAttachmentPaths() {
+        let attachmentURL = URL(fileURLWithPath: "/tmp/reference image.png")
+        let prompt = CustomCodingAgentPrompt.compose(
+            userPrompt: "Build it",
+            displayName: "Example",
+            executableName: "Example",
+            appKind: .window,
+            sandboxEnabled: true,
+            attachments: [
+                ToolPersistedPromptAttachment(
+                    fileName: "reference image.png",
+                    url: attachmentURL,
+                    isImage: true
+                )
+            ]
+        )
+        #expect(prompt.contains(attachmentURL.path))
+        #expect(prompt.contains("strictly as read-only context"))
+        #expect(prompt.contains("Create or edit only Sources/Example/ContentView.swift"))
+    }
+
+    @MainActor
+    @Test
+    func selectedRunnerFlowsIntoCustomPipelineContext() async throws {
+        let preferences = InferenceTests.generationPreferences()
+        preferences.codingAgentPreference = .custom
+        let suiteName = "CustomCodingAgentContextTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let runners = CustomCodingAgentStore(userDefaults: defaults)
+        let runner = try runners.save(
+            CustomCodingAgent(name: "CLI", command: "agent {{prompt}}")
+        )
+        runners.selectedAgentID = runner.id
+
+        let store = InferenceStore(
+            dependencies: InferenceTests.dependencies(),
+            generationPreferences: preferences,
+            customCodingAgents: runners,
+            appleFoundationModelPreferenceStore: InferenceTests.appleFoundationModelPreferenceStore()
+        )
+        let provider = try #require(ProviderCatalog.makeProvider(for: .ollama))
+        let model = ModelConfig(
+            identifier: "test-model",
+            displayName: "Test Model",
+            providerIdentifier: provider.identifier,
+            source: .remote,
+            installState: .installed
+        )
+        store.providers = [provider]
+        store.remoteModels = [model]
+        store.selectedModelID = model.selectionIdentifier
+
+        let context = try await store.makeSelectedAgentLanguageModelContext()
+        #expect(context.pipelineConfiguration == .custom())
+        #expect(context.customCodingAgent == runner)
+        #expect(context.codexAgentAuthentication == nil)
+        #expect(context.codingAgentSupportsImageInput)
+    }
+
+    @MainActor
+    @Test
+    func failedCustomRunnerRestoresProtectedWorkspaceFiles() async throws {
+        let toolsDirectory = try AgentPipelineTests.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: toolsDirectory) }
+
+        let runner = CustomCodingAgent(name: "Failing Runner", command: "agent {{prompt}}")
+        let client = CustomCodingAgentClient { request in
+            let layout = ToolPackageLayout(
+                packageRootURL: request.packageRootURL,
+                executableName: "CustomFailure"
+            )
+            try "corrupted".write(
+                to: layout.packageManifestURL,
+                atomically: true,
+                encoding: .utf8
+            )
+            try "struct Extra {}".write(
+                to: layout.sourceDirectoryURL.appendingPathComponent("Extra.swift"),
+                atomically: true,
+                encoding: .utf8
+            )
+            throw CustomCodingAgentError.commandFailed(
+                status: 7,
+                transcriptURL: request.packageRootURL.appendingPathComponent("failure.jsonl")
+            )
+        }
+        let runtime = AgentPipelineTests.makeRuntime(
+            languageModel: EmptyLanguageModel(),
+            pipelineConfiguration: .custom(),
+            toolsDirectoryURL: toolsDirectory,
+            processClient: AgentPipelineTests.successfulProcessClient(),
+            planningClient: ToolGenerationPlanningClient { _ in
+                ToolCreationPlan(displayName: "Custom Failure", iconPrompt: "")
+            },
+            customCodingAgentClient: client,
+            customCodingAgent: runner
+        )
+
+        await #expect(throws: CustomCodingAgentError.self) {
+            _ = try await runtime.generateTool(for: "Build a failing app", settings: .default)
+        }
+
+        let packageRoot = toolsDirectory.appendingPathComponent("custom-failure", isDirectory: true)
+        let layout = ToolPackageLayout(
+            packageRootURL: packageRoot,
+            executableName: "CustomFailure"
+        )
+        let manifest = try String(contentsOf: layout.packageManifestURL, encoding: .utf8)
+        #expect(manifest.contains("// swift-tools-version"))
+        #expect(!manifest.contains("corrupted"))
+        #expect(!FileManager.default.fileExists(
+            atPath: layout.sourceDirectoryURL.appendingPathComponent("Extra.swift").path
+        ))
+    }
+}
+
+private actor CustomOutputRecorder {
+    private(set) var outputs: [CustomCodingAgentOutput] = []
+
+    func append(_ output: CustomCodingAgentOutput) {
+        outputs.append(output)
+    }
+}

--- a/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
+++ b/IronsmithTests/Features/ToolLibrary/ToolLibraryGenerationTests.swift
@@ -34,6 +34,7 @@ extension ToolLibraryTests {
         #expect(
             store.remixIdentitySubmissionAction(
                 for: tool,
+                isStoreFeatureEnabled: true,
                 generatesIdentity: true,
                 hasPresentedNotice: false,
                 isConfirmedDownloadedFromAnotherUser: true
@@ -42,6 +43,7 @@ extension ToolLibraryTests {
         #expect(
             store.remixIdentitySubmissionAction(
                 for: tool,
+                isStoreFeatureEnabled: true,
                 generatesIdentity: true,
                 hasPresentedNotice: true,
                 isConfirmedDownloadedFromAnotherUser: true
@@ -50,6 +52,7 @@ extension ToolLibraryTests {
         #expect(
             store.remixIdentitySubmissionAction(
                 for: tool,
+                isStoreFeatureEnabled: true,
                 generatesIdentity: false,
                 hasPresentedNotice: false,
                 isConfirmedDownloadedFromAnotherUser: true
@@ -58,9 +61,19 @@ extension ToolLibraryTests {
         #expect(
             store.remixIdentitySubmissionAction(
                 for: tool,
+                isStoreFeatureEnabled: true,
                 generatesIdentity: true,
                 hasPresentedNotice: false,
                 isConfirmedDownloadedFromAnotherUser: false
+            ) == .submit
+        )
+        #expect(
+            store.remixIdentitySubmissionAction(
+                for: tool,
+                isStoreFeatureEnabled: false,
+                generatesIdentity: true,
+                hasPresentedNotice: false,
+                isConfirmedDownloadedFromAnotherUser: true
             ) == .submit
         )
         try (source + "// changed\n").write(
@@ -72,6 +85,7 @@ extension ToolLibraryTests {
         #expect(
             store.remixIdentitySubmissionAction(
                 for: tool,
+                isStoreFeatureEnabled: true,
                 generatesIdentity: true,
                 hasPresentedNotice: false,
                 isConfirmedDownloadedFromAnotherUser: true


### PR DESCRIPTION
## Summary
- add editable custom coding-agent runners with Claude Code and OpenCode presets
- support prompt delivery through standard input or command placeholders, uploaded attachments, transcripts, streamed agent output, and runner testing
- keep unfinished Store, publishing, creator-profile, and remix entry points behind the Store feature flag
- use small routing, presentation, and action guards without runtime flag-transition teardown

## Testing
- script/test.sh --filter AppRoutingTests
- script/test.sh --filter ToolLibraryGenerationTests
- script/test.sh
- 594 tests passed across 17 suites
- git diff --check