### PR TITLE
Fix popover layering, opaque generated icons, and shell agent invocation

### DIFF
--- a/Ironsmith/App/Controllers/IronsmithMenuBarController.swift
+++ b/Ironsmith/App/Controllers/IronsmithMenuBarController.swift
@@ -33,6 +33,7 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
 
         configurePopover()
         configureStatusItem()
+        configureWorkspaceApplicationObservation()
     }
 
     private func configurePopover() {
@@ -72,8 +73,82 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
         showPopover()
     }
 
-    func applicationDidResignActive() {
-        closePopover(nil)
+    static func popoverWindowLevel(
+        activatedApplicationBundleIdentifier: String?,
+        isCurrentApplication: Bool
+    ) -> NSWindow.Level {
+        if isCurrentApplication || ToolBundleIdentifier.isGeneratedApp(activatedApplicationBundleIdentifier) {
+            return .normal
+        }
+        return .floating
+    }
+
+    func updatePopoverWindowLevel(
+        activatedApplicationBundleIdentifier: String?,
+        isCurrentApplication: Bool
+    ) {
+        guard let popoverWindow = popover.contentViewController?.view.window else { return }
+
+        popoverWindow.level = Self.popoverWindowLevel(
+            activatedApplicationBundleIdentifier: activatedApplicationBundleIdentifier,
+            isCurrentApplication: isCurrentApplication
+        )
+        if isCurrentApplication {
+            orderPopoverBehindIronsmithWindows(popoverWindow)
+        }
+    }
+
+    func orderPopoverBehindIronsmithWindows(
+        _ popoverWindow: NSWindow
+    ) {
+        orderPopoverBehindIronsmithWindows(
+            popoverWindow,
+            orderedWindows: NSApp.orderedWindows
+        ) { popoverWindow, otherWindow in
+            popoverWindow.order(.below, relativeTo: otherWindow.windowNumber)
+        }
+    }
+
+    func orderPopoverBehindIronsmithWindows(
+        _ popoverWindow: NSWindow,
+        orderedWindows: [NSWindow],
+        performOrder: @MainActor (NSWindow, NSWindow) -> Void
+    ) {
+        guard
+            let backmostNormalWindow = orderedWindows.last(where: {
+                $0 !== popoverWindow
+                    && $0.isVisible
+                    && !$0.isMiniaturized
+                    && $0.level == .normal
+            })
+        else {
+            return
+        }
+
+        performOrder(popoverWindow, backmostNormalWindow)
+    }
+
+    private func configureWorkspaceApplicationObservation() {
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(workspaceApplicationDidActivate(_:)),
+            name: NSWorkspace.didActivateApplicationNotification,
+            object: nil
+        )
+    }
+
+    @objc private func workspaceApplicationDidActivate(_ notification: Notification) {
+        guard
+            let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey]
+                as? NSRunningApplication
+        else {
+            return
+        }
+
+        updatePopoverWindowLevel(
+            activatedApplicationBundleIdentifier: application.bundleIdentifier,
+            isCurrentApplication: application.processIdentifier == ProcessInfo.processInfo.processIdentifier
+        )
     }
 
     private func showPopover() {
@@ -82,12 +157,14 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
         NSApp.activate(ignoringOtherApps: true)
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         if let popoverWindow = popover.contentViewController?.view.window {
-            // NSPopover uses a menu-style window level by default, which can cover
-            // the app's Settings, About, Store, Agent Output, and open panels.
-            // Ironsmith keeps this popover open while those windows are presented,
-            // so use the normal app-window level and let key-window ordering win.
-            popoverWindow.level = .normal
+            // Keep Ironsmith and its generated apps above the popover. Workspace
+            // activation notifications raise it only while an unrelated app is active.
+            popoverWindow.level = Self.popoverWindowLevel(
+                activatedApplicationBundleIdentifier: Bundle.main.bundleIdentifier,
+                isCurrentApplication: true
+            )
             popoverWindow.makeKey()
+            orderPopoverBehindIronsmithWindows(popoverWindow)
         }
         button.state = .on
         presentationStore?.didShow()
@@ -113,5 +190,13 @@ final class IronsmithMenuBarController: NSObject, NSPopoverDelegate {
         }
 
         window.endSheet(attachedSheet)
+    }
+
+    deinit {
+        NSWorkspace.shared.notificationCenter.removeObserver(
+            self,
+            name: NSWorkspace.didActivateApplicationNotification,
+            object: nil
+        )
     }
 }

