### PR TITLE
Select the first available DeepSeek Flash model after Ironsmith sign-in

### DIFF
--- a/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/InferenceStore.swift
@@ -27,8 +27,6 @@ enum InferenceMessages {
 @MainActor
 @Observable
 final class InferenceStore {
-    static let onboardingPreferredIronsmithModelIdentifier = "deepseek/deepseek-v4-flash"
-
     struct ProviderChoice: Identifiable, Hashable {
         let kind: ProviderKind
         let title: String

--- a/Ironsmith/Core/Inference/InferenceStore/ModelSelection.swift
+++ b/Ironsmith/Core/Inference/InferenceStore/ModelSelection.swift
@@ -44,6 +44,22 @@ extension InferenceStore {
         return true
     }
 
+    @discardableResult
+    func selectPreferredIronsmithModel() -> Bool {
+        guard let provider = providers.first(where: { $0.kind == .ironsmith }),
+            let model = remoteModels.first(where: {
+                guard $0.providerIdentifier == provider.identifier else { return false }
+                let searchableName = "\($0.identifier) \($0.displayName)".lowercased()
+                return searchableName.contains("deepseek") && searchableName.contains("flash")
+            })
+        else {
+            return false
+        }
+
+        selectModel(model.selectionIdentifier)
+        return true
+    }
+
     func reconcileSelectedModel() {
         if let selectedModelID,
             availableModels.contains(where: { $0.selectionIdentifier == selectedModelID })

--- a/Ironsmith/Features/Launch/Onboarding/IronsmithWelcomeOnboardingSheetView.swift
+++ b/Ironsmith/Features/Launch/Onboarding/IronsmithWelcomeOnboardingSheetView.swift
@@ -166,9 +166,7 @@ struct IronsmithWelcomeOnboardingSheetView: View {
             await MainActor.run {
                 isSigningIn = false
                 guard didSignIn else { return }
-                inferenceStore.selectIronsmithModel(
-                    identifier: InferenceStore.onboardingPreferredIronsmithModelIdentifier
-                )
+                inferenceStore.selectPreferredIronsmithModel()
                 onComplete()
             }
         }

--- a/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
+++ b/Ironsmith/Features/ToolLibrary/Popover/ToolLibraryPopoverView.swift
@@ -980,9 +980,7 @@ struct ToolLibraryPopoverView: View {
             await MainActor.run {
                 isSigningInToIronsmith = false
                 guard didFinishProviderSetup else { return }
-                inferenceStore.selectIronsmithModel(
-                    identifier: InferenceStore.onboardingPreferredIronsmithModelIdentifier
-                )
+                inferenceStore.selectPreferredIronsmithModel()
             }
             guard let resumePublishingToolID,
                 isStoreFeatureEnabled,

--- a/IronsmithTests/Core/Inference/InferenceIronsmithAccountTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceIronsmithAccountTests.swift
@@ -96,11 +96,12 @@ extension InferenceTests {
         let container = try IronsmithModelContainerFactory.make(isRunningTests: true)
         let context = ModelContext(container)
         let callbackURL = URL(string: "com.jeidoban.ironsmith://auth/callback?code=test")!
+        let deepSeekFlashVariant = "deepseek/deepseek-v4-flash-0324"
         let inferenceStore = InferenceStore(
             dependencies: Self.dependencies(
                 remoteModelIDs: [
                     "openai/gpt-5",
-                    InferenceStore.onboardingPreferredIronsmithModelIdentifier,
+                    deepSeekFlashVariant,
                 ],
                 accountClient: Self.accountClient()
             ),
@@ -111,13 +112,11 @@ extension InferenceTests {
         let didSignIn = await inferenceStore.signInToIronsmithWithAppleOAuth { _ in
             callbackURL
         }
-        let didSelectDeepSeek = inferenceStore.selectIronsmithModel(
-            identifier: InferenceStore.onboardingPreferredIronsmithModelIdentifier
-        )
+        let didSelectDeepSeek = inferenceStore.selectPreferredIronsmithModel()
 
         #expect(didSignIn)
         #expect(didSelectDeepSeek)
-        #expect(inferenceStore.selectedModel?.identifier == InferenceStore.onboardingPreferredIronsmithModelIdentifier)
+        #expect(inferenceStore.selectedModel?.identifier == deepSeekFlashVariant)
         #expect(inferenceStore.modelSelection.selectedModelID == inferenceStore.selectedModelID)
     }
 

--- a/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
+++ b/IronsmithTests/Core/Inference/InferenceModelSelectionAndOllamaTests.swift
@@ -629,26 +629,43 @@ extension InferenceTests {
 
     @MainActor
     @Test
-    func selectIronsmithModelSelectsMatchingRemoteModel() throws {
+    func selectPreferredIronsmithModelSelectsFirstDeepSeekFlashVariant() throws {
         let store = InferenceStore(
             dependencies: Self.dependencies(),
             modelSelection: Self.modelSelection()
         )
         let provider = try #require(ProviderCatalog.makeProvider(for: .ironsmith))
+        let firstDeepSeekFlashModel = ModelConfig(
+            identifier: "deepseek/deepseek-v4-flash-0324",
+            displayName: "DeepSeek V4 Flash 0324",
+            providerIdentifier: provider.identifier,
+            source: .remote,
+            installState: .installed
+        )
         let deepSeekModel = ModelConfig(
-            identifier: InferenceStore.onboardingPreferredIronsmithModelIdentifier,
-            displayName: "DeepSeek V4 Flash",
+            identifier: "deepseek/deepseek-v4-flash-671b",
+            displayName: "DeepSeek V4 Flash 671B",
             providerIdentifier: provider.identifier,
             source: .remote,
             installState: .installed
         )
 
         store.providers = [provider]
-        store.remoteModels = [deepSeekModel]
+        store.remoteModels = [
+            ModelConfig(
+                identifier: "openai/gpt-5",
+                displayName: "GPT-5",
+                providerIdentifier: provider.identifier,
+                source: .remote,
+                installState: .installed
+            ),
+            firstDeepSeekFlashModel,
+            deepSeekModel,
+        ]
 
-        #expect(store.selectIronsmithModel(identifier: InferenceStore.onboardingPreferredIronsmithModelIdentifier))
-        #expect(store.selectedModelID == deepSeekModel.selectionIdentifier)
-        #expect(store.modelSelection.selectedModelID == deepSeekModel.selectionIdentifier)
+        #expect(store.selectPreferredIronsmithModel())
+        #expect(store.selectedModelID == firstDeepSeekFlashModel.selectionIdentifier)
+        #expect(store.modelSelection.selectedModelID == firstDeepSeekFlashModel.selectionIdentifier)
     }
 
     @MainActor
@@ -671,7 +688,7 @@ extension InferenceTests {
         store.remoteModels = [selectedModel]
         store.selectModel(selectedModel.selectionIdentifier)
 
-        #expect(!store.selectIronsmithModel(identifier: InferenceStore.onboardingPreferredIronsmithModelIdentifier))
+        #expect(!store.selectPreferredIronsmithModel())
         #expect(store.selectedModelID == selectedModel.selectionIdentifier)
         #expect(store.modelSelection.selectedModelID == selectedModel.selectionIdentifier)
     }


### PR DESCRIPTION
## Summary

- Replace the hard-coded Ironsmith onboarding model identifier with dynamic DeepSeek Flash model selection.
- Reuse the preferred-model selection after onboarding and provider setup.
- Update inference tests to cover model variants and first-match behavior.

## Testing

- Updated Swift Testing coverage for sign-in selection, variant matching, and fallback behavior.