--- a/Ironsmith/App/IronsmithApp.swift
+++ b/Ironsmith/App/IronsmithApp.swift
@@ -23,10 +23,6 @@ final class IronsmithAppDelegate: NSObject, NSApplicationDelegate {
         applicationController?.applicationDidBecomeActive()
     }
 
-    func applicationDidResignActive(_ notification: Notification) {
-        applicationController?.applicationDidResignActive()
-    }
-
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         false
     }
@@ -180,10 +176,6 @@ final class IronsmithApplicationController {
         Task {
             await inferenceStore.refreshIronsmithAccountSummaryIfNeededAfterCheckout()
         }
-    }
-
-    func applicationDidResignActive() {
-        menuBarController?.applicationDidResignActive()
     }
 
     func showToolLibraryPopover() {

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolIconClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolIconClient.swift
@@ -272,7 +272,7 @@ struct ToolIconClient: Sendable {
             - Use smooth satin or lightly enameled surfaces with one restrained translucent accent when appropriate. Avoid realistic wood, fabric, paper fibers, grime, metallic noise, and other photographic textures.
             - Use a nearly front-facing orthographic view with only subtle depth. Avoid dramatic camera angles, deep perspective, and exaggerated foreshortening.
             - Light every icon with one broad soft source from the upper left, gentle ambient occlusion, and one short soft contact shadow toward the lower right. Avoid cinematic lighting, hard reflections, bloom, and dramatic glow.
-            - Place the symbol on a simple, calm, full-bleed two-tone gradient background with no scenery, pattern, horizon, or decorative frame.
+            - Place the symbol on a simple, calm, full-bleed two-tone gradient background with no scenery, pattern, horizon, or decorative frame. The canvas must be opaque and painted edge-to-edge; do not leave a white, off-white, transparent, blank, or unpainted margin around the subject.
 
             Default palette: \(palette). Use this palette when the visual concept does not request specific colors, a gradient, or background hues. If the visual concept does make an explicit color or background request, follow that preference instead of the default palette. Color and background preferences never override the locked rendering style, centered composition, lighting, full-bleed canvas, or prohibited-content rules.
 

--- a/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageGenerationClient.swift
+++ b/Ironsmith/Core/AgentPipeline/AppBundle/ToolImageGenerationClient.swift
@@ -185,7 +185,8 @@ nonisolated struct ToolImageGenerationClient: Sendable {
             OpenAIImageRequest(
                 model: "gpt-image-2",
                 prompt: prompt,
-                background: "auto",
+                background: "opaque",
+                outputFormat: "png",
                 n: 1,
                 quality: "low",
                 size: "1024x1024"
@@ -306,9 +307,15 @@ nonisolated private struct OpenAIImageRequest: Encodable {
     let model: String
     let prompt: String
     let background: String
+    let outputFormat: String
     let n: Int
     let quality: String
     let size: String
+
+    enum CodingKeys: String, CodingKey {
+        case model, prompt, background, n, quality, size
+        case outputFormat = "output_format"
+    }
 }
 
 nonisolated private struct OpenAIImageResponse: Decodable {

--- a/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
+++ b/Ironsmith/Core/AgentPipeline/Clients/CustomCodingAgentClient.swift
@@ -221,9 +221,9 @@ nonisolated struct CustomCodingAgentClient: Sendable {
                 of: "{{prompt}}",
                 with: #""$1""#
             )
-            return ["-lc", command, request.agent.name, request.prompt]
+            return ["-ilc", command, request.agent.name, request.prompt]
         case .standardInput:
-            return ["-lc", request.agent.command]
+            return ["-ilc", request.agent.command]
         }
     }
 

--- a/Ironsmith/Core/Models/Tool.swift
+++ b/Ironsmith/Core/Models/Tool.swift
@@ -182,10 +182,17 @@ extension GeneratedAppSandboxPermissions {
 }
 
 enum ToolBundleIdentifier {
+    static let generatedPrefix = "com.ironsmith.generated."
+
     static func make(executableName: String, id: UUID = UUID()) -> String {
         let component = bundleComponent(from: executableName)
         let suffix = id.uuidString.lowercased()
-        return "com.ironsmith.generated.\(component).\(suffix)"
+        return "\(generatedPrefix)\(component).\(suffix)"
+    }
+
+    static func isGeneratedApp(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return bundleIdentifier.hasPrefix(generatedPrefix)
     }
 
     private static func bundleComponent(from value: String) -> String {

--- a/IronsmithTests/App/MenuBarControllerTests.swift
+++ b/IronsmithTests/App/MenuBarControllerTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct MenuBarControllerTests {
     @MainActor
     @Test
-    func applicationDeactivationClosesShownPopover() {
+    func appActivationChangesWindowLevelWithoutClosingShownPopover() throws {
         let popover = TestPopover(isShown: true)
         let presentationStore = MenuBarPopoverPresentationStore()
         presentationStore.didShow()
@@ -15,29 +15,79 @@ struct MenuBarControllerTests {
             presentationStore: presentationStore,
             popover: popover
         )
+        let contentViewController = try #require(popover.contentViewController)
+        let popoverWindow = NSWindow(contentViewController: contentViewController)
 
-        controller.applicationDidResignActive()
+        controller.updatePopoverWindowLevel(
+            activatedApplicationBundleIdentifier: "com.apple.TextEdit",
+            isCurrentApplication: false
+        )
 
-        #expect(popover.closeCount == 1)
-        #expect(!presentationStore.isShown)
-        #expect(presentationStore.closeCount == 1)
+        #expect(popoverWindow.level == .floating)
+        #expect(popover.closeCount == 0)
+        #expect(presentationStore.isShown)
+
+        controller.updatePopoverWindowLevel(
+            activatedApplicationBundleIdentifier: ToolBundleIdentifier.make(
+                executableName: "Generated Tool"
+            ),
+            isCurrentApplication: false
+        )
+
+        #expect(popoverWindow.level == .normal)
+        #expect(popover.closeCount == 0)
+
+        controller.updatePopoverWindowLevel(
+            activatedApplicationBundleIdentifier: Bundle.main.bundleIdentifier,
+            isCurrentApplication: true
+        )
+
+        #expect(popoverWindow.level == .normal)
+        #expect(popover.closeCount == 0)
+        #expect(presentationStore.closeCount == 0)
+    }
+
+    @Test
+    func windowLevelPolicyTreatsUnknownBundleIdentifiersAsExternal() {
+        #expect(
+            IronsmithMenuBarController.popoverWindowLevel(
+                activatedApplicationBundleIdentifier: nil,
+                isCurrentApplication: false
+            ) == .floating
+        )
     }
 
     @MainActor
     @Test
-    func applicationDeactivationDoesNothingWhenPopoverIsClosed() {
-        let popover = TestPopover(isShown: false)
-        let presentationStore = MenuBarPopoverPresentationStore()
+    func showingPopoverOrdersItBehindExistingIronsmithWindows() {
+        let popover = TestPopover(isShown: true)
         let controller = IronsmithMenuBarController(
             rootView: AnyView(EmptyView()),
-            presentationStore: presentationStore,
+            presentationStore: nil,
             popover: popover
         )
+        let popoverWindow = TestWindow(isVisible: true)
+        let frontIronsmithWindow = TestWindow(isVisible: true)
+        let backIronsmithWindow = TestWindow(isVisible: true)
+        let hiddenWindow = TestWindow(isVisible: false)
+        var orderedPopover: NSWindow?
+        var orderedBehindWindow: NSWindow?
 
-        controller.applicationDidResignActive()
+        controller.orderPopoverBehindIronsmithWindows(
+            popoverWindow,
+            orderedWindows: [
+                frontIronsmithWindow,
+                popoverWindow,
+                backIronsmithWindow,
+                hiddenWindow,
+            ]
+        ) { popoverWindow, otherWindow in
+            orderedPopover = popoverWindow
+            orderedBehindWindow = otherWindow
+        }
 
-        #expect(popover.closeCount == 0)
-        #expect(presentationStore.closeCount == 0)
+        #expect(orderedPopover === popoverWindow)
+        #expect(orderedBehindWindow === backIronsmithWindow)
     }
 }
 
@@ -62,5 +112,28 @@ private final class TestPopover: NSPopover {
     override func performClose(_ sender: Any?) {
         closeCount += 1
         reportsShown = false
+    }
+}
+
+private final class TestWindow: NSWindow {
+    private let reportsVisible: Bool
+
+    init(isVisible: Bool) {
+        reportsVisible = isVisible
+        super.init(
+            contentRect: .zero,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var isVisible: Bool {
+        reportsVisible
     }
 }

--- a/IronsmithTests/Core/AgentPipeline/AgentPipelineImageGenerationTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/AgentPipelineImageGenerationTests.swift
@@ -88,6 +88,8 @@ extension AgentPipelineTests {
         #expect(openAIRequest.value(forHTTPHeaderField: "Authorization") == "Bearer openai-key")
         let openAIBody = try #require(jsonObject(openAIRequest) as? [String: Any])
         #expect(openAIBody["model"] as? String == "gpt-image-2")
+        #expect(openAIBody["background"] as? String == "opaque")
+        #expect(openAIBody["output_format"] as? String == "png")
         #expect(openAIBody["quality"] as? String == "low")
         #expect(openAIBody["size"] as? String == "1024x1024")
 
@@ -143,6 +145,8 @@ extension AgentPipelineTests {
         #expect(hostedPrompt.contains("nearly front-facing orthographic view"))
         #expect(hostedPrompt.contains("one broad soft source from the upper left"))
         #expect(hostedPrompt.contains("full-bleed two-tone gradient background"))
+        #expect(hostedPrompt.contains("canvas must be opaque and painted edge-to-edge"))
+        #expect(hostedPrompt.contains("white, off-white, transparent, blank, or unpainted margin"))
         #expect(hostedPrompt.contains("Default palette:"))
         #expect(hostedPrompt.contains(ToolIconClient.hostedIconPalette(for: "Mortgage Calc")))
         #expect(hostedPrompt.contains("follow that preference instead of the default palette"))

--- a/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
+++ b/IronsmithTests/Core/AgentPipeline/CustomCodingAgentTests.swift
@@ -74,7 +74,7 @@ struct CustomCodingAgentTests {
         )
 
         #expect(CustomCodingAgentClient.shellArguments(for: request) == [
-            "-lc",
+            "-ilc",
             #"tool --prompt "$1""#,
             "Runner",
             prompt,
@@ -93,7 +93,7 @@ struct CustomCodingAgentTests {
             packageRootURL: URL(fileURLWithPath: "/tmp"),
             prompt: "secret prompt"
         )
-        #expect(CustomCodingAgentClient.shellArguments(for: request) == ["-lc", "tool --stdin"])
+        #expect(CustomCodingAgentClient.shellArguments(for: request) == ["-ilc", "tool --stdin"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Keep the menu bar popover visible while dynamically adjusting its window level for Ironsmith, generated apps, and external applications.
- Order the popover behind existing Ironsmith windows without closing it on app deactivation.
- Request opaque PNG icon output and strengthen full-bleed icon generation guidance.
- Run custom coding agents with interactive login shell arguments.
- Add focused coverage for window-level behavior, icon request payloads, prompt guidance, and shell arguments.

## Testing

- Added and updated focused Swift Testing coverage for the affected app controller and agent-pipeline behavior.